### PR TITLE
docs: document the fact decision task loop

### DIFF
--- a/docs-release/learn/en/01-three-primitive-kernel.md
+++ b/docs-release/learn/en/01-three-primitive-kernel.md
@@ -56,15 +56,12 @@ reviewed. The three interlock; only together are they self-consistent.
 
 ## One pass through the loop
 
-Use the canonical commands in this order. Each command writes one part of the
-graph, and the final fact is the input to the next pass:
-
-1. `ha fact record --statement "<observation>" --source "<source>" --confidence high` records the initial immutable observation.
-2. `ha decision propose --json-input '<decision-packet.json contents>'` creates a decision whose claims can be supported by that observation.
-3. `ha decision relate <decision-id> --anchor <claim-id> --type evidenced-by --target fact/F-XXXXXXXX --rationale "<why this fact supports the claim>"` attaches the fact to a decision claim.
-4. `ha task create --title "<work selected by the decision>"` creates the executable work package selected by the decision.
-5. `ha decision relate <decision-id> --anchor <claim-id> --type derives --target task/<task-id> --rationale "<why this task follows>"` records the decision-to-task derivation edge.
-6. `ha fact record --task <task-id> --statement "<result>" --source "<verification>" --confidence high` records the task result and closes the loop.
+The concepts above have one executable walkthrough: the
+[first closed-loop recipe](../../start/en/02-first-loop.md). It includes the
+current relation anchors, explicit human approval, task submission, review,
+consent, upstream Fact disposition, and the new closing Fact. Keeping the
+commands there prevents this conceptual chapter from becoming a second,
+drifting workflow.
 
 ## Asymmetric storage: task ownership is an edge
 

--- a/docs-release/learn/en/02-decision-and-verdict.md
+++ b/docs-release/learn/en/02-decision-and-verdict.md
@@ -61,14 +61,11 @@ propose ──▶ accept / reject / defer
 
 ## The fact-to-decision handoff
 
-These commands make the evidence path explicit:
-
-1. `ha fact record --statement "<observation>" --source "<source>" --confidence high` records an immutable observation that can support a claim.
-2. `ha decision propose --json-input '<decision-packet.json contents>'` opens a proposal and returns its receipt; when no fact evidence is present, the receipt points to the next two commands without rejecting the proposal.
-3. `ha decision relate <decision-id> --anchor <claim-id> --type evidenced-by --target fact/F-XXXXXXXX --rationale "<why this fact supports the claim>"` attaches the recorded fact to the claim as a typed evidence edge.
-4. `ha decision relate <decision-id> --anchor <claim-id> --type derives --target task/<task-id> --rationale "<why this task follows>"` records which executable task the decision derives.
-5. `ha decision accept <decision-id> --rationale "<review>"` adjudicates the proposal after its evidence and derivation paths are ready.
-6. `ha decision reckon <decision-id> --task <task-id>` checks claim coverage against the task's current facts and records the closeout observation.
+The evidence handoff is executable in the
+[first closed-loop recipe](../../start/en/02-first-loop.md). The current path
+uses first-class `relation relate` edges and `decision transition in_effect`
+with explicit human approval; the deprecated `decision accept` alias is not a
+second workflow.
 
 ## Evidence is edges, not embedded arrays
 

--- a/docs-release/learn/zh/01-three-primitive-kernel.md
+++ b/docs-release/learn/zh/01-three-primitive-kernel.md
@@ -36,14 +36,9 @@
 
 ## 走一遍回环
 
-按下面的顺序使用规范命令。每条命令都会写入图上的一部分，最后一条 fact 会成为下一轮的输入：
-
-1. `ha fact record --statement "<observation>" --source "<source>" --confidence high` 记录初始的不可变观察。
-2. `ha decision propose --json-input '<decision-packet.json contents>'` 创建 decision，让其中的主张可以由这条观察支撑。
-3. `ha decision relate <decision-id> --anchor <claim-id> --type evidenced-by --target fact/F-XXXXXXXX --rationale "<why this fact supports the claim>"` 把 fact 挂到 decision 的主张上。
-4. `ha task create --title "<work selected by the decision>"` 创建由 decision 选定的可执行任务包。
-5. `ha decision relate <decision-id> --anchor <claim-id> --type derives --target task/<task-id> --rationale "<why this task follows>"` 记录 decision 到 task 的衍生关系边。
-6. `ha fact record --task <task-id> --statement "<result>" --source "<verification>" --confidence high` 记录任务结果并闭合回环。
+上面的概念只有一份可执行演练：[第一个完整闭环](../../start/zh/02-first-loop.md)。其中包括
+当前 relation anchors、明确的人类批准、task submit、review、consent、上游 Fact disposition，
+以及用于闭环的新 Fact。把命令集中在那里，可以避免概念章节变成第二条逐渐漂移的工作流。
 
 ## 不对称的存储:task 归属由边表达
 

--- a/docs-release/learn/zh/02-decision-and-verdict.md
+++ b/docs-release/learn/zh/02-decision-and-verdict.md
@@ -42,14 +42,9 @@ propose ──▶ accept / reject / defer
 
 ## Fact 到 decision 的交接
 
-下面这些命令把证据路径写清楚：
-
-1. `ha fact record --statement "<observation>" --source "<source>" --confidence high` 记录一条可以支撑主张的不可变观察。
-2. `ha decision propose --json-input '<decision-packet.json contents>'` 打开 proposal 并返回回执；如果还没有 fact evidence，回执会指向接下来的两条命令，而不会拒绝 proposal。
-3. `ha decision relate <decision-id> --anchor <claim-id> --type evidenced-by --target fact/F-XXXXXXXX --rationale "<why this fact supports the claim>"` 把已记录的 fact 作为类型化证据边挂到主张上。
-4. `ha decision relate <decision-id> --anchor <claim-id> --type derives --target task/<task-id> --rationale "<why this task follows>"` 记录 decision 衍生出的可执行 task。
-5. `ha decision accept <decision-id> --rationale "<review>"` 在证据和衍生路径准备好后裁决 proposal。
-6. `ha decision reckon <decision-id> --task <task-id>` 根据 task 当前的 facts 检查主张覆盖，并记录收口观察。
+证据交接的可执行版本位于[第一个完整闭环](../../start/zh/02-first-loop.md)。当前路径使用
+一等 `relation relate` 边，以及带明确人类批准的 `decision transition in_effect`；弃用的
+`decision accept` alias 不再作为第二条工作流。
 
 ## 证据是边,不是嵌入的数组
 

--- a/docs-release/site/index.html
+++ b/docs-release/site/index.html
@@ -674,47 +674,18 @@
           <span class="sec-no">02</span>
           <h2><span lang="en">Run one real loop</span><span lang="zh">跑一个真实的循环</span></h2>
           <p>
-            <span lang="en">After the local source install, do this end to end in a scratch git repo. In a few minutes you'll have a real task, a fact, and an adjudicated decision — all as Markdown in your repo. First, <code>ha init</code> lays down the authored <code>harness/</code> directory (this goes into git; the generated <code>.harness/</code> cache stays out of it).</span>
-            <span lang="zh">完成本地源码安装后，在一个临时 git 仓库里端到端做一遍。几分钟内，你就有了一个真实的任务、一个事实、一个被裁决的决策——全部是仓库里的 Markdown。先用 <code>ha init</code> 铺好已撰写的 <code>harness/</code> 目录（它进 git；生成的 <code>.harness/</code> 缓存留在 git 之外）。</span>
+            <span lang="en">The executable walkthrough now has one canonical home. It starts from an observed Fact, proposes a structured Decision, attaches evidence, records explicit human approval, derives and runs a Task, then records a new Fact before review and completion.</span>
+            <span lang="zh">可执行演练现在只有一个规范入口：从已观察的 Fact 出发，提议结构化 Decision、挂证据、记录明确的人类批准、派生并执行 Task，再在评审和完成前记录一条新 Fact。</span>
           </p>
-          <figure class="code">
-            <figcaption><span lang="en">move a task through its lifecycle</span><span lang="zh">让任务走过它的生命周期</span></figcaption>
-<pre><span class="c"># a task gets a stable id; the title is just display metadata</span>
-<span class="c">$</span> ha task transition task_01KWPP52D062Q7BWTD8BCNDRWF active
-<span class="ok">ok</span> command="task transition" task=task_01KWPP52D... status=active
-
-<span class="c"># six states, done &amp; cancelled are terminal:</span>
-<span class="c">#</span> planned → active → blocked → in_review → done → cancelled</pre>
-          </figure>
           <p>
-            <span lang="en">Then record a <span class="term">fact</span> — an append-only observation anchored to the task — and propose then <em>adjudicate</em> a <span class="term">decision</span>:</span>
-            <span lang="zh">然后记录一个 <span class="term">fact</span>——一条只增不改、锚定到任务的观察——再提议、进而<em>裁决</em>一个 <span class="term">decision</span>：</span>
-          </p>
-          <figure class="code">
-            <figcaption><span lang="en">record a fact, then propose &amp; accept a decision</span><span lang="zh">记录事实，然后提议并接受决策</span></figcaption>
-<pre><span class="c">$</span> ha fact record <span class="k">--task</span> task_01KWPP52D... \
-    <span class="k">--statement</span> "Redirect loops when the session cookie is missing" \
-    <span class="k">--source</span> "manual repro" <span class="k">--confidence</span> high
-<span class="ok">ok</span> command="fact record" task=task_01KWPP52D... path=facts.md
-
-<span class="c">$</span> ha decision propose <span class="k">--title</span> "Use a server-side redirect guard" \
-    <span class="k">--question</span> "How do we stop the login redirect loop?" \
-    <span class="k">--chosen</span> "Add a server-side guard" \
-    <span class="k">--rejected</span> "Client-only fix" <span class="k">--why-not</span> "Races with cookie set"
-<span class="ok">ok</span> command="decision propose" path=harness/decisions/decision-dec_mr6f3b4z/decision.md
-
-<span class="c">$</span> ha decision accept dec_mr6f3b4z <span class="k">--arbiter</span> human:you
-<span class="ok">ok</span> command="decision accept" path=harness/decisions/decision-dec_mr6f3b4z/decision.md</pre>
-          </figure>
-          <p>
-            <span lang="en"><code>accept</code> is the adjudication checkpoint: it's where a decision's evidence is validated before the decision becomes binding. That's what makes an accepted decision <em>trustworthy</em> rather than merely asserted.</span>
-            <span lang="zh"><code>accept</code> 是裁决检查点：在决策变得有约束力之前，它的证据在这里被验证。这正是一个被接受的决策<em>可信</em>、而不只是被声称的原因。</span>
+            <span lang="en"><a href="../start/en/02-first-loop.md">Run the English recipe</a>; it contains the exact current commands, a Decision body template, closeout template, and receipt fragments captured from an isolated run.</span>
+            <span lang="zh"><a href="../start/zh/02-first-loop.md">运行中文配方</a>；其中包含当前准确命令、Decision 正文模板、closeout 模板，以及隔离实跑回执片段。</span>
           </p>
           <div class="note aha">
             <p style="margin:0">
               <strong><span lang="en">This is the aha:</span><span lang="zh">这就是啊哈时刻：</span></strong>
-              <span lang="en"> what you produced isn't a chat log. It's real, versioned structure in your repo — the task, the fact it observed, and the decision it justified, all linked and all reviewable in a git diff. Run <code>ha graph</code> and it renders them as a self-contained HTML panorama.</span>
-              <span lang="zh"> 你产出的不是一份聊天记录。它是你仓库里真实、版本化的结构——任务、它观察到的事实、它所支撑的决策，全部有链接、全部能在 git diff 里审查。运行 <code>ha graph</code>，它会把它们渲染成一张自包含的 HTML 全景图。</span>
+              <span lang="en"> the result is a queryable Fact → Decision → Task → Fact graph, not a chat log.</span>
+              <span lang="zh"> 结果是一张可查询的 Fact → Decision → Task → Fact 图，而不是聊天记录。</span>
             </p>
           </div>
         </section>
@@ -723,8 +694,8 @@
           <span class="sec-no">03</span>
           <h2><span lang="en">The three record types, on disk</span><span lang="zh">三种记录，在磁盘上长什么样</span></h2>
           <p>
-            <span lang="en">Nothing here is a mystery format. A task is a small directory; a decision is a folder with a Markdown file; a fact is a line appended to its task's <code>facts.md</code>. Here's the shape after your first loop:</span>
-            <span lang="zh">这里没有什么神秘格式。任务是一个小目录；决策是一个带 Markdown 文件的文件夹；事实是追加到它所属任务的 <code>facts.md</code> 里的一行。第一个循环之后，形状大致是这样：</span>
+            <span lang="en">Nothing here is a mystery format. Tasks are packages, Decisions are centralized records, and Facts are independent immutable records whose ownership is expressed by relations.</span>
+            <span lang="zh">这里没有神秘格式。Task 是包，Decision 是集中记录，Fact 是独立的不可变记录；归属由关系表达。</span>
           </p>
           <figure class="code">
             <figcaption><span lang="en">what landed in git</span><span lang="zh">进了 git 的东西</span></figcaption>
@@ -733,11 +704,13 @@
 ├── decisions/
 │   └── decision-dec_mr6f3b4z/
 │       └── decision.md          <span class="c"># the WHY: question, chosen, rejected</span>
+├── facts/
+│   └── F-3C9EB45C.md            <span class="c"># the IS: immutable observation</span>
 └── tasks/
     └── task_01KWPP52D...-fix-login-redirect-bug/
         ├── INDEX.md             <span class="c"># the WHAT: status, lifecycle</span>
-        ├── progress.md
-        └── facts.md             <span class="c"># the IS: append-only observations</span></pre>
+        ├── task_plan.md
+        └── closeout.md</pre>
           </figure>
           <p>
             <span lang="en">A handful of commands cover almost everything you'll do day to day. Add <code>--json</code> to any of them for structured output.</span>
@@ -754,10 +727,7 @@
               <tbody>
                 <tr><td><code>ha init</code></td><td><span lang="en">Create the <code>harness/</code> layout in the current repo.</span><span lang="zh">在当前仓库创建 <code>harness/</code> 布局。</span></td></tr>
                 <tr><td><code>ha task create --title …</code></td><td><span lang="en">Create a new task package.</span><span lang="zh">创建一个新任务包。</span></td></tr>
-                <tr><td><code>ha task transition &lt;id&gt; &lt;state&gt;</code></td><td><span lang="en">Move a task to a new lifecycle state.</span><span lang="zh">把任务移到新的生命周期状态。</span></td></tr>
-                <tr><td><code>ha decision propose …</code></td><td><span lang="en">Propose a decision — question, chosen, rejected, why-not.</span><span lang="zh">提议一个决策——问题、已选、已拒、为何不。</span></td></tr>
-                <tr><td><code>ha decision accept &lt;id&gt;</code></td><td><span lang="en">Adjudicate a proposed decision — the evidence checkpoint.</span><span lang="zh">裁决一个提议的决策——证据检查点。</span></td></tr>
-                <tr><td><code>ha fact record --task &lt;id&gt; …</code></td><td><span lang="en">Record an append-only fact anchored to a task.</span><span lang="zh">记录一个锚定到任务、只增不改的事实。</span></td></tr>
+                <tr><td><code>ha task start &lt;id&gt;</code></td><td><span lang="en">Acquire or reuse an execution lease.</span><span lang="zh">取得或复用 execution lease。</span></td></tr>
                 <tr><td><code>ha status</code> · <code>ha check</code></td><td><span lang="en">Summarize state · run health checks.</span><span lang="zh">总结状态 · 运行健康检查。</span></td></tr>
                 <tr><td><code>ha graph</code></td><td><span lang="en">Render the relation graph as a self-contained HTML panorama.</span><span lang="zh">把关系图渲染成自包含 HTML 全景。</span></td></tr>
               </tbody>
@@ -782,10 +752,6 @@
 <span class="c">$</span> ha task list <span class="k">--state</span> active
 <span class="c">$</span> ha task progress append &lt;id&gt; <span class="k">--text</span> "Implemented first slice"
 
-<span class="c"># record a choice, then adjudicate it</span>
-<span class="c">$</span> ha decision list <span class="k">--state</span> active
-<span class="c">$</span> ha decision accept &lt;id&gt;        <span class="c"># or: reject | defer</span>
-
 <span class="c"># check state and navigate</span>
 <span class="c">$</span> ha status            <span class="c"># what state am I in?</span>
 <span class="c">$</span> ha graph             <span class="c"># see how it all links, as HTML</span></pre>
@@ -793,7 +759,6 @@
           <ul>
             <li><span lang="en"><code>ha task list --state active</code> — the tasks in flight right now, with state / module / search filters.</span><span lang="zh"><code>ha task list --state active</code> —— 此刻在飞的任务，带状态 / 模块 / 搜索过滤。</span></li>
             <li><span lang="en"><code>ha task progress append &lt;id&gt; --text …</code> — leave a dated line in the task's <code>progress.md</code> so the next agent inherits state, not a cold start.</span><span lang="zh"><code>ha task progress append &lt;id&gt; --text …</code> —— 在任务的 <code>progress.md</code> 里留下一行带日期的记录，让下一个代理接手的是状态，而不是冷启动。</span></li>
-            <li><span lang="en"><code>ha decision accept &lt;id&gt;</code> — the evidence checkpoint; its siblings <code>reject</code> and <code>defer</code> close the other doors.</span><span lang="zh"><code>ha decision accept &lt;id&gt;</code> —— 证据检查点；它的兄弟 <code>reject</code> 和 <code>defer</code> 关上另外两扇门。</span></li>
             <li><span lang="en"><code>ha doctor</code> — read-only environment diagnostics when something feels off, safe to run anytime.</span><span lang="zh"><code>ha doctor</code> —— 感觉哪里不对时的只读环境诊断，随时跑都安全。</span></li>
           </ul>
         </section>
@@ -1113,23 +1078,24 @@
           </button>
           <h3><span lang="en">How the three entities live on disk</span><span lang="zh">三个实体在磁盘上怎么住</span></h3>
           <p>
-            <span lang="en">Accepted entities publish authored Markdown with YAML frontmatter through <code>packages/kernel/src/store/sqlite-task-event-store.ts</code>. The frontmatter isn't decoration — it's validated against a schema in <code>packages/kernel/src/schemas/</code> before the file is accepted, so the fields are contracts, not conventions. Three primitives, but only two storage sites: decisions centralized, tasks as containers, facts embedded.</span>
-            <span lang="zh">已接受实体经 <code>packages/kernel/src/store/sqlite-task-event-store.ts</code> 发布带 YAML frontmatter 的撰写 Markdown。frontmatter 不是装饰——在文件被接受之前，它要经 <code>packages/kernel/src/schemas/</code> 里的 schema 校验，所以这些字段是合同，不是约定。三个原语，却只有两个存储点：决策集中，任务作容器，事实嵌入。</span>
+            <span lang="en">Accepted entities publish authored Markdown with YAML frontmatter through <code>packages/kernel/src/store/sqlite-task-event-store.ts</code>. The frontmatter isn't decoration — it's validated against a schema in <code>packages/kernel/src/schemas/</code> before the file is accepted, so the fields are contracts, not conventions. Decisions are centralized, Tasks are packages, and Facts are independent immutable records connected by typed relations.</span>
+            <span lang="zh">已接受实体经 <code>packages/kernel/src/store/sqlite-task-event-store.ts</code> 发布带 YAML frontmatter 的撰写 Markdown。frontmatter 不是装饰——在文件被接受之前，它要经 <code>packages/kernel/src/schemas/</code> 里的 schema 校验，所以这些字段是合同，不是约定。Decision 集中存放，Task 是文档包，Fact 是由类型化关系连接的独立不可变记录。</span>
           </p>
           <p>
             <span lang="en">The IDs are shaped and enforced. A decision id matches <span class="idchip">dec_…</span>. A task id is <span class="idchip">task_&lt;ULID&gt;-&lt;slug&gt;</span> — the ULID is sortable and unique, the slug is human-readable. A fact id is <span class="idchip">F-</span> plus exactly eight Crockford base32 characters (digits and uppercase, excluding <code>I L O U</code>), e.g. <span class="idchip">F-3DQ0KZRV</span>.</span>
             <span lang="zh">这些 ID 有固定形状并被强制。决策 id 匹配 <span class="idchip">dec_…</span>。任务 id 是 <span class="idchip">task_&lt;ULID&gt;-&lt;slug&gt;</span>——ULID 可排序且唯一，slug 人类可读。事实 id 是 <span class="idchip">F-</span> 加上恰好八个 Crockford base32 字符（数字和大写字母，排除 <code>I L O U</code>），例如 <span class="idchip">F-3DQ0KZRV</span>。</span>
           </p>
           <figure class="code">
-            <figcaption><span lang="en">directory layout — two storage sites</span><span lang="zh">目录布局——两个存储点</span></figcaption>
+            <figcaption><span lang="en">directory layout — independent records and task packages</span><span lang="zh">目录布局——独立记录与 task 包</span></figcaption>
 <pre>&lt;repo root&gt;/
 ├── decisions/                       <span class="c"># centralized: the spine</span>
 │   └── decision-dec_.../decision.md
+├── facts/
+│   └── F-3DQ0KZRV.md                <span class="c"># immutable observation</span>
 └── &lt;tasks root&gt;/
     └── task_&lt;ULID&gt;-&lt;slug&gt;/           <span class="c"># one directory per task</span>
         ├── INDEX.md                 <span class="c"># frontmatter: task-package/v2</span>
-        ├── task_plan.md · progress.md · review.md · closeout.md
-        └── facts.md                 <span class="c"># the local fact ledger</span></pre>
+        └── task_plan.md · progress.md · closeout.md</pre>
           </figure>
           <p>
             <span lang="en">The decision file's frontmatter is validated against <code>decision-package/v1</code> and carries load-bearing fields like <code>question</code>, <code>chosen[]</code>, <code>rejected[]</code> (each with a <code>why_not</code>), <code>claims[]</code>, <code>relations[]</code>, and <code>provenance[]</code>. One rule is enforced by the schema itself: a decision whose <code>proposedBy</code> equals its <code>arbiter</code> is <em>rejected</em> — you cannot arbitrate your own proposal, and a record of that shape never reaches disk.</span>

--- a/docs-release/start/en/02-first-loop.md
+++ b/docs-release/start/en/02-first-loop.md
@@ -1,131 +1,158 @@
-# Your first loop
+# Your first closed loop
 
-Run this end to end in a scratch git repo. In a few minutes you'll have a real
-task, a fact, and an adjudicated decision — all as Markdown inside the private
-`harness/` ledger. Every output below is captured from an actual run.
-
-## 0. Set write attribution
-
-Local `ha` write commands are attributed by the authenticated daemon. Initialize
-the workspace with the human identity and set the commit author variables:
-
-```bash
-export HARNESS_GIT_AUTHOR_NAME="Your Name"
-export HARNESS_GIT_AUTHOR_EMAIL="you@example.com"
-ha init --person-id you --display-name "Your Name"
-```
-
-Continue this loop with plain `ha` commands. The daemon authenticates the
-local socket owner and records the configured person; do not export
-`HARNESS_ACTOR=human:you`. Agent automation may use `HARNESS_ACTOR=agent:<id>`
-per command. See [Actor Attribution](../../actor-attribution.md) for the source
-matrix.
-
-## 1. Initialize
-
-```bash
-$ ha init --person-id you --display-name "Your Name"
-ok command=init path=harness/harness.yaml summary="initialized harness at harness/harness.yaml"
-```
-
-This creates the authored `harness/` directory. Your tasks, decisions, and
-standards live here, but not in your project git repository. `ha init` adds
-`harness/` to the outer `.gitignore` and initializes `harness/` as its own
-private nested git repository.
-
-That isolation is the leak-prevention design: code PRs must not include
-`harness/` changes. Commit ledger changes inside `harness/` when you want to
-version the private ledger:
-
-```bash
-git -C harness status
-git -C harness add .
-git -C harness -c user.name="$HARNESS_GIT_AUTHOR_NAME" \
-  -c user.email="$HARNESS_GIT_AUTHOR_EMAIL" \
-  commit -m "docs: update harness ledger"
-```
-
-The generated `.harness/` cache is local-only and also stays out of the outer
-project git repository.
+Run this recipe in a scratch Git repository after `ha init`. It follows the
+canonical cycle:
 
 ```text
-harness/
-├── harness.yaml
-├── adr/
-├── context/
-├── milestones/
-├── standards/
-└── tasks/
+Fact → Decision → Task → Fact
 ```
 
-## 2. Create a task
+The receipt fragments below came from an isolated Ubuntu fixture on 2026-09-12.
+IDs will differ in your repository. Every write still goes through the center's
+single-writer queue; do not run the example against somebody else's workspace.
+
+## Before the loop
+
+Initialize once with the human who owns the workspace:
 
 ```bash
-$ ha task create --title "Fix login redirect bug"
-ok command="task create" task=task_01KWPP52D062Q7BWTD8BCNDRWF status=planned
-   path=harness/tasks/task_01KWPP52D...-fix-login-redirect-bug
+ha init --person-id owner --display-name "Loop Owner"
 ```
 
-You get a stable `task_<id>` and a task package on disk. IDs are identity; titles are just display metadata.
+Expected: `ok=true command=repo-bootstrap`. Do not set `HARNESS_ACTOR` to a
+human value; the daemon authenticates the socket owner. Agent automation may set
+`HARNESS_ACTOR=agent:<id>` for its own commands.
 
-## 3. Move it through the lifecycle
+## 1. Record the observation
 
 ```bash
-$ ha task transition task_01KWPP52D062Q7BWTD8BCNDRWF active
-ok command="task transition" task=task_01KWPP52D062Q7BWTD8BCNDRWF status=active
-   summary="set task task_01KWPP52D062Q7BWTD8BCNDRWF to active"
+ha fact record --statement "Repeated handoffs lose the reason for the work." --source "support-review-2026-09-12" --confidence high
 ```
 
-Tasks move through six states: `planned → active → blocked → in_review → done → cancelled`. `done` and `cancelled` are terminal.
+Expected: `ok=true command=fact-record factId=F-3C9EB45C status=accepted_durable`.
+Keep the returned Fact ID; do not invent one from the statement.
 
-## 4. Record a fact, then a decision
-
-Facts are append-only observations. Add `--task` when the observation belongs to
-the task and should receive a `produces` edge:
+## 2. Propose the choice
 
 ```bash
-$ ha fact record --task task_01KWPP52D062Q7BWTD8BCNDRWF \
-    --statement "Redirect loops when the session cookie is missing" \
-    --source "manual repro" --confidence high
-ok command="fact record" fact=F-7K3M2Q9R path=facts/F-7K3M2Q9R.md
+ha decision propose --json-input '{"title":"Keep handoff reasons in the ledger","question":"How should handoff context survive between sessions?","riskTier":"medium","urgency":"medium","decisionClass":"ordinary","chosen":[{"id":"CH1","text":"Record reasons as facts before creating follow-up work","rationale":"Preserves provenance"}],"rejected":[{"id":"RJ1","text":"Keep reasons only in chat","whyNot":"Chat is not a durable ledger"}],"claims":[{"id":"C1","text":"Durable facts preserve handoff reasons","loadBearing":true}]}' --body $'## 背景\nRepeated handoffs lose their rationale.\n\n## 权衡\nDurable facts preserve provenance; chat alone does not.\n\n## 结论\nRecord the reason as a Fact before creating follow-up work.'
 ```
 
-Now propose a decision — the WHY — and adjudicate it:
+Expected: `ok=true command=decision-propose decisionId=dec_... state=proposed`.
+The packet carries machine fields; the body must keep the three human-readable
+sections `背景`, `权衡`, and `结论`.
+
+## 3. Attach evidence, then accept with human approval
 
 ```bash
-$ ha decision propose --title "Use a server-side redirect guard" \
-    --question "How do we stop the login redirect loop?" \
-    --chosen "Add a server-side guard" \
-    --rejected "Client-only fix" \
-    --why-not "Client fix races with cookie set"
-ok command="decision propose" path=harness/decisions/decision-dec_mr6f3b4z/decision.md
-
-$ ha decision accept dec_mr6f3b4z --arbiter you
-ok command="decision accept" path=harness/decisions/decision-dec_mr6f3b4z/decision.md
+ha relation relate --source-ref decision/dec_.../C1 --target-ref fact/F-3C9EB45C --type evidenced-by --rationale "The observed handoff loss supports the durability claim." --expected-version 0
 ```
 
-`accept` is the adjudication checkpoint: it's where a decision's evidence relations (attach them with `--evidence-relation` on propose, or `ha decision relate` later) are validated before the decision becomes binding. This is what makes an accepted decision _trustworthy_ rather than just asserted — the full fail-closed policy is covered in **[learn/](../../learn/en/00-overview.md)**.
-
-## 5. Watch the structure grow
+Expected: `ok=true command=relation-relate relationId=rel_...`. Point to claim
+`C1`, not chosen option `CH1`; acceptance requires the evidence edge or an
+explicit judgment-only rationale.
 
 ```bash
-$ ha status
-ok command=status path=.harness/cache/projections.sqlite rows=1
-
-$ ha graph
-ok command=graph path=.harness/generated/graph-panorama/index.html
+ha decision transition in_effect dec_... --consent-by owner --consent-at 2026-09-12T08:00:00Z --consent-channel cli
 ```
 
-`graph` renders a self-contained HTML panorama linking your tasks, decisions, and facts.
+Expected: `ok=true command=decision-transition state=in_effect consentId=djc_...`.
+The two independent conditions are now visible: claim evidence and explicit
+human approval. All three consent flags are one atomic input, and `--consent-by`
+must name the authenticated principal. The old `ha decision accept` spelling is
+a deprecated alias, not a second workflow.
 
-**This is the aha:** what you produced isn't a chat log. It's real, versioned
-structure in the private `harness/` ledger — the task, the fact it observed, and
-the decision it justified, all linked and reviewable with `git -C harness diff`.
+## 4. Create the derived task
 
-![demo](../assets/demo.gif)
+```bash
+ha task create --title "Publish a durable handoff note" --preset docs-task
+```
 
-> **GIF coming soon** — replaced with a live clip once the GUI ships.
+Expected: `ok=true command=task-create taskId=task_... status=accepted_durable`.
+Use the returned package path, replace the scaffolded `task_plan.md` with a real
+plan, then publish it with `ha doc sync --submit` before starting.
 
----
+```bash
+ha relation relate --source-ref decision/dec_.../CH1 --target-ref task/task_... --type derives --rationale "The chosen durable-record path creates this work." --expected-version 0
+```
 
-Next: go deeper on the _why_ → **[learn/](../../learn/en/00-overview.md)**, or grab the **[daily commands cheat sheet](03-daily-commands.md)**.
+Expected: `ok=true command=relation-relate relationId=rel_...`. A derivation
+starts at the chosen option `CH1`; this is intentionally different from the
+claim anchor used by `evidenced-by`.
+
+## 5. Start, produce the closing Fact, and submit
+
+```bash
+ha task start task_...
+```
+
+Expected: `ok=true command=task-start executionId=exe_... status=accepted_durable`.
+`start` acquires the execution lease; the holder must perform the task writes.
+
+After doing the work, record a new observation owned by this task:
+
+```bash
+ha fact record --task task_... --statement "The handoff note is present in the task package." --source "tasks/task_.../closeout.md" --confidence high
+```
+
+Expected: `ok=true command=fact-record factId=F-... status=accepted_durable`.
+This new Fact closes the loop; reusing the opening Fact does not.
+
+Fill the task's `closeout.md` before submission:
+
+```markdown
+## Summary
+
+Published the durable handoff note.
+
+## Verification
+
+Checked the submitted task package and closing Fact.
+
+## Residual Risk
+
+None known.
+
+## Same Mechanism Elsewhere
+
+Use the same Fact → Decision → Task → Fact cycle for the next handoff.
+```
+
+```bash
+ha task submit task_...
+```
+
+Expected: `ok=true command=task-submit transition.from=active/implementation transition.to=in_review/review`.
+`submit` publishes eligible task documents, including the closeout; do not make
+a separate manual Git commit in the private ledger.
+
+## 6. Review and complete with owner consent
+
+An independent reviewer records the verdict against the submitted execution:
+
+```bash
+HARNESS_ACTOR=agent:loop-reviewer ha task review-execution task_... --review-id review-docs-loop --json-input '{"verdict":"approved","reason":"Independent reviewer checked the submitted closeout and result fact.","evidenceChecked":["fact/F-...","tasks/task_.../closeout.md"]}'
+```
+
+Expected: `ok=true command=task-review-execution reviewId=review-docs-loop`.
+The reviewer must not be the execution's agent.
+
+```bash
+ha task complete task_...
+```
+
+Expected before owner consent/disposition: `ok=false command=task-complete
+code=fact_retirement_undeclared`. The receipt names every upstream Fact that
+still needs an explicit disposition; do not bypass it.
+
+```bash
+ha task complete task_... --consent --fact-holds "F-3C9EB45C:The handoff-loss observation still holds after publishing this note."
+```
+
+Expected: `ok=true command=task-complete transition.to=done/review status=accepted_durable`.
+`--consent` selects the approved Review and records owner consent atomically;
+`--fact-holds` records why the opening evidence remains standing.
+
+You now have a complete, queryable cycle rather than a task-shaped chat log.
+Next, read [The three-primitive kernel](../../learn/en/01-three-primitive-kernel.md)
+or keep the [daily command sheet](03-daily-commands.md) nearby.

--- a/docs-release/start/en/03-daily-commands.md
+++ b/docs-release/start/en/03-daily-commands.md
@@ -2,6 +2,10 @@
 
 A cheat sheet for the commands you'll reach for most. Add `--json` to any command for structured output.
 
+For the executable Fact → Decision → Task → Fact sequence, use the single
+[first closed-loop recipe](02-first-loop.md). This page does not duplicate that
+stateful workflow.
+
 ## The commands you'll use constantly
 
 | Command | What it does |
@@ -10,34 +14,10 @@ A cheat sheet for the commands you'll reach for most. Add `--json` to any comman
 | `ha task create --title <title>` | Create a new task package. |
 | `ha task list` | List task packages, with state / module / search filters. |
 | `ha task show <id>` | Show one task with projected status, metadata, hierarchy, relation edges, and fact anchors. |
-| `ha task transition <id> <state>` | Move a task to a new lifecycle state. |
-| `ha decision propose --title <t> ...` | Propose a decision (question, chosen, rejected, why-not). |
-| `ha decision accept <id>` | Adjudicate a proposed decision — the evidence checkpoint. |
-| `ha fact record --statement <text> --source <text> [--task <id>]` | Record an append-only fact; optionally associate it with a task. |
+| `ha task start <id>` | Acquire or reuse the current execution lease. |
 | `ha status` | Summarize harness state. |
 | `ha check` | Run harness health checks. |
 | `ha graph` | Render the relation graph as a self-contained HTML panorama. |
-
-## By scenario
-
-**Task lifecycle**
-```bash
-ha task create --title "Implement slice"
-ha task transition <id> active
-ha task progress append <id> --text "Implemented first slice"
-```
-
-**Decisions**
-```bash
-ha decision propose --title "..." --question "..." --chosen "..." --rejected "..." --why-not "..."
-ha decision accept <id>       # or: reject | defer
-ha decision list --state active
-```
-
-**Facts**
-```bash
-ha fact record --statement "..." --source "..." --confidence high [--task <id>]
-```
 
 **Check & navigate**
 ```bash
@@ -57,4 +37,5 @@ ha --help              # global help, or: ha help <command>
 ha capabilities        # entity operations, input schemas, and examples
 ```
 
-Some older command spellings still work as deprecated aliases and will be retired in a future release — prefer the forms shown above.
+Deprecated aliases are not documented as alternate workflows; use the forms
+shown by current help and by the closed-loop recipe.

--- a/docs-release/start/zh/02-first-loop.md
+++ b/docs-release/start/zh/02-first-loop.md
@@ -1,118 +1,148 @@
-# 你的第一个循环
+# 你的第一个完整闭环
 
-在一个临时 git 仓库里端到端运行这个。几分钟内你会有一个真实任务、一个事实和一个裁决的决策——全部是私有 `harness/` 账本里的 Markdown。下面的每个输出都从一次实际运行中捕捉下来。
-
-## 0. 设置写入归属
-
-本地 `ha` 写命令由已认证的 daemon 归属。初始化工作区时声明人类身份，并设置 commit
-author 变量：
-
-```bash
-export HARNESS_GIT_AUTHOR_NAME="Your Name"
-export HARNESS_GIT_AUTHOR_EMAIL="you@example.com"
-ha init --person-id you --display-name "Your Name"
-```
-
-接下来使用普通的 `ha` 命令。daemon 会认证本地 socket 所有者并记录已配置的人；不要
-`export HARNESS_ACTOR=human:you`。agent 自动化可按命令使用 `HARNESS_ACTOR=agent:<id>`。
-完整 source 矩阵见[归属模型](../../actor-attribution.zh-CN.md)。
-
-## 1. 初始化
-
-```bash
-$ ha init --person-id you --display-name "Your Name"
-ok command=init path=harness/harness.yaml summary="initialized harness at harness/harness.yaml"
-```
-
-这会创建已撰写的 `harness/` 目录。你的任务、决策和标准住在这里，但不进入你的项目 git 仓。`ha init` 会把 `harness/` 加进外层 `.gitignore`，并把 `harness/` 初始化成独立的私有嵌套 git 仓。
-
-这种隔离是防泄漏设计：代码 PR 不应包含 `harness/` 变更。需要给私有账本做版本记录时，在 `harness/` 里面提交：
-
-```bash
-git -C harness status
-git -C harness add .
-git -C harness -c user.name="$HARNESS_GIT_AUTHOR_NAME" \
-  -c user.email="$HARNESS_GIT_AUTHOR_EMAIL" \
-  commit -m "docs: update harness ledger"
-```
-
-生成的 `.harness/` 缓存只留在本地，也不会进入外层项目 git 仓。
+在临时 Git 仓库里完成 `ha init` 后，运行这一页配方。规范回环是：
 
 ```text
-harness/
-├── harness.yaml
-├── adr/
-├── context/
-├── milestones/
-├── standards/
-└── tasks/
+Fact → Decision → Task → Fact
 ```
 
-## 2. 创建一个任务
+下列回执片段来自 2026-09-12 的隔离 Ubuntu fixture；你的 ID 会不同。所有写入仍经
+center 单写队列，不要拿别人的工作区做示例。
+
+## 开始之前
+
+用拥有工作区的人类身份初始化一次：
 
 ```bash
-$ ha task create --title "Fix login redirect bug"
-ok command="task create" task=task_01KWPP52D062Q7BWTD8BCNDRWF status=planned
-   path=harness/tasks/task_01KWPP52D...-fix-login-redirect-bug
+ha init --person-id owner --display-name "Loop Owner"
 ```
 
-你得到一个稳定的 `task_<id>` 和一个磁盘上的任务包。ID 是身份；标题只是显示元数据。
+预期：`ok=true command=repo-bootstrap`。不要把 `HARNESS_ACTOR` 设成人类值；daemon 会
+认证 socket owner。agent 自动化可以为自己的命令设置 `HARNESS_ACTOR=agent:<id>`。
 
-## 3. 贯穿生命周期移动
+## 1. 记录观察
 
 ```bash
-$ ha task transition task_01KWPP52D062Q7BWTD8BCNDRWF active
-ok command="task transition" task=task_01KWPP52D062Q7BWTD8BCNDRWF status=active
-   summary="set task task_01KWPP52D062Q7BWTD8BCNDRWF to active"
+ha fact record --statement "Repeated handoffs lose the reason for the work." --source "support-review-2026-09-12" --confidence high
 ```
 
-任务经历六个状态：`planned → active → blocked → in_review → done → cancelled`。`done` 和 `cancelled` 是终态。
+预期：`ok=true command=fact-record factId=F-3C9EB45C status=accepted_durable`。
+保存回执里的 Fact ID，不要从 statement 猜 ID。
 
-## 4. 记录一个事实，然后一个决策
-
-事实是只增不改的观察。若要把观察归属到 task 并生成 `produces` 边，加上 `--task`：
+## 2. 提议选择
 
 ```bash
-$ ha fact record --task task_01KWPP52D062Q7BWTD8BCNDRWF \
-    --statement "Redirect loops when the session cookie is missing" \
-    --source "manual repro" --confidence high
-ok command="fact record" fact=F-7K3M2Q9R path=facts/F-7K3M2Q9R.md
+ha decision propose --json-input '{"title":"Keep handoff reasons in the ledger","question":"How should handoff context survive between sessions?","riskTier":"medium","urgency":"medium","decisionClass":"ordinary","chosen":[{"id":"CH1","text":"Record reasons as facts before creating follow-up work","rationale":"Preserves provenance"}],"rejected":[{"id":"RJ1","text":"Keep reasons only in chat","whyNot":"Chat is not a durable ledger"}],"claims":[{"id":"C1","text":"Durable facts preserve handoff reasons","loadBearing":true}]}' --body $'## 背景\nRepeated handoffs lose their rationale.\n\n## 权衡\nDurable facts preserve provenance; chat alone does not.\n\n## 结论\nRecord the reason as a Fact before creating follow-up work.'
 ```
 
-现在提议一个决策——为什么——并裁决它：
+预期：`ok=true command=decision-propose decisionId=dec_... state=proposed`。packet 承载
+机器字段；正文必须保留 `背景`、`权衡`、`结论` 三节。
+
+## 3. 挂证据，再用人类批准接受
 
 ```bash
-$ ha decision propose --title "Use a server-side redirect guard" \
-    --question "How do we stop the login redirect loop?" \
-    --chosen "Add a server-side guard" \
-    --rejected "Client-only fix" \
-    --why-not "Client fix races with cookie set"
-ok command="decision propose" path=harness/decisions/decision-dec_mr6f3b4z/decision.md
-
-$ ha decision accept dec_mr6f3b4z --arbiter you
-ok command="decision accept" path=harness/decisions/decision-dec_mr6f3b4z/decision.md
+ha relation relate --source-ref decision/dec_.../C1 --target-ref fact/F-3C9EB45C --type evidenced-by --rationale "The observed handoff loss supports the durability claim." --expected-version 0
 ```
 
-`accept` 是裁决检查点：决策的证据关系（用提议时的 `--evidence-relation` 附加，或稍后用 `ha decision relate`）在决策变为有约束力前被验证。这就是为什么一个被接受的决策*可信*而不只是被声称——完整的失败-闭合策略在 **[learn/](../../learn/zh/00-overview.md)** 里覆盖。
-
-## 5. 看结构增长
+预期：`ok=true command=relation-relate relationId=rel_...`。这里指向 claim `C1`，不是
+chosen option `CH1`；接受 decision 需要这条证据边，或明确的 judgment-only 理由。
 
 ```bash
-$ ha status
-ok command=status path=.harness/cache/projections.sqlite rows=1
-
-$ ha graph
-ok command=graph path=.harness/generated/graph-panorama/index.html
+ha decision transition in_effect dec_... --consent-by owner --consent-at 2026-09-12T08:00:00Z --consent-channel cli
 ```
 
-`graph` 把你的任务、决策和事实渲染成自包含 HTML 全景，全部有链接。
+预期：`ok=true command=decision-transition state=in_effect consentId=djc_...`。两个独立
+条件已经可见：claim 证据和明确的人类批准。三个 consent flags 是一次原子输入，且
+`--consent-by` 必须是已认证 principal。旧的 `ha decision accept` 是弃用 alias，不是
+第二条工作流。
 
-**这就是啊哈时刻**：你产生的不是聊天记录。它是私有 `harness/` 账本里的真实、版本化结构——任务、它观察到的事实和它说明的决策，全部有链接，并且可以用 `git -C harness diff` 审查。
+## 4. 创建由 decision 派生的 task
 
-![demo](../assets/demo.gif)
+```bash
+ha task create --title "Publish a durable handoff note" --preset docs-task
+```
 
-> **GIF 即将上线**——等 GUI 上船后替换为实时片段。
+预期：`ok=true command=task-create taskId=task_... status=accepted_durable`。使用回执给出的
+package path，把脚手架 `task_plan.md` 写实，再用 `ha doc sync --submit` 发布后才能 start。
 
----
+```bash
+ha relation relate --source-ref decision/dec_.../CH1 --target-ref task/task_... --type derives --rationale "The chosen durable-record path creates this work." --expected-version 0
+```
 
-下一步：更深入探索*为什么* → **[learn/](../../learn/zh/00-overview.md)**，或抓住 **[日常命令速记表](03-daily-commands.md)**。
+预期：`ok=true command=relation-relate relationId=rel_...`。派生边从 chosen option `CH1`
+出发；它与 `evidenced-by` 使用 claim anchor 的规则不同。
+
+## 5. 开工、产生收口 Fact、提交
+
+```bash
+ha task start task_...
+```
+
+预期：`ok=true command=task-start executionId=exe_... status=accepted_durable`。`start` 会
+取得 execution lease，之后的 task 写入必须由 holder 完成。
+
+完成工作后，记录一条归属此 task 的新观察：
+
+```bash
+ha fact record --task task_... --statement "The handoff note is present in the task package." --source "tasks/task_.../closeout.md" --confidence high
+```
+
+预期：`ok=true command=fact-record factId=F-... status=accepted_durable`。这条新 Fact 才会
+闭合回环；复用开头的 Fact 不算。
+
+提交前填写 task 的 `closeout.md`：
+
+```markdown
+## Summary
+
+Published the durable handoff note.
+
+## Verification
+
+Checked the submitted task package and closing Fact.
+
+## Residual Risk
+
+None known.
+
+## Same Mechanism Elsewhere
+
+Use the same Fact → Decision → Task → Fact cycle for the next handoff.
+```
+
+```bash
+ha task submit task_...
+```
+
+预期：`ok=true command=task-submit transition.from=active/implementation transition.to=in_review/review`。
+`submit` 会发布符合条件的 task 文档，包括 closeout；不要再手工提交私有 ledger Git。
+
+## 6. 评审并带 owner consent 完成
+
+独立 reviewer 针对已提交 execution 写入 verdict：
+
+```bash
+HARNESS_ACTOR=agent:loop-reviewer ha task review-execution task_... --review-id review-docs-loop --json-input '{"verdict":"approved","reason":"Independent reviewer checked the submitted closeout and result fact.","evidenceChecked":["fact/F-...","tasks/task_.../closeout.md"]}'
+```
+
+预期：`ok=true command=task-review-execution reviewId=review-docs-loop`。reviewer 不能与
+execution 的 agent 相同。
+
+```bash
+ha task complete task_...
+```
+
+在 owner consent／上游 Fact disposition 仍缺失时，预期：`ok=false command=task-complete
+code=fact_retirement_undeclared`。回执会点名仍需明确处置的上游 Fact，不要绕过。
+
+```bash
+ha task complete task_... --consent --fact-holds "F-3C9EB45C:The handoff-loss observation still holds after publishing this note."
+```
+
+预期：`ok=true command=task-complete transition.to=done/review status=accepted_durable`。
+`--consent` 会原子地选中 approved Review 并记录 owner consent；`--fact-holds` 记录开头
+那条证据为何仍然成立。
+
+现在得到的是可查询的完整闭环，而不是 task 形状的聊天记录。下一步可读
+[三原语内核](../../learn/zh/01-three-primitive-kernel.md)，或把[日常命令速记表](03-daily-commands.md)
+放在手边。

--- a/docs-release/start/zh/03-daily-commands.md
+++ b/docs-release/start/zh/03-daily-commands.md
@@ -2,6 +2,9 @@
 
 你最常用命令的速记表。任何命令加 `--json` 得到结构化输出。
 
+完整可执行的 Fact → Decision → Task → Fact 顺序只保留在
+[第一个完整闭环](02-first-loop.md)。本页不重复那条有状态工作流。
+
 ## 你会持续用的命令
 
 | 命令 | 做什么 |
@@ -10,34 +13,10 @@
 | `ha task create --title <title>` | 创建一个新任务包。 |
 | `ha task list` | 列出任务包，带状态/模块/搜索过滤。 |
 | `ha task show <id>` | 查看单个任务的投影状态、元数据、层级、关系边和事实锚。 |
-| `ha task transition <id> <state>` | 把任务移到新的生命周期状态。 |
-| `ha decision propose --title <t> ...` | 提议一个决策（问题、已选、已拒、为何不）。 |
-| `ha decision accept <id>` | 裁决一个提议的决策——证据检查点。 |
-| `ha fact record --statement <text> --source <text> [--task <id>]` | 记录一个只增不改的事实；可选关联到任务。 |
+| `ha task start <id>` | 取得或复用当前 execution lease。 |
 | `ha status` | 总结 harness 状态。 |
 | `ha check` | 运行 harness 健康检查。 |
 | `ha graph` | 把关系图渲染成自包含 HTML 全景。 |
-
-## 按场景
-
-**任务生命周期**
-```bash
-ha task create --title "Implement slice"
-ha task transition <id> active
-ha task progress append <id> --text "Implemented first slice"
-```
-
-**决策**
-```bash
-ha decision propose --title "..." --question "..." --chosen "..." --rejected "..." --why-not "..."
-ha decision accept <id>       # or: reject | defer
-ha decision list --state active
-```
-
-**事实**
-```bash
-ha fact record --statement "..." --source "..." --confidence high [--task <id>]
-```
 
 **检查和导航**
 ```bash
@@ -57,4 +36,4 @@ ha --help              # 全局帮助，或：ha help <command>
 ha capabilities        # 实体操作、输入 schema 和例子
 ```
 
-一些旧的命令拼写仍然作为已弃用别名工作，会在未来发布中退役——优先用上面展示的形式。
+弃用 alias 不再作为另一条工作流记录；请使用当前 help 和完整闭环页展示的形式。


### PR DESCRIPTION
# English

## Summary

Round 1 stopped on a real premise error before touching any public file: the prescribed one-page recipe's `task complete --consent-by <owner>` step was rejected (exit 2, `unknown_field`) by both the source CLI and the installed `ha` binary — `--consent-by`/`--consent-at`/`--consent-channel` actually belong to `decision transition`, not `task complete` (`task complete` only exposes `--execution-id`/`--consent`/`--fact-holds`; source anchor `daemon-protocol-commands-decision-lifecycle.ts:129`). The worker traced this to PR #2540 ("feat: record explicit human decision approval") having added those flags to Decision surfaces, not Task, and refused to silently rewrite the documented command (which would misrepresent the CEO-acceptance chain) or weaken any gate to make the literal recipe work. It proposed a corrected recipe to the CEO instead. After that ruling, the corrected chain (fact record -> decision propose with the three-section body -> attach fact evidence -> decision transition in_effect with truthful consent-by/at/channel -> task create+derives -> start -> result fact + submitted docs -> submit -> task complete --consent) was actually run end-to-end in an isolated fixture and passed, and 9 public `docs-release/**` files were rewritten to teach that corrected recipe, de-duplicating the loop/handoff steps that had drifted across the start/learn pages and the static site.

## Architectural Justification

-

## What Changed

- `docs-release/start/{en,zh}/02-first-loop.md` (108/98 lines changed, the largest edit): replaces the old lifecycle recipe — the retired propose/accept flag names, the manual-ledger-commit recipe, and unsupported claimed receipts — with the corrected, fixture-verified one-page loop (fact -> decision propose -> evidence -> decision transition in_effect with real consent flags -> task create/derives -> start -> submit -> complete --consent).
- `docs-release/start/{en,zh}/03-daily-commands.md`: removes the now-stale command examples this replaced, keeping navigation pointing at the single corrected recipe rather than duplicating it.
- `docs-release/learn/{en,zh}/{01-three-primitive-kernel,02-decision-and-verdict}.md`: removes duplicated loop/handoff steps that had drifted from the start pages, replacing them with links to the one validated recipe instead of a second copy that could drift again.
- `docs-release/site/index.html` (72 lines changed): updates the static site's overview/command examples and a Fact-storage description to match.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +254/-287 production (docs-release only, no code); tests +0/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_f1c29eb293f3aed69c566c6091 (parent task_4455977a529becac425737d812)
- Branch: `codex/docs-release-loop`
- Public scope: Public docs-release start/learn pages and the static site only. No code, gate, protocol, or CLI change — the underlying flag-placement issue that triggered the Round 1 stop was not itself modified; only the documentation was corrected to describe the commands as they actually exist.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Full `check:local` (forbidden for workers) and manual browser-rendering verification of the site changes were not performed. The worker's own CLI-help-gate coverage check found that `tools/check-cli-help-contract.mjs` reads command descriptors from `packages/kernel/src/domain/completion-readiness.ts` only and does not scan docs-release at all — i.e. there is no automated gate that would have caught this recipe/CLI drift in the first place, and none was added by this change (a coverage gap, explicitly named as a finding rather than fixed).

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/docs-release-loop`
- Private evidence commit/path: task_f1c29eb293f3aed69c566c6091 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Round 1 (blocked): `node packages/cli/src/index.ts --json task complete task_docs_release_fixture --consent-by fixture-owner` exit 2 `unknown_field`; `ha --json task complete ... --consent-by ...` exit 2, same rejection (both source and installed binary agree, ruling out a stale-build explanation); `task complete --help` confirms no `--consent-by`; `decision transition --help` confirms it belongs there; `git show --stat c61349de9` (#2540) confirms the flags were added to Decision surfaces only. Round 1 made zero public edits and no commit; `git status --short` was empty throughout. After the CEO's correction, the final round (commit `715dd2688`, base `690ae1a1672...`) ran: a full closed-loop isolated-Ubuntu fixture end-to-end (1/1 pass); post-rebase release-lifecycle tests (3/3 pass); post-rebase decision-human-approval tests (2/2 pass); CLI help-contract check, line-density, and production-delta gates all passed; changed-path manifest gates (3/3) passed. No command failed in this final, landed round — the one failure that did occur (Round 1's `--consent-by` rejection) was the correctly-identified premise error the recipe was rewritten to fix, not a defect in this PR's own changes.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- As with the other two docs-release branches in this batch, the worker's own accounting reports "Production delta: +0/-0" for a change that actually rewrites +254/-287 lines of shipped, user-facing onboarding documentation — because the repo's `tools/gates/module-policy.mjs`/`isProductionPath` only counts `packages/*/src` and `tools/` as production, excluding `docs-release/**` entirely. This review's own delta definition (which counts docs-release as production) disagrees with that self-report by the same amount. Separately, the coverage gap the worker surfaced is itself worth flagging: nothing in CI currently re-verifies that a docs-release command recipe still matches the real CLI surface, so this exact drift (a flag documented on the wrong command) can recur silently the next time a CLI flag moves.

## References

- Task: task_f1c29eb293f3aed69c566c6091

---

# 中文

## 概要

Round 1 在触碰任何公开文件之前，先发现了一个真实的前提错误，就此止步：规定配方一页闭环里的 `task complete --consent-by <owner>` 一步，被源码 CLI 和已安装的 `ha` 二进制双双拒绝（退出 2，`unknown_field`）——`--consent-by`/`--consent-at`/`--consent-channel` 实际上属于 `decision transition`，不属于 `task complete`（`task complete` 只暴露 `--execution-id`/`--consent`/`--fact-holds`；源码锚点 `daemon-protocol-commands-decision-lifecycle.ts:129`）。worker 追溯到这是 PR #2540（"feat: record explicit human decision approval"）把这些参数加到了 Decision 面而非 Task 面，并拒绝悄悄改写已文档化的命令（那样会歪曲 CEO 接受链），也拒绝为了让字面配方跑通而放宽任何门。它转而向 CEO 提出一份更正后的配方建议。裁决之后，更正链路（record fact → decision propose（三节正文）→ 附加 fact 证据 → decision transition in_effect（带真实 consent-by/at/channel）→ task create+derives → start → 结果 fact + 提交文档 → submit → task complete --consent）在隔离 fixture 中被端到端实跑并通过，随后重写了 9 份公开 `docs-release/**` 文件来讲授这条更正后的配方，同时去重此前在 start/learn 页面和静态站点之间漂移出的重复闭环/交接步骤。

## 架构辩护

-

## 改动内容

- `docs-release/start/{en,zh}/02-first-loop.md`（108/98 行改动，改动最大）：把旧的生命周期配方——已退役的 propose/accept 参数名、手动提交台账的配方、未获支持的所谓回执——替换为经 fixture 核验的更正版一页闭环（fact → decision propose → 证据 → decision transition in_effect（真实 consent 参数）→ task create/derives → start → submit → complete --consent）。
- `docs-release/start/{en,zh}/03-daily-commands.md`：删掉被替换掉的过时命令示例，让导航指向唯一的更正配方，不再重复。
- `docs-release/learn/{en,zh}/{01-three-primitive-kernel,02-decision-and-verdict}.md`：删除与 start 页面漂移出的重复闭环/交接步骤，改为链接到那份唯一经核验的配方，而不是留一份可能再次漂移的副本。
- `docs-release/site/index.html`（72 行改动）：同步更新静态站点的概览/命令示例与一处 Fact 存储描述。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+254/-287 production (docs-release only, no code); tests +0/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_f1c29eb293f3aed69c566c6091（父 task_4455977a529becac425737d812）
- 分支：`codex/docs-release-loop`
- 公开范围：仅公开 docs-release 的 start/learn 页面与静态站点。无代码、门、协议或 CLI 改动——触发 Round 1 止步的那个参数归属问题本身未被修改；只是文档被更正为如实描述命令的现状。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：完整 `check:local`（对 worker 禁止）和站点改动的人工浏览器渲染核验均未执行。worker 自己做的 CLI-help-gate 覆盖面检查发现，`tools/check-cli-help-contract.mjs` 只从 `packages/kernel/src/domain/completion-readiness.ts` 读取命令描述符，完全不扫描 docs-release——也就是说，本来就没有任何自动化门能捕捉到这种配方/CLI 漂移，本次改动也没有新增这样的门（这是一处被明确点名的覆盖缺口，而不是被修复的缺口）。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/docs-release-loop`
- 私有证据路径：task_f1c29eb293f3aed69c566c6091 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Round 1（被阻塞）：`node packages/cli/src/index.ts --json task complete task_docs_release_fixture --consent-by fixture-owner` 退出 2 `unknown_field`；`ha --json task complete ... --consent-by ...` 退出 2，同样被拒（源码与已装二进制结论一致，排除了"构建过期"的解释）；`task complete --help` 确认没有 `--consent-by`；`decision transition --help` 确认该参数确实属于这里；`git show --stat c61349de9`（#2540）确认这些参数只加到了 Decision 面。Round 1 全程零公开改动、无提交；`git status --short` 全程为空。CEO 更正之后，最终一轮（提交 `715dd2688`，基线 `690ae1a1672...`）运行了：完整闭环隔离 Ubuntu fixture 端到端（1/1 通过）；rebase 后的 release-lifecycle 测试（3/3 通过）；rebase 后的 decision-human-approval 测试（2/2 通过）；CLI help-contract 检查、line-density、production-delta 门全部通过；改动路径 manifest gates（3/3）通过。本次最终落地的这一轮没有任何命令失败——唯一发生过的失败（Round 1 的 `--consent-by` 拒绝）正是被正确识别出来、并促使配方被改写的那个前提错误，不是本 PR 自身改动的缺陷。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 和本批次另外两个 docs-release 分支一样，worker 自己的核算报的是"Production delta: +0/-0"，但实际改动重写了 +254/-287 行已发布、面向用户的上手文档——因为仓库的 `tools/gates/module-policy.mjs`/`isProductionPath` 只把 `packages/*/src` 和 `tools/` 算作生产面，完全不计入 `docs-release/**`。本次审阅任务给定的 delta 定义（把 docs-release 算作 production）与这份自报数字恰好相差这么多。另外，worker 自己揭示的这处覆盖缺口本身就值得点名：目前 CI 里没有任何东西会重新核实 docs-release 里的命令配方是否还和真实 CLI 面一致，所以这次这种漂移（一个参数被文档记在了错误的命令上）在下次 CLI 参数挪动时可以再次悄悄发生。

## 参考

- 任务：task_f1c29eb293f3aed69c566c6091

