### PR TITLE
fix: accept multi-cwd dispatch cuts and fall back to ledger delivery

### DIFF
--- a/packages/daemon/src/repo-cell-submit.ts
+++ b/packages/daemon/src/repo-cell-submit.ts
@@ -4,6 +4,8 @@ import {
   heldLeaseForExecutionActor,
   isSameExecution,
   isTaskEvent,
+  ledgerGitPath,
+  resolveLedgerGitLayout,
   submissionFromCloseout,
   submissionDigest,
   type SubmissionV1,
@@ -62,32 +64,30 @@ export function deriveCloseoutSubmission(
         dispatch.cwd,
     ),
     directories = [...new Set(dispatches.map((dispatch) => dispatch.cwd!))],
-    git = makeGitReadinessSource();
-  if (directories.length > 1)
-    throw cell.cellCodedError("invalid_submission", "Execution has more than one delivery worktree.");
-  let root = directories[0] ?? cell.rootDir,
-    commitSha = named[0]!;
-  const publishedRoot = [...new Set([root, cell.rootDir])].find(
-    (candidate) => git.run(candidate, ["cat-file", "-e", `${commitSha}^{commit}`]).ok,
-  );
+    git = makeGitReadinessSource(),
+    publishedRoot = [...new Set([...directories, cell.rootDir])].find(
+      (candidate) => git.run(candidate, ["cat-file", "-e", `${named[0]!}^{commit}`]).ok,
+    );
   if (!publishedRoot)
     throw cell.cellCodedError(
       "invalid_submission",
-      `Delivery commit ${commitSha} is not published in either repository.`,
+      `Delivery commit ${named[0]!} is not published in any bound or canonical repository.`,
     );
-  root = publishedRoot;
-  commitSha = git.run(root, ["rev-parse", `${commitSha}^{commit}`]).stdout;
-  if (directories.length && named.length) {
-    const dispatchHead = git.run(directories[0]!, ["rev-parse", "HEAD"]).stdout;
+  const root = publishedRoot,
+    commitSha = git.run(root, ["rev-parse", `${named[0]!}^{commit}`]).stdout;
+  // One execution may dispatch through several cwds (delivery worktree, then closeout prep at
+  // the canonical root). The named cut must still be explained by one of them: it is that
+  // directory's HEAD, contains a dispatch HEAD, or is already published to origin/main.
+  if (directories.length) {
+    const published = git.run(root, ["merge-base", "--is-ancestor", commitSha, "origin/main"]).ok;
     if (
-      dispatchHead
-        ? commitSha !== dispatchHead &&
-          !(
-            git.run(root, ["merge-base", "--is-ancestor", dispatchHead, commitSha]).ok &&
-            git.run(root, ["merge-base", "--is-ancestor", commitSha, "origin/main"]).ok &&
-            git.run(root, ["rev-list", "--parents", "-n", "1", commitSha]).stdout.split(" ").length > 2
-          )
-        : !git.run(cell.rootDir, ["merge-base", "--is-ancestor", commitSha, "origin/main"]).ok
+      !directories.some((directory) => {
+        const head = git.run(directory, ["rev-parse", "HEAD"]).stdout;
+        return (
+          head === commitSha ||
+          (published && (head ? git.run(root, ["merge-base", "--is-ancestor", head, commitSha]).ok : true))
+        );
+      })
     )
       throw cell.cellCodedError(
         "invalid_submission",
@@ -110,9 +110,36 @@ export function deriveCloseoutSubmission(
     removed = runProcessText("git", ["diff", "--name-only", "-z", "--diff-filter=D", base, commitSha, "--"], root)
       .split("\0")
       .filter(Boolean);
-  if (!deliverables.length && !removed.length)
-    throw cell.cellCodedError("invalid_submission", "Delivery cut contains no changed paths.");
   const { artifacts: _artifacts, ...codeProse } = prose;
+  if (!deliverables.length && !removed.length) {
+    // A task without CI or code-doc gates delivers authored documents: its cut is the private
+    // ledger HEAD plus this package's accepted artifacts, never a public code diff.
+    const privateDelivery = !(snapshot.task?.completionGateIds ?? []).some(
+      (gate) => gate === "ci" || gate === "code-doc-reconciliation",
+    );
+    if (!privateDelivery) throw cell.cellCodedError("invalid_submission", "Delivery cut contains no changed paths.");
+    const ledger = resolveLedgerGitLayout(cell.rootDir),
+      artifacts = git.run(ledger.rootDir, [
+        "ls-tree",
+        "-r",
+        "--name-only",
+        "HEAD",
+        "--",
+        ledgerGitPath(ledger, `${document.packagePath}/artifacts/`),
+      ]);
+    if (!artifacts.ok || !artifacts.stdout)
+      throw cell.cellCodedError(
+        "invalid_submission",
+        `Delivery cut contains no changed paths; publish harness/${document.packagePath}/artifacts/ ` +
+          `or name artifact:path@revision anchors in Summary.`,
+      );
+    return {
+      ...codeProse,
+      commitSha: git.run(ledger.rootDir, ["rev-parse", "HEAD"]).stdout,
+      deliverables: artifacts.stdout.split("\n"),
+      outputs: [],
+    };
+  }
   return {
     ...codeProse,
     commitSha,

--- a/packages/daemon/test/closeout-submission-cut.test.ts
+++ b/packages/daemon/test/closeout-submission-cut.test.ts
@@ -52,8 +52,8 @@ function fixture(t: TestContext, sharedGit = false) {
   return { root, ledger, base };
 }
 
-function derive(rootDir: string, summary: string, missingPath?: string) {
-  const snapshot = { executions: [], task: { completionGateIds: ["ci"] } } as unknown as Parameters<
+function derive(rootDir: string, summary: string, missingPath?: string, gates: readonly string[] = ["ci"]) {
+  const snapshot = { executions: [], task: { completionGateIds: gates } } as unknown as Parameters<
       typeof deriveCloseoutSubmission
     >[3],
     body = closeout(summary),
@@ -87,9 +87,9 @@ function derive(rootDir: string, summary: string, missingPath?: string) {
   );
 }
 
-function dispatch(root: string, cwd: string) {
+function dispatch(root: string, cwd: string, dispatchId = "dispatch_111111111111111111111111") {
   openDispatchStream(root, {
-    dispatchId: "dispatch_111111111111111111111111",
+    dispatchId,
     taskId: "task-1",
     executionId: "execution-1",
     runtimeSessionId: "runtime_111111111111111111111111",
@@ -212,4 +212,44 @@ test("removed dispatch worktree resolves an explicit published cut in the canoni
   put(root, "src/unpublished.ts", "unpublished\n");
   const unpublished = commit(root);
   assert.throws(() => derive(root, `Delivery ${unpublished}`), /published merge commit/u);
+});
+
+test("one execution with two dispatch directories accepts its published merge cut", (t) => {
+  const { root } = fixture(t),
+    worker = path.join(root, "worker");
+  git(root, "worktree", "add", "-qb", "worker", worker);
+  put(worker, "src/delivery.ts", "delivery\n");
+  commit(worker);
+  git(root, "merge", "--no-ff", "-qm", "test: merge delivery", "worker");
+  const merged = git(root, "rev-parse", "HEAD");
+  git(root, "update-ref", "refs/remotes/origin/main", merged);
+  dispatch(root, worker);
+  dispatch(root, root, "dispatch_222222222222222222222222");
+  const packet = derive(root, `Delivery ${merged}.`);
+  assert.equal(packet.commitSha, merged);
+  assert.deepEqual(packet.deliverables, ["src/delivery.ts"]);
+});
+
+test("dispatch-bound documentation task with an empty product cut falls back to ledger artifacts", (t) => {
+  const { root, ledger } = fixture(t);
+  put(ledger, `${packagePath}/artifacts/report.md`, "Evidence.\n");
+  commit(ledger);
+  git(root, "commit", "-q", "--allow-empty", "-m", "test: empty product cut");
+  const empty = git(root, "rev-parse", "HEAD");
+  dispatch(root, root);
+  const packet = derive(root, `Delivered ${empty}.`, undefined, []);
+  assert.equal(packet.commitSha, git(ledger, "rev-parse", "HEAD"));
+  assert.deepEqual(packet.deliverables, [`${packagePath}/artifacts/report.md`]);
+  assert.deepEqual(packet.outputs, []);
+});
+
+test("ledger fallback still fails closed when the task has no accepted artifacts", (t) => {
+  const { root } = fixture(t);
+  git(root, "commit", "-q", "--allow-empty", "-m", "test: empty product cut");
+  const empty = git(root, "rev-parse", "HEAD");
+  dispatch(root, root);
+  assert.throws(() => derive(root, `Delivered ${empty}.`, undefined, []), {
+    code: "invalid_submission",
+    message: /artifacts/u,
+  });
 });


### PR DESCRIPTION
# English

## Summary

`deriveCloseoutSubmission` (`packages/daemon/src/repo-cell-submit.ts`) had two deadlocks reported by a peer session (fact F-B1B5EABC, affecting `task_e2eab881` and `task_8e29be09`): (a) once an execution dispatched through more than one worktree cwd — a worker in an isolated worktree, then a later closeout-prep dispatch at the repo root — the function unconditionally rejected with "Execution has more than one delivery worktree," even though 14 already-merged tasks in this repository legitimately took that shape; (b) a dispatch-bound docs-only task, whose entire deliverable lives in the gitignored `/harness/` ledger tree, always produces an empty product-repo diff between its named commit and its merge-base, and was rejected outright instead of falling back to the private ledger delivery path that non-dispatch-bound tasks already use. The fix replaces the single-directory `directories.length > 1` rejection and the old HEAD-equality/merge-shape check with a per-directory check across all of an execution's dispatch cwds (the named commit must be some directory's HEAD, or — once published to `origin/main` — reachable from some directory's HEAD), and adds an explicit `privateDelivery` fallback: when the product diff is empty and the task's completion gates don't include `ci` or `code-doc-reconciliation`, the submission is built from the ledger repository's HEAD plus that task package's `artifacts/` tree via `git ls-tree`, failing closed with a message naming both paths (publish to `artifacts/` or name an `artifact:path@revision` anchor) when no artifacts exist.

## Architectural Justification

-

## What Changed

- `packages/daemon/src/repo-cell-submit.ts`: removed the outright `directories.length > 1` rejection and the old single-dispatch `dispatchHead`/`rev-list --parents` merge-shape check; `publishedRoot` resolution now searches every dispatch cwd plus the cell root (not just `directories[0]`); the named-commit-explained-by-a-dispatch check now iterates all `directories`, accepting a cwd whose HEAD equals the named commit, or — once the commit is confirmed published to `origin/main` — whose HEAD is an ancestor of it; when the product diff (`deliverables`/`removed`) is empty, a new branch checks `snapshot.task?.completionGateIds` for `ci`/`code-doc-reconciliation` and, if neither gate applies, resolves the ledger's git layout (`resolveLedgerGitLayout`/`ledgerGitPath`, newly imported from kernel) and returns a submission built from the ledger HEAD commit and an `ls-tree -r` of the task package's `artifacts/` directory, or throws `invalid_submission` naming both fallback paths if that tree is empty.
- Note on an unrelated pre-existing check in the same function: `named.length > 1` (more than one distinct 40-hex sha appearing in the closeout Summary, once `artifact:` anchors are stripped) is still rejected — this branch does not touch that check or its surrounding conditional, and it continues to share the existing "Summary must explicitly name one commit or artifact:path@revision anchors" message with the artifact-anchor-mismatch case rather than gaining a message of its own.
- `packages/daemon/test/closeout-submission-cut.test.ts`: `derive()`/`dispatch()` helpers parameterized with `gates`/`dispatchId`; three new tests — a two-dispatch-cwd execution accepting its published merge cut, a dispatch-bound docs task with an empty product diff falling back to ledger artifacts, and that same fallback failing closed when the task has no accepted artifacts.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +50/-23 production; tests +44/-4.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_146e0fa851280a569c57c978eb (parent none)
- Branch: `codex/doc-task-submit-fallback`
- Public scope: `packages/daemon/src/repo-cell-submit.ts` only, exactly the stated execution surface; no schema or protocol shape change
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: The secondary deadlock the peer session also reported — an active execution blocking `ha task start --execution-id <new>` so a stuck dispatch-bound execution cannot be routed around — is explicitly out of scope for this change. Full `check:local` and the Windows lane were not run (worker is barred from the former; CI is authoritative). No new governance decision was required per the report.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/doc-task-submit-fallback`
- Private evidence commit/path: task_146e0fa851280a569c57c978eb `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Both peer-cited deadlocks reproduced red before the fix ("Execution has more than one delivery worktree" for the two-dispatch-cwd case; "Delivery cut contains no changed paths" for the dispatch-bound empty-diff docs case) and pass after, plus a new fail-closed negative for the no-artifacts ledger fallback; `closeout-submission-cut.test.ts` went from 3 failing / 10 passing to 13/13 passing; adjacent `submission-artifacts`, `repo-cell-task-progress-evidence`, and `projection-readiness` suites 24/24; three submit-chain integration files individually exit 0 via the isolated dispatch command (target=ubuntu); local gates (eslint, `npm run typecheck`, line-density, `run-manifest-gates --changed origin/main`, file-complexity, canonical-event-compat) all exit 0; production delta measured at +51/-23 in the report versus +50/-23 by direct `git diff --numstat` (one-line rounding in the report's own count, not a discrepancy in the diff itself).

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Deliberately narrowed acceptance: a commit already merged to `origin/main` no longer needs to look like a merge commit (`rev-list --parents` shape) to be named — a fast-forward delivery can now be named directly, which widens what Summary can point at. The ledger fallback records `commitSha` as the ledger repository's HEAD (pre-#2541 semantics, restored here as an explicit branch rather than a flag) rather than a product-repo commit; downstream consumers of `SubmissionV1.commitSha` for dispatch-bound docs tasks were not individually audited beyond the submit-to-review integration chain already covered by tests. Acceptance of this change should exercise both the two-dispatch-cwd path and the ledger-fallback path, not just one. The secondary active-execution deadlock reported alongside this one remains unresolved and out of scope.

## References

- Task: task_146e0fa851280a569c57c978eb

---

# 中文

## 概要

`deriveCloseoutSubmission`（`packages/daemon/src/repo-cell-submit.ts`）存在一个对等 session 上报的两处死锁（fact F-B1B5EABC，影响 `task_e2eab881`、`task_8e29be09`）：其一，一旦某次执行经由多于一个 dispatch cwd（先在隔离 worktree 里的 worker，之后又在仓库根做 closeout-prep dispatch），函数会无条件以 "Execution has more than one delivery worktree." 拒绝——尽管本仓已有 14 个已合并任务合法地是这种形状；其二，一个 dispatch 绑定了 cwd 的纯文档任务，其全部产出都在被 gitignore 的 `/harness/` 台账树里，其命名提交与 merge-base 之间的产品仓 diff 必然为空，此前会被直接拒绝，而不是像未绑定 worktree 的同类任务那样回落到既有的私有台账交付路径。本次修复用「遍历该执行所有 dispatch cwd 逐一判定」取代了单目录的 `directories.length > 1` 拒绝和旧的 HEAD 相等/merge 形状检查（命名提交须是某个目录的 HEAD，或者——一旦已发布到 `origin/main`——是某个目录 HEAD 的后继），并新增显式的 `privateDelivery` 回落：当产品 diff 为空且任务的完成门不包含 `ci` 或 `code-doc-reconciliation` 时，从台账仓库的 HEAD 加该任务包 `artifacts/` 目录的 `git ls-tree` 结果构造交付；若该目录为空则 fail-closed，错误信息同时点名两条路径（发布到 `artifacts/`，或在 Summary 里点名 `artifact:path@revision` 锚点）。

## 架构辩护

-

## 改动内容

- `packages/daemon/src/repo-cell-submit.ts`：删除了整段无条件的 `directories.length > 1` 拒绝，以及旧的单-dispatch `dispatchHead`/`rev-list --parents` merge 形状检查；`publishedRoot` 的解析改为搜索所有 dispatch cwd 加 cell 根（不再只看 `directories[0]`）；「命名提交须被某个 dispatch 解释」的检查改为遍历全部 `directories`，接受某个 cwd 的 HEAD 恰好等于命名提交，或者——一旦确认该提交已发布到 `origin/main`——某个 cwd 的 HEAD 是它的祖先；当产品 diff（`deliverables`/`removed`）为空时，新增一个分支检查 `snapshot.task?.completionGateIds` 是否含 `ci`/`code-doc-reconciliation`，若都不含，则解析台账的 git layout（新从 kernel 引入 `resolveLedgerGitLayout`/`ledgerGitPath`），返回由台账 HEAD 提交 + 该任务包 `artifacts/` 目录的 `ls-tree -r` 构造的交付，若该目录为空则以 `invalid_submission` 抛出、信息里点名两条回落路径。
- 关于同一函数内一处未改动的既有检查：`named.length > 1`（剥离 `artifact:` 锚点后，closeout Summary 里出现超过一个不同的 40 位十六进制 sha）仍然会被拒绝——本分支未触碰这条检查及其所在的条件式，它继续与「artifact 锚点数量不匹配」共用既有的 "Summary must explicitly name one commit or artifact:path@revision anchors" 拒绝信息，而不是获得一条专属的新信息。
- `packages/daemon/test/closeout-submission-cut.test.ts`：`derive()`/`dispatch()` 辅助函数参数化增加 `gates`/`dispatchId`；新增三条测试——双 dispatch cwd 执行接受其已发布的 merge 提交、dispatch 绑定的文档任务在产品 diff 为空时回落台账 artifacts、以及台账无 artifacts 时该回落 fail-closed。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+50/-23 production; tests +44/-4。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_146e0fa851280a569c57c978eb（父 none）
- 分支：`codex/doc-task-submit-fallback`
- 公开范围：仅 `packages/daemon/src/repo-cell-submit.ts`，与既定执行面完全一致；未改动 schema 或协议形状
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：对等 session 一并上报的次生死锁——执行处于 active 状态时 `ha task start --execution-id <新id>` 被拒，导致卡住的 dispatch 绑定执行无法绕开——明确不在本次改动范围内。整套 `check:local` 与 Windows lane 未跑（worker 被禁止跑前者；CI 为权威）。据报告本次修复无需新增治理决策。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/doc-task-submit-fallback`
- 私有证据路径：task_146e0fa851280a569c57c978eb 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 对等 session 点名的两处死锁均先复现为红（双 dispatch cwd 场景报 "Execution has more than one delivery worktree."；dispatch 绑定的空 diff 文档任务报 "Delivery cut contains no changed paths."），修复后转绿，另加一条台账无 artifacts 时 fail-closed 的负向测试；`closeout-submission-cut.test.ts` 从 3 败/10 过变为 **13/13 通过**；相邻的 `submission-artifacts`、`repo-cell-task-progress-evidence`、`projection-readiness` 三个套件 24/24；三个 submit 链路 integration 文件经隔离派测命令逐个 exit 0（target=ubuntu）；本地 gate（eslint、`npm run typecheck`、line-density、`run-manifest-gates --changed origin/main`、file-complexity、canonical-event-compat）全部 exit 0；生产净变更报告里记为 +51/-23，直接用 `git diff --numstat` 核算为 +50/-23（报告自身计数上的一行舍入差，非 diff 本身的问题）。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 有意收窄的验收面：已合入 `origin/main` 的提交不再需要看起来像 merge 提交（`rev-list --parents` 形状检查）才能被点名——一次 fast-forward 交付现在也可以被直接点名，这扩大了 Summary 能指向的提交范围。台账回落把 `commitSha` 记为台账仓库的 HEAD（#2541 之前的语义，本次以显式分支而非 flag 的形式恢复），而不是产品仓提交；`SubmissionV1.commitSha` 在 dispatch 绑定文档任务场景下的下游消费方，除了测试已覆盖的 submit→review 集成链路外未逐一审计。验收本变更时应同时演练双 dispatch cwd 路径和台账回落路径，而不只验一条。与本问题一并上报的 active-execution 次生死锁仍未解决，且不在本次范围内。

## 参考

- 任务：task_146e0fa851280a569c57c978eb

