### PR TITLE
feat: configure CI workflow names through settings update

### DIFF
--- a/packages/cli/test/thin-command-routing.test.ts
+++ b/packages/cli/test/thin-command-routing.test.ts
@@ -71,6 +71,16 @@ test("an unknown command domain reports unknown with the available set instead o
   assert.match(logs[0] ?? "", /migrate ledger/u);
 });
 
+test("settings update projects repeatable CI workflow flags into the daemon Action", () => {
+  const parsed = parseThinCommand(["settings", "update", "--ci-workflows", "ci", "--ci-workflows", "nightly"]);
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.deepEqual(parsed.command.action, { kind: "settings-update", ciWorkflows: ["ci", "nightly"] });
+  // .yml suffixes pass the identifier regex here and are rejected by the kernel compiler.
+  const rejected = parseThinCommand(["settings", "update", "--ci-workflows", "bad name"]);
+  assert.equal(rejected.ok, false);
+});
+
 test("entity import and update carry declared attributes as one typed JSON object", () => {
   const imported = parseThinCommand([
     "entity",

--- a/packages/daemon/src/protocol/daemon-protocol-commands.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands.ts
@@ -88,6 +88,13 @@ const settingsWriteTopology = {
         positiveSettingInput("--wal-flush-bytes"),
         positiveSettingInput("--wal-flush-milliseconds"),
         cliInput(
+          "--ci-workflows",
+          "repeated",
+          false,
+          { code: "invalid_field" },
+          { regex: "^[A-Za-z0-9][A-Za-z0-9/_.@-]*$" },
+        ),
+        cliInput(
           "--expected-version",
           "single",
           false,

--- a/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
@@ -204,6 +204,7 @@ export const daemonGuiActionMethods = Object.freeze([
       walFlushEvents: "number?",
       walFlushBytes: "number?",
       walFlushMilliseconds: "number?",
+      ciWorkflows: "array?",
       expectedVersion: "number?",
       idempotencyKey: "string",
     }),

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -284,18 +284,19 @@ export function validateGuiActionPayload(method: DaemonGuiActionMethod, value: u
       required.every((field) => nonEmpty(item[field])) &&
       Object.keys(item).every((field) => required.includes(field) || optional.includes(field));
   if (method === "repo.settings.update") {
+    // ciWorkflows is array-typed (enforced by the action shape) and its contents are judged by the
+    // kernel compiler, so only the scalar settings get the identifier check here.
     const settingFields = (
-        "defaultVertical defaultPreset defaultProfile defaultReviewer reviewIndependence " +
-        "reviewReturnBudget locale taskScaffold " +
-        "repositoryScaffold " +
-        "walFlushAdaptive walFlushEvents walFlushBytes walFlushMilliseconds"
+        "defaultVertical defaultPreset defaultProfile defaultReviewer reviewIndependence reviewReturnBudget " +
+        "locale taskScaffold repositoryScaffold walFlushAdaptive walFlushEvents " +
+        "walFlushBytes walFlushMilliseconds ciWorkflows"
       ).split(" "),
       changed = settingFields.filter((field) => value[field] !== undefined),
       identifier = /^[A-Za-z0-9][A-Za-z0-9/_.@-]*$/u;
     if (
       changed.length === 0 ||
       changed
-        .filter((field) => !field.startsWith("walFlush"))
+        .filter((field) => !field.startsWith("walFlush") && field !== "ciWorkflows")
         .some((field) => typeof value[field] !== "string" || !identifier.test(String(value[field]))) ||
       (value.walFlushAdaptive !== undefined && typeof value.walFlushAdaptive !== "boolean") ||
       [value.walFlushEvents, value.walFlushBytes, value.walFlushMilliseconds].some(

--- a/packages/daemon/src/repo-cell-task-progress.ts
+++ b/packages/daemon/src/repo-cell-task-progress.ts
@@ -63,8 +63,7 @@ export function readLatestCiEvidence(
   // unverified observation to find an older green observation; verified cancelled/skipped runs give no verdict.
   const submitted = execution.submission.commitSha,
     publicCut = localGitObjectRefStore.hasCommit(cell.rootDir, submitted),
-    root = publicCut ? cell.rootDir : resolveHarnessLayout(cell.rootDir).authoredRoot,
-    workflows = cell.settings.read().ci.workflows;
+    root = publicCut ? cell.rootDir : resolveHarnessLayout(cell.rootDir).authoredRoot;
   for (const event of observations.events) {
     if (!relatedCiObservation(root, event, submitted)) continue;
     const verification = event.payload.verification;
@@ -73,14 +72,14 @@ export function readLatestCiEvidence(
       !verification ||
       (publicCut
         ? verification.source !== "github-actions" ||
-          !workflows.includes(verification.workflow) ||
+          !cell.settings.read().ci.workflows.includes(verification.workflow) ||
           event.payload.run.branch !== "main"
         : verification.source !== "write-coordinator" || verification.workflow !== "ledger-publication")
     )
       throw cell.cellCodedError(
         "invalid_proof",
         publicCut
-          ? `Public delivery requires a verified ${workflows.join(" or ")} GitHub main run.`
+          ? `Public delivery requires a verified ${cell.settings.read().ci.workflows.join(" or ")} GitHub main run.`
           : "Private delivery requires a verified ledger-publication observation for its authored cut.",
       );
     if (verification.conclusion === "cancelled" || verification.conclusion === "skipped") continue;

--- a/packages/daemon/src/repo-cell-task-progress.ts
+++ b/packages/daemon/src/repo-cell-task-progress.ts
@@ -63,7 +63,8 @@ export function readLatestCiEvidence(
   // unverified observation to find an older green observation; verified cancelled/skipped runs give no verdict.
   const submitted = execution.submission.commitSha,
     publicCut = localGitObjectRefStore.hasCommit(cell.rootDir, submitted),
-    root = publicCut ? cell.rootDir : resolveHarnessLayout(cell.rootDir).authoredRoot;
+    root = publicCut ? cell.rootDir : resolveHarnessLayout(cell.rootDir).authoredRoot,
+    workflows = cell.settings.read().ci.workflows;
   for (const event of observations.events) {
     if (!relatedCiObservation(root, event, submitted)) continue;
     const verification = event.payload.verification;
@@ -72,14 +73,14 @@ export function readLatestCiEvidence(
       !verification ||
       (publicCut
         ? verification.source !== "github-actions" ||
-          verification.workflow !== "rewrite-ci" ||
+          !workflows.includes(verification.workflow) ||
           event.payload.run.branch !== "main"
         : verification.source !== "write-coordinator" || verification.workflow !== "ledger-publication")
     )
       throw cell.cellCodedError(
         "invalid_proof",
         publicCut
-          ? "Public delivery requires a verified rewrite-ci GitHub main run."
+          ? `Public delivery requires a verified ${workflows.join(" or ")} GitHub main run.`
           : "Private delivery requires a verified ledger-publication observation for its authored cut.",
       );
     if (verification.conclusion === "cancelled" || verification.conclusion === "skipped") continue;

--- a/packages/daemon/test/repo-cell-settings.integration.test.ts
+++ b/packages/daemon/test/repo-cell-settings.integration.test.ts
@@ -151,6 +151,27 @@ test("settings writes reject catalog-inconsistent vertical, preset, and profile 
     assert.equal(flushed.wait?.state, "satisfied", JSON.stringify(flushed));
     assert.match(readFileSync(configPath, "utf8"), /walFlush:[\s\S]*adaptive: false[\s\S]*events: 4096/u);
 
+    const ciApplied = await cell.run(
+      {
+        kind: "settings-update",
+        ciWorkflows: ["ci", "nightly"],
+        expectedVersion: flushApplied.revision,
+        idempotencyKey: "ci-workflows-settings",
+      },
+      binding,
+    );
+    assert.equal(ciApplied.outcome, "applied", JSON.stringify(ciApplied));
+    const ciSettings = (await cell.read("repo.settings.read")) as {
+      readonly settings: { readonly ci: { readonly workflows: readonly string[] } };
+    };
+    assert.deepEqual(ciSettings.settings.ci.workflows, ["ci", "nightly"]);
+    const ciFlushed = await cell.run(
+      { kind: "receipt-show", opId: ciApplied.opId, waitFor: ["worktree_visible"], timeoutMs: 5000 },
+      binding,
+    );
+    assert.equal(ciFlushed.wait?.state, "satisfied", JSON.stringify(ciFlushed));
+    assert.match(readFileSync(configPath, "utf8"), /ci:\n    workflows: \[ci, nightly\]/u);
+
     const beforeLocalRevision = eventStore.readHead()!.revision,
       localApplied = await cell.run(
         { kind: "settings-update", locale: "zh-CN", idempotencyKey: "local-settings-update" },

--- a/packages/daemon/test/repo-cell-task-progress-evidence.test.ts
+++ b/packages/daemon/test/repo-cell-task-progress-evidence.test.ts
@@ -107,6 +107,7 @@ function fixture(
     rootDir,
     projectionReady,
     service: { read: async () => read },
+    settings: { read: () => ({ ci: { workflows: ["rewrite-ci"] } }) },
     projection: {
       read: () => read,
       readCiRunObservations: () => ({ status: "ready", events, watermark: 2, sourceRevision: 2 }),
@@ -287,6 +288,22 @@ test("public and private cuts reject cross-kind exact and descendant witnesses",
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("CI evidence follows the repository's configured workflow names, not only rewrite-ci", () => {
+  const current = execution(publicSha),
+    configured = fixture(publicRoot, current, [observation(publicSha, 1, "success", "ci")]);
+  Object.assign(configured.cell, { settings: { read: () => ({ ci: { workflows: ["ci"] } }) } });
+  assert.equal(readLatestCiEvidence(configured.cell, current)?.result, "pass");
+  const unconfigured = fixture(publicRoot, current, [observation(publicSha, 2, "success", "rewrite-ci")]);
+  Object.assign(unconfigured.cell, { settings: { read: () => ({ ci: { workflows: ["ci"] } }) } });
+  assert.throws(
+    () => readLatestCiEvidence(unconfigured.cell, current),
+    (error: unknown) => {
+      if ((error as { readonly code?: string }).code !== "invalid_proof") return false;
+      return /verified ci GitHub main run/u.test((error as Error).message);
+    },
+  );
 });
 
 test("pure deletion reconciles empty paths and surviving deliverables reconcile without deletion output", async () => {

--- a/packages/kernel/src/domain/settings-action-contract.ts
+++ b/packages/kernel/src/domain/settings-action-contract.ts
@@ -15,6 +15,7 @@ import {
   repositorySettings,
   DEFAULT_RESTORE_DRILL_RETENTION,
   reviewIndependenceLevels,
+  settingValuePattern,
   settingsLocales,
   validateRepositorySettings,
   writeRepositorySettingsFacet,
@@ -49,6 +50,7 @@ const repositoryFieldNames = Object.freeze([
   "walFlushEvents",
   "walFlushBytes",
   "walFlushMilliseconds",
+  "ciWorkflows",
   "restoreDrillRetention",
 ] as const);
 
@@ -136,6 +138,7 @@ export function createSettingsActionCatalog(
           field("walFlushEvents", "number"),
           field("walFlushBytes", "number"),
           field("walFlushMilliseconds", "number"),
+          field("ciWorkflows", "string-array"),
           field("restoreDrillRetention", "number"),
           field("expectedVersion", "number"),
           field("idempotencyKey"),
@@ -219,7 +222,7 @@ export function compileSettingsUpdate(input: EntityActionCompileInput): Settings
         bytes: updatedPositiveInteger(input.action, "walFlushBytes", current.walFlush.bytes),
         milliseconds: updatedPositiveInteger(input.action, "walFlushMilliseconds", current.walFlush.milliseconds),
       },
-      ci: current.ci,
+      ci: { workflows: updatedWorkflows(input.action, current.ci.workflows) },
       restoreDrillRetention: updatedPositiveInteger(
         input.action,
         "restoreDrillRetention",
@@ -295,6 +298,20 @@ function updatedPositiveInteger(action: Readonly<Record<string, unknown>>, name:
     parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
   if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
   rejectSettings("invalid_command", `${name} must be a positive integer.`);
+}
+
+function updatedWorkflows(action: Readonly<Record<string, unknown>>, current: readonly string[]): readonly string[] {
+  if (!Object.hasOwn(action, "ciWorkflows")) return current;
+  const value = action.ciWorkflows;
+  if (!Array.isArray(value) || value.length === 0 || value.some((workflow) => typeof workflow !== "string"))
+    rejectSettings("invalid_command", "ciWorkflows must be a non-empty array of workflow names.");
+  const workflows = value.map((workflow) => workflow.trim());
+  if (
+    workflows.some((workflow) => !new RegExp(settingValuePattern, "u").test(workflow) || /\.ya?ml$/u.test(workflow)) ||
+    new Set(workflows).size !== workflows.length
+  )
+    rejectSettings("invalid_command", "ciWorkflows must contain unique workflow names without .yml.");
+  return workflows;
 }
 
 function rejectSettings(code: string, message: string): never {

--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -124,7 +124,7 @@ export const INITIAL_SETTINGS_V1: SettingsV1 = Object.freeze({
   restoreDrillRetention: DEFAULT_RESTORE_DRILL_RETENTION,
 });
 
-const settingValuePattern = "^[A-Za-z0-9][A-Za-z0-9/_.@-]*$";
+export const settingValuePattern = "^[A-Za-z0-9][A-Za-z0-9/_.@-]*$";
 
 export const SETTINGS_V1_SCHEMA: EntityDocumentJsonSchema<SettingsV1> = {
   $schema: "https://json-schema.org/draft/2020-12/schema",
@@ -356,6 +356,7 @@ export function writeRepositorySettingsFacet(body: string, settings: RepositoryS
     INITIAL_SETTINGS_V1.scaffolds.task,
   );
   next = writeWalFlushFacet(next, repository.walFlush);
+  next = writeCiFacet(next, repository.ci);
   next = replaceOptionalDefaultedScalar(
     next,
     "  ",
@@ -468,6 +469,17 @@ function writeWalFlushFacet(body: string, settings: WalFlushSettingsV1): string 
     `    milliseconds: ${settings.milliseconds}`,
     "",
   ].join("\n");
+  if (section.test(body)) return body.replace(section, rendered);
+  const header = /^settings:[^\r\n]*(?:\r?\n|$)/mu;
+  if (!header.test(body)) throw new Error("Missing settings block in harness.yaml.");
+  return body.replace(header, (match) => `${match}${rendered}`);
+}
+
+function writeCiFacet(body: string, ci: RepositorySettingsV1["ci"]): string {
+  const section = /^  ci:[^\S\r\n]*(?:\r?\n)(?:    [^\r\n]*(?:\r?\n|$))*/mu,
+    isDefault = JSON.stringify(ci) === JSON.stringify(INITIAL_SETTINGS_V1.ci);
+  if (!section.test(body) && isDefault) return body;
+  const rendered = `  ci:\n    workflows: [${ci.workflows.join(", ")}]\n`;
   if (section.test(body)) return body.replace(section, rendered);
   const header = /^settings:[^\r\n]*(?:\r?\n|$)/mu;
   if (!header.test(body)) throw new Error("Missing settings block in harness.yaml.");

--- a/packages/kernel/test/contracts/settings-action.test.ts
+++ b/packages/kernel/test/contracts/settings-action.test.ts
@@ -76,6 +76,25 @@ test("Settings update hydrates the default when the projected event predates rev
   assert.equal(draft.result.bundle.event.payload.settings.reviewIndependence, "principal");
 });
 
+test("Settings update writes the repository CI workflow names through the canonical event", () => {
+  const draft = compile({ ciWorkflows: ["ci", "nightly"] });
+  assert.equal(draft.kind, "settings");
+  if (draft.kind !== "settings" || draft.result.kind !== "event") throw new Error("missing settings event");
+  assert.deepEqual(draft.result.bundle.event.payload.settings.ci.workflows, ["ci", "nightly"]);
+  assert.equal(readSettingsFacet(draft.result.bundle.blobs[0].body).ci.workflows.join(","), "ci,nightly");
+  assertSettingsEventInputs(draft.result.bundle.event, draft.result.bundle.plan, draft.result.bundle.blobs);
+});
+
+test("Settings update rejects malformed CI workflow name lists", () => {
+  for (const ciWorkflows of [[], ["ci", "ci"], ["ci.yml"], ["ci.yaml"], [""]]) {
+    assert.throws(
+      () => compile({ ciWorkflows }),
+      (error: unknown) => error instanceof SettingsActionError && error.code === "invalid_command",
+      JSON.stringify(ciWorkflows),
+    );
+  }
+});
+
 test("Settings expectedVersion rejects a stale edge update with a typed error", () => {
   assert.throws(
     () => compile({ walFlushEvents: 512, expectedVersion: 6 }),

--- a/packages/kernel/test/layout/harness-settings.test.ts
+++ b/packages/kernel/test/layout/harness-settings.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { setting, settingBlockValue } from "../../src/layout/index.ts";
-import { readSettingsFacet } from "../../src/index.ts";
+import { readSettingsFacet, writeRepositorySettingsFacet } from "../../src/index.ts";
 
 const body = [
   "schema: harness-anything/v1",
@@ -47,4 +47,15 @@ test("CI workflows fail closed on empty, duplicate, extension-bearing, or block 
     const configured = `${body}\n  ci:\n    workflows: ${workflows}\n`;
     assert.throws(() => readSettingsFacet(configured), /settings\.ci\.workflows/u);
   }
+});
+
+test("the repository facet writer inserts, replaces, and leaves default CI workflows unmaterialized", () => {
+  const defaultCi = writeRepositorySettingsFacet(body, readSettingsFacet(body));
+  assert.doesNotMatch(defaultCi, /^  ci:/mu);
+  const inserted = writeRepositorySettingsFacet(body, { ...readSettingsFacet(body), ci: { workflows: ["ci"] } });
+  assert.match(inserted, /^  ci:\n    workflows: \[ci\]$/mu);
+  assert.deepEqual(readSettingsFacet(inserted).ci.workflows, ["ci"]);
+  const replaced = writeRepositorySettingsFacet(`${body}\n  ci:\n    workflows: [legacy]\n`, readSettingsFacet(body));
+  assert.doesNotMatch(replaced, /legacy/u);
+  assert.deepEqual(readSettingsFacet(replaced).ci.workflows, ["rewrite-ci"]);
 });


### PR DESCRIPTION
# English

## Summary

The public CI completion gate hardcoded this repository's own GitHub workflow name (`rewrite-ci`) as if it were a product default: any repository whose workflow is named something else — reported by a peer session on `FairladyZ625/protein-directed-evolution-agent`, whose workflow is `ci.yml` — could never satisfy the `ci` completion gate. `DEFAULT_CI_WORKFLOWS` was this repo's own workflow name baked into the kernel default, `ha settings update` had no field to write `ci.workflows` even though it is declared repository-owned, and `repo-cell-task-progress.ts` compared the observed workflow against the literal string `"rewrite-ci"`. This change adds a canonical `--ci-workflows <name>...` (repeated) flag to `ha settings update` that threads through the existing settings-event write path into a new `ci` facet writer for `harness.yaml`, and replaces the hardcoded string comparison with a read of the repository's configured `settings.ci.workflows`, naming the configured workflow(s) in the rejection message. `DEFAULT_CI_WORKFLOWS = ["rewrite-ci"]` remains this repo's default but is now overridable.

## Architectural Justification

-

## What Changed

- `packages/kernel/src/domain/settings-action-contract.ts`: `compileSettingsUpdate` gains a `ciWorkflows` field (`string-array`), a new `updatedWorkflows` validator (non-empty, unique, matches the shared identifier pattern, rejects `.yml`/`.yaml` suffixes), and now writes `ci: { workflows: updatedWorkflows(...) }` into the settings event instead of passing through `current.ci` unchanged.
- `packages/kernel/src/domain/settings.ts`: exports the previously-private `settingValuePattern`; adds `writeCiFacet` to `writeRepositorySettingsFacet` so the `ci:` block is inserted, replaced, or left unmaterialized (default value) in `harness.yaml`, mirroring the existing WAL-flush facet writer.
- `packages/daemon/src/protocol/daemon-protocol-commands.ts` / `daemon-protocol-gui-actions.ts` / `daemon-protocol-rpc-validation.ts`: add the repeated `--ci-workflows` CLI input, the `ciWorkflows: "array?"` GUI action field, and RPC validation that treats `ciWorkflows` as array-typed (leaving its content judged by the kernel compiler) rather than the scalar identifier check applied to the other settings fields.
- `packages/daemon/src/repo-cell-task-progress.ts`: `readLatestCiEvidence` now reads `cell.settings.read().ci.workflows` and checks `workflows.includes(verification.workflow)` instead of `verification.workflow !== "rewrite-ci"`; the rejection message names the configured workflow(s).
- Tests added/extended: `packages/cli/test/thin-command-routing.test.ts`, `packages/daemon/test/repo-cell-settings.integration.test.ts` (end-to-end: apply, read back, and materialize `workflows: [ci, nightly]` in `harness.yaml`), `packages/daemon/test/repo-cell-task-progress-evidence.test.ts` (a workflow named `ci` now passes; the old default name is rejected when not configured), `packages/kernel/test/contracts/settings-action.test.ts`, `packages/kernel/test/layout/harness-settings.test.ts` (facet writer insert/replace/default-omit round trip).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +49/-10 production; tests +79/-1.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_6e7837e1117d5df94c06a00995 (parent none)
- Branch: `codex/ci-workflow-configurable`
- Public scope: kernel settings domain/contract, daemon protocol declarations (CLI input, GUI action, RPC validation), and the CI-evidence check in `repo-cell-task-progress.ts`; no schema-shape change beyond the new optional `ciWorkflows` settings field, and no change to which repository owns the `ci` facet
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: GUI Vitest lane and the Windows lane were not run (worker is barred from the full `check:local`); the real `gh` fetch path (`fetchCiObservations`) was not touched and relies on its existing test coverage. No new governance decision was required per the report.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/ci-workflow-configurable`
- Private evidence commit/path: task_6e7837e1117d5df94c06a00995 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Directed tests across the 7 touched files all green, including the settings integration test that materializes `workflows: [ci, nightly]` in `harness.yaml` end to end; `test:fast` 719/712 passed with the 7 failures matching the pristine tree's pre-existing failures test-for-test (pre-existing debt, not a regression); typecheck/eslint/line-density/file-complexity/`run-manifest-gates --changed origin/main`/canonical-event-compat all green; production delta measured at +49/-10 matching this table; G0-5 RPC-validation ratchet net -1 line (shrink-only, satisfied by not duplicating kernel-level content validation at the ingress layer).

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The GUI has no editor for `ci.workflows` yet — it can only be set via `ha settings update --ci-workflows <name>...`, so a downstream repository (e.g. the reporting peer repo) must run that command itself once to unblock its `ci` completion gate; nothing defaults or auto-detects the workflow name from GitHub. `repo-cell-task-progress.ts` is also touched by concurrent in-flight work (ci-cancel/peer session) per the report, so a merge-order conflict is expected and flagged. The RPC ingress layer deliberately does not re-validate `ciWorkflows` content (uniqueness, `.yml` suffix) — it only checks the array shape and defers to the kernel compiler's typed rejection, following the existing `expectedVersion` precedent in the same function.

## References

- Task: task_6e7837e1117d5df94c06a00995

---

# 中文

## 概要

公开 CI 完成门此前把本仓自己的 GitHub workflow 名（`rewrite-ci`）当作产品默认值硬编码：任何 workflow 不叫这个名字的仓库都永远无法通过 `ci` 完成门——这是由一个对等 session 在 `FairladyZ625/protein-directed-evolution-agent`（其 workflow 叫 `ci.yml`）上报的真实阻塞。`DEFAULT_CI_WORKFLOWS` 是把本仓 workflow 名写死进 kernel 默认值，`ha settings update` 虽然把 `ci` 声明为 repository-owned，却没有字段可以写 `ci.workflows`，`repo-cell-task-progress.ts` 里则直接拿观测到的 workflow 名和字符串字面量 `"rewrite-ci"` 比较。本次改动给 `ha settings update` 新增了走既有 settings-event 写路的 canonical `--ci-workflows <name>...`（可重复）参数，落到 `harness.yaml` 一个新的 `ci` facet writer 里；并把硬编码字符串比较改成读该仓库配置的 `settings.ci.workflows`，拒绝信息里点名配置的 workflow 名。`DEFAULT_CI_WORKFLOWS = ["rewrite-ci"]` 仍是本仓默认值，但现在可被覆盖。

## 架构辩护

-

## 改动内容

- `packages/kernel/src/domain/settings-action-contract.ts`：`compileSettingsUpdate` 新增 `ciWorkflows` 字段（`string-array`），新增 `updatedWorkflows` 校验器（非空、去重、匹配共用的 identifier 正则、拒绝 `.yml`/`.yaml` 后缀），并把 `ci: { workflows: updatedWorkflows(...) }` 写入 settings 事件，而不是原样透传 `current.ci`。
- `packages/kernel/src/domain/settings.ts`：把原来私有的 `settingValuePattern` 导出；给 `writeRepositorySettingsFacet` 新增 `writeCiFacet`，在 `harness.yaml` 里插入/替换/（默认值时）不落盘 `ci:` 块，与既有 WAL-flush facet writer 同构。
- `packages/daemon/src/protocol/daemon-protocol-commands.ts` / `daemon-protocol-gui-actions.ts` / `daemon-protocol-rpc-validation.ts`：新增可重复的 `--ci-workflows` CLI 输入、GUI action 的 `ciWorkflows: "array?"` 字段，以及把 `ciWorkflows` 当数组类型处理的 RPC 校验（内容判断留给 kernel 编译器），而不是套用其余 settings 字段的标量 identifier 校验。
- `packages/daemon/src/repo-cell-task-progress.ts`：`readLatestCiEvidence` 改为读取 `cell.settings.read().ci.workflows`，用 `workflows.includes(verification.workflow)` 取代 `verification.workflow !== "rewrite-ci"`；拒绝信息点名配置的 workflow 名。
- 新增/扩展测试：`packages/cli/test/thin-command-routing.test.ts`、`packages/daemon/test/repo-cell-settings.integration.test.ts`（端到端验证写入、读回并在 `harness.yaml` 物化 `workflows: [ci, nightly]`）、`packages/daemon/test/repo-cell-task-progress-evidence.test.ts`（workflow 名为 `ci` 时通过；未配置时旧默认名被拒绝）、`packages/kernel/test/contracts/settings-action.test.ts`、`packages/kernel/test/layout/harness-settings.test.ts`（facet writer 插入/替换/默认不落盘的往返测试）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+49/-10 production; tests +79/-1。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_6e7837e1117d5df94c06a00995（父 none）
- 分支：`codex/ci-workflow-configurable`
- 公开范围：kernel settings 领域/contract、daemon 协议声明层（CLI 输入、GUI action、RPC 校验），以及 `repo-cell-task-progress.ts` 里的 CI 证据校验；除新增可选的 `ciWorkflows` settings 字段外没有其他 schema 形状变化，`ci` facet 的归属仓也未变
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：本次未跑 GUI Vitest lane 与 Windows lane（worker 被禁止跑整套 `check:local`）；真正的 `gh` 拉取路径（`fetchCiObservations`）未改动，沿用其既有测试覆盖。据报告本次修复无需新增治理决策。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/ci-workflow-configurable`
- 私有证据路径：task_6e7837e1117d5df94c06a00995 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 7 个触碰文件的定向测试全绿，含端到端验证在 `harness.yaml` 中物化 `workflows: [ci, nightly]` 的 settings 集成测试；`test:fast` 719/712 通过，7 个失败与 pristine 树逐 test 比对完全一致（存量债，非本次引入的回归）；typecheck/eslint/line-density/file-complexity/`run-manifest-gates --changed origin/main`/canonical-event-compat 全绿；生产净变更实测 +49/-10，与本表一致；G0-5 RPC-validation ratchet 净 −1 行（shrink-only，靠不在 ingress 层重复 kernel 内容校验满足）。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- GUI 目前没有 `ci.workflows` 的编辑入口——只能靠 `ha settings update --ci-workflows <name>...` 设置，因此下游仓库（例如上报问题的对等仓）必须自行跑一次这个命令才能解除其 `ci` 完成门阻塞；没有任何自动探测或默认从 GitHub 推断 workflow 名的机制。据报告，`repo-cell-task-progress.ts` 同时被一个在飞的并发工作（ci-cancel/peer session）触碰，合并顺序上预期会有冲突，已在报告中标出。RPC ingress 层刻意不重复校验 `ciWorkflows` 的内容（去重、`.yml` 后缀）——只检查数组形状，内容校验交给 kernel 编译器的 typed 拒绝，沿用同一函数里 `expectedVersion` 的既有先例。

## 参考

- 任务：task_6e7837e1117d5df94c06a00995

