### PR TITLE
fix(daemon,cli): carry coded rejection messages to the CLI hint and request logs

### DIFF
--- a/packages/cli/test/guidance-plane.test.ts
+++ b/packages/cli/test/guidance-plane.test.ts
@@ -302,3 +302,41 @@ test("relation rejection renders structured triples and preserves them through d
     assert.equal(diagnosticForError({ diagnostic: { ...diagnostic, allowedTriples } }), undefined);
   }
 });
+
+test("daemon-coded rejection messages reach the CLI hint verbatim for submit and complete", () => {
+  const submitMessage =
+      "Delivery cut contains no changed paths; publish harness/tasks/task-1/artifacts/ " +
+      "or name artifact:path@revision anchors in Summary.",
+    submit = renderCliReceipt({
+      schema: "command-receipt/v2",
+      ok: false,
+      command: "task-submit",
+      outcome: "op_rejected",
+      opId: "op_submit",
+      code: "document_invalid",
+      origin: "daemon",
+      evidence: "rejection:document_invalid",
+      diagnostic: { kind: "failure", code: "document_invalid" },
+      rejectionExplanation: submitMessage,
+      error: { code: "document_invalid" },
+    });
+  assert.equal(submit.stream, "stderr");
+  assert.match(submit.text, /error code=document_invalid hint=/u);
+  assert.ok(submit.text.includes(submitMessage), submit.text);
+  const completeMessage = "CI receipt cannot support completion: evidence executionId is not the current execution.",
+    complete = renderCliReceipt({
+      schema: "command-receipt/v2",
+      ok: false,
+      command: "task-complete",
+      outcome: "op_rejected",
+      opId: "op_complete",
+      code: "invalid_proof",
+      origin: "daemon",
+      evidence: "rejection:invalid_proof",
+      diagnostic: { kind: "failure", code: "invalid_proof" },
+      rejectionExplanation: completeMessage,
+      error: { code: "invalid_proof" },
+    });
+  assert.equal(complete.stream, "stderr");
+  assert.ok(complete.text.includes(completeMessage), complete.text);
+});

--- a/packages/daemon/src/daemon-host-errors.ts
+++ b/packages/daemon/src/daemon-host-errors.ts
@@ -10,7 +10,7 @@ import { type RepoTaskAction } from "./repo-cell.ts";
 export function rejectHostAction(
   action: RepoTaskAction,
   errorCode: string,
-  _legacyGuidance: string,
+  explanation: string,
   diagnostic?: ReceiptDiagnostic,
 ): WriteReceipt {
   return {
@@ -20,6 +20,8 @@ export function rejectHostAction(
     origin: "daemon",
     evidence: `rejection:${errorCode}`,
     diagnostic: diagnostic ?? { kind: "failure", code: errorCode },
+    // The same receipt field every other rejection path uses; a host-caught error keeps its message.
+    rejectionExplanation: explanation,
   };
 }
 

--- a/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
+++ b/packages/daemon/src/protocol/json-rpc-dispatch-support.ts
@@ -73,7 +73,11 @@ export function resultErrorCode(result: object): string | null {
 }
 export function resultErrorDetail(result: object): string | null {
   if (resultOk(result)) return null;
-  const diagnostic = "diagnostic" in result ? result.diagnostic : undefined,
+  const explanation =
+      "rejectionExplanation" in result && typeof result.rejectionExplanation === "string"
+        ? result.rejectionExplanation
+        : null,
+    diagnostic = "diagnostic" in result ? result.diagnostic : undefined,
     error = "error" in result ? result.error : undefined,
     sqliteError = isJsonObject(error)
       ? {
@@ -81,11 +85,47 @@ export function resultErrorDetail(result: object): string | null {
           ...(typeof error.errstr === "string" ? { errstr: error.errstr } : {}),
         }
       : {},
+    // The rejection's own message says why it failed; the diagnostic is a fallback for results
+    // that carry no message, and a code-only {kind:"failure"} placeholder collapses to the code
+    // that the log's own field already records.
     detail =
-      (isJsonObject(diagnostic) ? JSON.stringify(diagnostic) : null) ??
+      explanation ??
+      (isJsonObject(diagnostic) && diagnostic.kind !== "failure" ? JSON.stringify(diagnostic) : null) ??
       (Object.keys(sqliteError).length > 0 ? JSON.stringify(sqliteError) : null) ??
       ("evidence" in result && typeof result.evidence === "string" ? result.evidence : null);
   return detail?.slice(0, 500) ?? "Unknown request failure.";
+}
+
+// The one place a dispatched result becomes its request-log entry, next to the result-derived
+// helpers it reads from, so the protocol server stays a routing concern.
+export function daemonRequestLogEntry(input: {
+  readonly method: string;
+  readonly repoId: string;
+  readonly command: string;
+  readonly connectionId: string;
+  readonly auth: DaemonAuthenticationContext;
+  readonly executor: DaemonRequestLogEntry["executor"];
+  readonly result: object;
+  readonly dispatchDelayMs: number;
+  readonly serviceMs: number;
+}): DaemonRequestLogEntry {
+  const ok = resultOk(input.result);
+  return {
+    method: input.method,
+    repoId: input.repoId,
+    command: input.command,
+    connectionId: input.connectionId,
+    auth: input.auth,
+    executor: input.executor,
+    ok,
+    outcome: "outcome" in input.result && typeof input.result.outcome === "string" ? input.result.outcome : null,
+    code: resultErrorCode(input.result),
+    opId: "opId" in input.result && typeof input.result.opId === "string" ? input.result.opId : null,
+    ...(ok ? {} : { detail: resultErrorDetail(input.result) }),
+    dispatchDelayMs: input.dispatchDelayMs,
+    serviceMs: input.serviceMs,
+    durationMs: input.serviceMs,
+  };
 }
 export function rpcError(id: JsonRpcId, errorCode: number, message: string): JsonRpcResponse {
   return { jsonrpc: "2.0", id, error: { code: errorCode, message } };

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -19,6 +19,7 @@ import {
 } from "./daemon-protocol.contract.ts";
 import {
   declaredExecutorOrNull,
+  daemonRequestLogEntry,
   isDaemonStreamCall,
   isRepoGuiReadCall,
   isRuntimeInstanceAuthCall,
@@ -563,21 +564,19 @@ export function createJsonRpcProtocolServer(options: {
     serviceMs: number,
   ): void {
     if (!options.recordRequest || !observed.repoId) return;
-    options.recordRequest({
-      method,
-      repoId: observed.repoId,
-      command: observed.command,
-      connectionId,
-      auth: options.authContext,
-      executor: observed.executor,
-      ok: resultOk(result),
-      outcome: "outcome" in result && typeof result.outcome === "string" ? result.outcome : null,
-      code: resultErrorCode(result),
-      opId: "opId" in result && typeof result.opId === "string" ? result.opId : null,
-      dispatchDelayMs,
-      serviceMs,
-      durationMs: serviceMs,
-    });
+    options.recordRequest(
+      daemonRequestLogEntry({
+        method,
+        repoId: observed.repoId,
+        command: observed.command,
+        connectionId,
+        auth: options.authContext,
+        executor: observed.executor,
+        result,
+        dispatchDelayMs,
+        serviceMs,
+      }),
+    );
   }
   // Daemon-scoped counterpart: every request including hello and pre-dispatch rejections gets one
   // line, so connection-level forensics never depends on repo binding.

--- a/packages/daemon/src/repo-cell-submit.ts
+++ b/packages/daemon/src/repo-cell-submit.ts
@@ -256,6 +256,8 @@ export function submissionStopped(
   const code = error.code === "closeout_placeholder" ? "closeout_placeholder" : "document_invalid";
   return {
     ...cell.rejected(cell.operationId(action, binding, cell.input.repoId, snapshot.revision), code),
+    // The remapped code alone cannot say why the document was rejected; the guard's own message can.
+    rejectionExplanation: error.message,
     next: [
       completionGuidance(
         snapshot,

--- a/packages/daemon/src/request-log.ts
+++ b/packages/daemon/src/request-log.ts
@@ -29,6 +29,7 @@ export interface DaemonRequestLogEntry {
   readonly outcome: string | null;
   readonly code: string | null;
   readonly opId: string | null;
+  readonly detail?: string | null;
   readonly dispatchDelayMs?: number;
   readonly serviceMs?: number;
   readonly durationMs: number;
@@ -50,6 +51,7 @@ export interface DaemonRequestLogRecord {
   readonly outcome: string | null;
   readonly code: string | null;
   readonly opId: string | null;
+  readonly detail?: string | null;
   readonly dispatchDelayMs: number;
   readonly serviceMs: number;
   readonly durationMs: number;
@@ -176,6 +178,7 @@ function buildRecord(entry: DaemonRequestLogEntry, at: Date): DaemonRequestLogRe
     outcome: entry.outcome,
     code: entry.code,
     opId: entry.opId,
+    ...(entry.detail === undefined ? {} : { detail: entry.detail }),
     dispatchDelayMs: entry.dispatchDelayMs ?? 0,
     serviceMs: entry.serviceMs ?? entry.durationMs,
     durationMs: entry.durationMs,

--- a/packages/daemon/test/closeout-submission-cut.test.ts
+++ b/packages/daemon/test/closeout-submission-cut.test.ts
@@ -5,8 +5,9 @@ import { mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test, { type TestContext } from "node:test";
-import { deriveCloseoutSubmission } from "../src/repo-cell-submit.ts";
+import { deriveCloseoutSubmission, submissionStopped } from "../src/repo-cell-submit.ts";
 import { openDispatchStream } from "../src/dispatch-stream.ts";
+import type { RepoCellBinding, RepoTaskAction, Snapshot } from "../src/repo-cell-types.ts";
 
 const packagePath = "tasks/task-1";
 const documentPath = `${packagePath}/closeout.md`;
@@ -252,4 +253,31 @@ test("ledger fallback still fails closed when the task has no accepted artifacts
     code: "invalid_submission",
     message: /artifacts/u,
   });
+});
+
+test("a stopped submission keeps the invalid_submission message as its rejection explanation", () => {
+  const cell = {
+      input: { repoId: "canonical" },
+      operationId: () => "op_stopped",
+      rejected: (opId: string, code: string) => ({
+        outcome: "op_rejected",
+        opId,
+        code,
+        origin: "daemon",
+        evidence: `rejection:${code}`,
+        diagnostic: { kind: "failure", code },
+      }),
+    } as unknown as Parameters<typeof submissionStopped>[0],
+    error = Object.assign(new Error("Delivery cut contains no changed paths."), { code: "invalid_submission" }),
+    receipt = submissionStopped(
+      cell,
+      { kind: "task-submit", taskId: "task-1" } as RepoTaskAction,
+      {} as RepoCellBinding,
+      { revision: 3 } as Snapshot,
+      "execution-1",
+      packagePath,
+      error,
+    );
+  assert.equal(receipt.code, "document_invalid");
+  assert.equal(receipt.rejectionExplanation, "Delivery cut contains no changed paths.");
 });

--- a/packages/daemon/test/conn-log.test.ts
+++ b/packages/daemon/test/conn-log.test.ts
@@ -51,6 +51,29 @@ test("request failure detail records native SQLite result details", () => {
   );
 });
 
+test("request failure detail carries the daemon's rejection message over the code-only placeholder", () => {
+  const message = "CI receipt cannot support completion: evidence executionId is not the current execution.";
+  assert.equal(
+    resultErrorDetail({
+      ok: false,
+      code: "invalid_proof",
+      error: { code: "invalid_proof" },
+      diagnostic: { kind: "failure", code: "invalid_proof" },
+      rejectionExplanation: message,
+    }),
+    message,
+  );
+  // A structured diagnostic that says more than the code still wins when no message exists.
+  assert.equal(
+    resultErrorDetail({
+      ok: false,
+      error: { code: "invalid_result" },
+      diagnostic: { kind: "invalid-enum", field: "status", actual: "unknown", allowedValues: ["ready"] },
+    }),
+    '{"kind":"invalid-enum","field":"status","actual":"unknown","allowedValues":["ready"]}',
+  );
+});
+
 test("conn log records open/request/close with monotonic ids, active counts, and per-connection request totals", async () => {
   const userRoot = tempRoot(),
     log = openDaemonConnLog({ userRoot, daemonId: "test-daemon", now: at("2026-08-20T13:00:00Z") });

--- a/packages/daemon/test/daemon-host-errors.test.ts
+++ b/packages/daemon/test/daemon-host-errors.test.ts
@@ -1,0 +1,13 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { rejectHostAction } from "../src/daemon-host-errors.ts";
+import type { RepoTaskAction } from "../src/repo-cell-types.ts";
+
+test("a host-rejected action keeps its coded message as the receipt explanation", () => {
+  const message = "CI receipt cannot support completion: evidence executionId is not the current execution.",
+    receipt = rejectHostAction({ kind: "task-complete", taskId: "task-1" } as RepoTaskAction, "invalid_proof", message);
+  assert.equal(receipt.code, "invalid_proof");
+  assert.equal(receipt.rejectionExplanation, message);
+  assert.deepEqual(receipt.diagnostic, { kind: "failure", code: "invalid_proof" });
+});

--- a/packages/daemon/test/request-log.test.ts
+++ b/packages/daemon/test/request-log.test.ts
@@ -195,6 +195,42 @@ test("a rejected request is recorded with its error code", async () => {
   assert.equal(records[0].outcome, "op_rejected");
 });
 
+test("a rejected request records the daemon's failure message as its detail", async () => {
+  const rootDir = tempRoot(),
+    host = stubHost(rootDir),
+    message = "CI receipt cannot support completion: evidence executionId is not the current execution.";
+  const rejecting = {
+    ...host,
+    run: async () => ({
+      outcome: "op_rejected" as const,
+      opId: "rejected:task-complete",
+      code: "invalid_proof",
+      origin: "daemon",
+      evidence: "rejection:invalid_proof",
+      diagnostic: { kind: "failure", code: "invalid_proof" },
+      rejectionExplanation: message,
+    }),
+  } as unknown as DaemonHost;
+  const server = openServerWithLog(rootDir, rejecting);
+  await handshake(server);
+  await server.handle({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "repo.task.run",
+    params: {
+      repo: { repoId: "logged" },
+      payload: { action: { kind: "task-complete", taskId: "task_01ARZ3NDEKTSV4RRFFQ69G5FAV" } },
+    },
+  });
+  server.close();
+  await server.requestLog.settle();
+
+  const records = readRecords(rootDir);
+  assert.equal(records.length, 1);
+  assert.equal(records[0].ok, false);
+  assert.equal(records[0].detail, message);
+});
+
 test("a request that binds no repository is not recorded", async () => {
   const rootDir = tempRoot(),
     server = openServerWithLog(rootDir);


### PR DESCRIPTION
# English

## Summary

When the daemon rejected `ha task submit` or `ha task complete`, the CLI showed only the bare code (`document_invalid`, `invalid_proof`) and the request logs kept only the code, so operators had to read daemon source to learn which rule fired (two peer sessions hit this today: multi-cwd dispatch cuts, the new artifact-anchor closeout contract, empty delivery cuts). Three drop points are fixed on the one existing `rejectionExplanation` path: `submissionStopped` remapped `invalid_submission` to `document_invalid` and buried the message in `next[0].reason` which the CLI never rendered; `rejectHostAction` discarded the daemon message as `_legacyGuidance`; and the conn/request logs serialised a bare `{kind:"failure",code}` placeholder. Messages now reach the wire receipt, the CLI hint, and both jsonl log sinks verbatim.

## Architectural Justification

Smallest correct change: no new error channel; the three places that dropped the message are wired to the `rejectionExplanation` path that `invalid_proof` already used.

## What Changed

- `packages/daemon/src/repo-cell-submit.ts`: rejected submissions carry `rejectionExplanation` with the coded message.
- `packages/daemon/src/daemon-host-errors.ts` and `protocol/json-rpc-server.ts`: host-level rejections keep the daemon message instead of dropping it.
- `packages/daemon/src/request-log.ts` and conn-log: failure detail records the message, not only the code.
- Tests: closeout-submission-cut, conn-log, daemon-host-errors, request-log (4 new red-to-green cases).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +34/-19 production; tests +102/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_dcbfdb78a8bb1bb4496aaae22e (parent none)
- Branch: `codex/receipt-reason`
- Public scope: daemon rejection receipts and request logs
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: daemon stdio log (`daemon-default.log`) still does not log per-request rejections by design; the selection/execution-binding root cause from the original plan is a separate stop point

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/receipt-reason`
- Private evidence commit/path: task_dcbfdb78a8bb1bb4496aaae22e `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Touched-surface fast tests 47/47 locally; 6 integration files green through the Ubuntu isolated dispatcher; tsc, eslint, line-density, tier manifest, canonical-event-compat green. GitHub CI for this branch: pending on this PR.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Messages are now user-visible verbatim; a coded message that embeds a host path would surface it (existing messages checked, none do).

## References

- Task: task_dcbfdb78a8bb1bb4496aaae22e

---

# 中文

## 概要

daemon 拒绝 `ha task submit` / `ha task complete` 时，CLI 只显示裸错误码（`document_invalid`、`invalid_proof`），请求日志也只留 code，操作者只能读 daemon 源码反推撞了哪条规则（今天两个对等 session 都撞到：多 dispatch cwd、新的 artifact 锚 closeout 契约、空交付切点）。三处丢失点都在既有的 `rejectionExplanation` 通路上修好：`submissionStopped` 把 `invalid_submission` 重映射成 `document_invalid` 后把 message 埋进 CLI 从不渲染的 `next[0].reason`；`rejectHostAction` 以 `_legacyGuidance` 名义丢掉 daemon message；conn/request 日志把 `{kind:"failure",code}` 占位折叠成纯 code。现在 message 原样到达 wire 回执、CLI hint 和两个 jsonl 日志。

## 架构辩护

最小正确改法：不加新错误通道，把三处丢 message 的地方接到 `invalid_proof` 已在用的 `rejectionExplanation` 通路。

## 改动内容

- `packages/daemon/src/repo-cell-submit.ts`：被拒提交带 `rejectionExplanation`（coded message）。
- `packages/daemon/src/daemon-host-errors.ts` 与 `protocol/json-rpc-server.ts`：host 层拒绝保留 daemon message。
- `packages/daemon/src/request-log.ts` 与 conn-log：失败详情记 message 而不只是 code。
- 测试：closeout-submission-cut、conn-log、daemon-host-errors、request-log（4 条新红→绿）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+34/-19 production; tests +102/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_dcbfdb78a8bb1bb4496aaae22e（父 none）
- 分支：`codex/receipt-reason`
- 公开范围：daemon 拒绝回执与请求日志
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：daemon stdio 日志（`daemon-default.log`）按既有设计不逐请求记 rejection；原 plan 的 selection/execution 绑定根因是另一个停止点

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/receipt-reason`
- 私有证据路径：task_dcbfdb78a8bb1bb4496aaae22e 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 触碰面 fast 测试本地 47/47；6 个集成文件经 Ubuntu 隔离入口全绿；tsc、eslint、line-density、tier manifest、canonical-event-compat 绿。本分支 GitHub CI：本 PR 待跑。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- message 现在原样对用户可见；若某条 coded message 内嵌宿主路径会被透出（已查现有文案，没有）。

## 参考

- 任务：task_dcbfdb78a8bb1bb4496aaae22e

