### PR TITLE
feat: make CI completion witnessing optional per repository

### DIFF
--- a/docs-release/architecture/en/04-gates-in-the-pipeline.md
+++ b/docs-release/architecture/en/04-gates-in-the-pipeline.md
@@ -106,7 +106,7 @@ for the current Execution (ADR-0027 D5, D7).
 | transition document readiness | documents consumed by a transition must have every required section realized and contain no preset scaffold sentence; the shared validator covers task plan/closeout, Decision body, Agent instructions, and Squad roster | `<doc>_placeholder` |
 | code-doc reconciliation | when the resolved contract declares `code-doc-reconciliation` and the reviewed submission names any repository deliverable, the execution must carry a verified code-doc witness; a non-empty deliverable list containing only `artifacts/`, `tasks/`, or `harness/tasks/` task-package references makes the gate not applicable | `code_doc_missing` when an applicable execution has no witness |
 | review gate axis | the completion function receives review as `passed` after the review gate above succeeds | `review_not_passed` |
-| CI gate axis | when the resolved contract declares `ci`, the CLI-provided CI gate must be `passed`; otherwise `--ci` is not required | `missing_ci_gate` or `ci_not_passed` |
+| CI gate axis | the resolved contract declares `ci` only when repository settings configure CI witness workflows (`settings.ci.workflows`); with the gate declared, a green run of a configured workflow on `main` — imported through `ha ci observe pull` — must be witnessed for the submitted cut, the run conclusion being the verdict and uploaded `ci-observation-*` artifacts being optional detail | `ci_missing` |
 | closeout readiness axis | projected closeout readiness must be `ready` or `passed` | `closeout_not_ready` |
 | task tree dirty check | after the transition sweep, `tasks/<id>/` must be clean enough for the lifecycle writer to commit | `task_tree_dirty` |
 

--- a/docs-release/architecture/zh/04-gates-in-the-pipeline.md
+++ b/docs-release/architecture/zh/04-gates-in-the-pipeline.md
@@ -69,7 +69,7 @@ closeout readiness，最后才写入 `done`。legacy task 会重新运行 `revie
 | 转换文档就绪 | 被转换消费的文档必须写实全部必需节且不保留 preset 脚手架句；共享校验器覆盖 task plan/closeout、Decision body、Agent instructions 与 Squad roster | `<doc>_placeholder` |
 | code-doc reconciliation | 解析出的契约声明 `code-doc-reconciliation` 且已复核 submission 含任一公开仓交付物时，Execution 必须有已验证的 code-doc witness；非空 deliverable 列表若全部是 `artifacts/`、`tasks/` 或 `harness/tasks/` 下的任务包工件，则此门不适用 | 适用但缺 witness 时报告 `code_doc_missing` |
 | review 门轴 | 上面的 review 门通过后，completion 函数收到的 review 必须是 `passed` | `review_not_passed` |
-| CI 门轴 | 解析出的契约声明 `ci` 时，CLI 传入的 CI 门必须是 `passed`；否则无需 `--ci` | `missing_ci_gate` 或 `ci_not_passed` |
+| CI 门轴 | 只有当仓库 settings 配置了 CI 见证 workflow（`settings.ci.workflows` 非空）时，解析出的契约才声明 `ci`；声明时，submitted cut 必须有经 `ha ci observe pull` 导入的、配置 workflow 在 `main` 上的绿 run 见证，run conclusion 即判定，上传的 `ci-observation-*` 工件只是可选细节 | `ci_missing` |
 | closeout 就绪度轴 | 投影出的 closeout readiness 必须是 `ready` 或 `passed` | `closeout_not_ready` |
 | task tree dirty 检查 | 迁移清扫之后，`tasks/<id>/` 必须足够干净，让 lifecycle writer 可以提交 | `task_tree_dirty` |
 

--- a/packages/daemon/src/ci-observation-actions.ts
+++ b/packages/daemon/src/ci-observation-actions.ts
@@ -126,10 +126,36 @@ export async function fetchCiObservations(
               },
             );
           } catch (error) {
+            // A run without ci-observation-* artifacts fails the download; whatever landed is used below.
             consumeKnownError(error);
-            return { fetched: null };
           }
-          return { fetched: { databaseId: run.databaseId, summary, artifacts: readArtifacts(runRoot) } };
+          // The run conclusion is the completion verdict; a run that uploads no artifacts still
+          // yields one observation synthesized from its summary (tests/gates stay empty).
+          const artifacts = readArtifacts(runRoot);
+          return {
+            fetched: {
+              databaseId: run.databaseId,
+              summary,
+              artifacts: artifacts.length
+                ? artifacts
+                : [
+                    {
+                      schema: "ci-run-artifact/v1",
+                      run: {
+                        runId: `${run.databaseId}.${summary.attempt}`,
+                        sha: summary.headSha,
+                        branch: summary.headBranch,
+                        prNumber: null,
+                        job: summary.workflowName,
+                        wallclockMs: 0,
+                        runner: "github-actions",
+                      },
+                      tests: [],
+                      gates: [],
+                    },
+                  ],
+            },
+          };
         } catch (failure) {
           return { failure };
         }
@@ -273,7 +299,7 @@ export function ingestCiObservations(
       canonicalVisible: visible,
       worktreeVisible: false,
     },
-    summary: `Imported ${imported} CI observation artifact(s); ${duplicate} already existed.\n` + eventRefs.join("\n"),
+    summary: `Imported ${imported} CI observation(s); ${duplicate} already existed.\n` + eventRefs.join("\n"),
   } as WriteReceipt;
 }
 

--- a/packages/daemon/test/ci-observation-synthesis.test.ts
+++ b/packages/daemon/test/ci-observation-synthesis.test.ts
@@ -1,0 +1,120 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import type { CiRunObservationEventV3 } from "../../kernel/src/index.ts";
+import type { RepoCellOperationalContext } from "../src/repo-cell-action-context.ts";
+import { fetchCiObservations, ingestCiObservations } from "../src/ci-observation-actions.ts";
+import { readLatestCiEvidence } from "../src/repo-cell-task-progress.ts";
+import { projectionReady } from "../src/repo-cell-settlement.ts";
+
+const actor = { principal: { personId: "person-synthesis" }, executor: null } as const;
+
+function git(root: string, ...args: readonly string[]): string {
+  return execFileSync("git", ["-C", root, "-c", "user.name=test", "-c", "user.email=test@example.com", ...args], {
+    encoding: "utf8",
+  }).trim();
+}
+
+function initMainRepo(root: string): string {
+  git(root, "init", "-q", "-b", "main");
+  writeFileSync(path.join(root, "README.md"), "peer repo\n");
+  git(root, "add", "README.md");
+  git(root, "commit", "-q", "-m", "delivered");
+  return git(root, "rev-parse", "HEAD");
+}
+
+function ingestCell(rootDir: string, events: CiRunObservationEventV3[]) {
+  let revision = 0;
+  return {
+    rootDir,
+    settings: { read: () => ({ ci: { workflows: ["ci"] } }) },
+    now: () => "2026-09-12T00:00:00.000Z",
+    cellCodedError: (_code: string, message: string) => new Error(message),
+    store: {
+      readHead: () => (revision === 0 ? null : { revision }),
+      readEvent: (opId: string) => events.find((event) => event.opId === opId),
+      append: ({ event: observed }: { event: CiRunObservationEventV3 }) => {
+        revision += 1;
+        events.push(observed);
+        return { revision };
+      },
+    },
+    projection: { apply: () => undefined, readCiRunObservations: () => ({ watermark: events.length }) },
+  };
+}
+
+const noArtifactRunGh = (delivered: string) =>
+  (async (_command: string, args: readonly string[]) => {
+    if (args[1] === "list")
+      return JSON.stringify([{ databaseId: 900, headBranch: "main", createdAt: "2026-09-12T00:00:00Z" }]);
+    if (args[1] === "view")
+      return JSON.stringify({
+        workflowName: "ci",
+        headSha: delivered,
+        headBranch: "main",
+        status: "completed",
+        conclusion: "success",
+        attempt: 1,
+      });
+    assert.equal(args[1], "download");
+    // A workflow that uploads no ci-observation-* artifacts fails the pattern download.
+    throw new Error("no valid artifacts found to download");
+  }) as never;
+
+test("an artifact-less green main run synthesizes a passing observation from its run summary", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-ci-no-artifacts-")),
+    events: CiRunObservationEventV3[] = [],
+    cell = ingestCell(rootDir, events);
+  try {
+    const delivered = initMainRepo(rootDir);
+    const receipt = ingestCiObservations(
+      cell as never,
+      { actor, source: "local" },
+      await fetchCiObservations(cell as never, { kind: "ci-observe-pull", limit: 5 }, noArtifactRunGh(delivered)),
+    );
+    assert.equal(JSON.parse(receipt.evidence).imported, 1);
+    assert.equal(events.length, 1);
+    const observed = events[0]!;
+    assert.deepEqual(observed.payload.tests, []);
+    assert.deepEqual(observed.payload.gates, []);
+    assert.deepEqual(observed.payload.verification, {
+      source: "github-actions",
+      workflow: "ci",
+      runId: "900",
+      attempt: 1,
+      headSha: delivered,
+      conclusion: "success",
+    });
+    const submitted = {
+      schema: "execution/v1",
+      executionId: "execution",
+      iteration: 0,
+      submission: { commitSha: delivered, deliverables: [], outputs: [], verificationNotes: [], knownGaps: [] },
+    } as never;
+    const evidence = readLatestCiEvidence(
+      {
+        rootDir,
+        projectionReady,
+        settings: { read: () => ({ ci: { workflows: ["ci"] } }) },
+        projection: {
+          readCiRunObservations: () => ({
+            status: "ready",
+            events,
+            watermark: events.length,
+            sourceRevision: events.length,
+          }),
+        },
+        cellCodedError: (_code: string, message: string) => new Error(message),
+      } as unknown as RepoCellOperationalContext,
+      submitted,
+    );
+    assert.equal(evidence?.result, "pass");
+    assert.equal(evidence?.provenance.runId, "900.1");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/daemon/test/repo-cell-settings.integration.test.ts
+++ b/packages/daemon/test/repo-cell-settings.integration.test.ts
@@ -172,6 +172,27 @@ test("settings writes reject catalog-inconsistent vertical, preset, and profile 
     assert.equal(ciFlushed.wait?.state, "satisfied", JSON.stringify(ciFlushed));
     assert.match(readFileSync(configPath, "utf8"), /ci:\n    workflows: \[ci, nightly\]/u);
 
+    const ciCleared = await cell.run(
+      {
+        kind: "settings-update",
+        ciWorkflows: [],
+        expectedVersion: ciApplied.revision,
+        idempotencyKey: "ci-workflows-clear",
+      },
+      binding,
+    );
+    assert.equal(ciCleared.outcome, "applied", JSON.stringify(ciCleared));
+    const clearedSettings = (await cell.read("repo.settings.read")) as {
+      readonly settings: { readonly ci: { readonly workflows: readonly string[] } };
+    };
+    assert.deepEqual(clearedSettings.settings.ci.workflows, []);
+    const clearFlushed = await cell.run(
+      { kind: "receipt-show", opId: ciCleared.opId, waitFor: ["worktree_visible"], timeoutMs: 5000 },
+      binding,
+    );
+    assert.equal(clearFlushed.wait?.state, "satisfied", JSON.stringify(clearFlushed));
+    assert.match(readFileSync(configPath, "utf8"), /ci:\n    workflows: \[\]/u);
+
     const beforeLocalRevision = eventStore.readHead()!.revision,
       localApplied = await cell.run(
         { kind: "settings-update", locale: "zh-CN", idempotencyKey: "local-settings-update" },

--- a/packages/kernel/src/domain/settings-action-contract.ts
+++ b/packages/kernel/src/domain/settings-action-contract.ts
@@ -303,8 +303,9 @@ function updatedPositiveInteger(action: Readonly<Record<string, unknown>>, name:
 function updatedWorkflows(action: Readonly<Record<string, unknown>>, current: readonly string[]): readonly string[] {
   if (!Object.hasOwn(action, "ciWorkflows")) return current;
   const value = action.ciWorkflows;
-  if (!Array.isArray(value) || value.length === 0 || value.some((workflow) => typeof workflow !== "string"))
-    rejectSettings("invalid_command", "ciWorkflows must be a non-empty array of workflow names.");
+  // An empty list is the explicit opt-out from repository CI witnessing; entry shape is still enforced.
+  if (!Array.isArray(value) || value.some((workflow) => typeof workflow !== "string"))
+    rejectSettings("invalid_command", "ciWorkflows must be an array of workflow names.");
   const workflows = value.map((workflow) => workflow.trim());
   if (
     workflows.some((workflow) => !new RegExp(settingValuePattern, "u").test(workflow) || /\.ya?ml$/u.test(workflow)) ||

--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -400,7 +400,6 @@ function ciSettingsSchema() {
       workflows: ownedSchema("ci", {
         type: "array" as const,
         items: { type: "string" as const, pattern: settingValuePattern, minLength: 1 },
-        minItems: 1,
         uniqueItems: true,
       }),
     },
@@ -413,15 +412,16 @@ function readCiSettings(body: string): SettingsV1["ci"] {
   const section = /^  ci:[^\S\r\n]*(?:\r?\n)((?:    [^\r\n]*(?:\r?\n|$))*)/mu.exec(body)?.[1];
   if (section === undefined) return INITIAL_SETTINGS_V1.ci;
   const raw = settingBlockValue(body, "ci", "workflows");
-  if (raw === undefined) throw new Error("settings.ci.workflows must be a non-empty inline array of workflow names");
+  if (raw === undefined) throw new Error("settings.ci.workflows must be an inline array of workflow names");
   if (!raw.startsWith("[") || !raw.endsWith("]"))
-    throw new Error("settings.ci.workflows must be a non-empty inline array of workflow names");
+    throw new Error("settings.ci.workflows must be an inline array of workflow names");
+  // An empty list opts the repository out of CI witnessing; the section must still be explicit.
+  if (raw.slice(1, -1).trim() === "") return { workflows: [] };
   const workflows = raw
     .slice(1, -1)
     .split(",")
     .map((workflow) => workflow.trim());
   if (
-    workflows.length === 0 ||
     workflows.some((workflow) => !new RegExp(settingValuePattern, "u").test(workflow) || /\.ya?ml$/u.test(workflow)) ||
     new Set(workflows).size !== workflows.length
   )

--- a/packages/kernel/test/contracts/settings-action.test.ts
+++ b/packages/kernel/test/contracts/settings-action.test.ts
@@ -85,8 +85,17 @@ test("Settings update writes the repository CI workflow names through the canoni
   assertSettingsEventInputs(draft.result.bundle.event, draft.result.bundle.plan, draft.result.bundle.blobs);
 });
 
+test("Settings update clears CI witnessing through an empty workflow list", () => {
+  const draft = compile({ ciWorkflows: [] });
+  assert.equal(draft.kind, "settings");
+  if (draft.kind !== "settings" || draft.result.kind !== "event") throw new Error("missing settings event");
+  assert.deepEqual(draft.result.bundle.event.payload.settings.ci.workflows, []);
+  assert.deepEqual(readSettingsFacet(draft.result.bundle.blobs[0].body).ci.workflows, []);
+  assertSettingsEventInputs(draft.result.bundle.event, draft.result.bundle.plan, draft.result.bundle.blobs);
+});
+
 test("Settings update rejects malformed CI workflow name lists", () => {
-  for (const ciWorkflows of [[], ["ci", "ci"], ["ci.yml"], ["ci.yaml"], [""]]) {
+  for (const ciWorkflows of [["ci", "ci"], ["ci.yml"], ["ci.yaml"], [""]]) {
     assert.throws(
       () => compile({ ciWorkflows }),
       (error: unknown) => error instanceof SettingsActionError && error.code === "invalid_command",

--- a/packages/kernel/test/layout/harness-settings.test.ts
+++ b/packages/kernel/test/layout/harness-settings.test.ts
@@ -42,8 +42,12 @@ test("CI workflows default to rewrite-ci and accept configured workflow basename
   assert.deepEqual(readSettingsFacet(`${body}\n  ci:\n    workflows: [ci]\n`).ci.workflows, ["ci"]);
 });
 
-test("CI workflows fail closed on empty, duplicate, extension-bearing, or block arrays", () => {
-  for (const workflows of ["[]", "[ci, ci]", "[ci.yml]", "", "\n      - ci"]) {
+test("CI workflows read an explicit empty list as the CI-witnessing opt-out", () => {
+  assert.deepEqual(readSettingsFacet(`${body}\n  ci:\n    workflows: []\n`).ci.workflows, []);
+});
+
+test("CI workflows fail closed on duplicate, extension-bearing, or block arrays", () => {
+  for (const workflows of ["[ci, ci]", "[ci.yml]", "", "\n      - ci"]) {
     const configured = `${body}\n  ci:\n    workflows: ${workflows}\n`;
     assert.throws(() => readSettingsFacet(configured), /settings\.ci\.workflows/u);
   }
@@ -55,6 +59,9 @@ test("the repository facet writer inserts, replaces, and leaves default CI workf
   const inserted = writeRepositorySettingsFacet(body, { ...readSettingsFacet(body), ci: { workflows: ["ci"] } });
   assert.match(inserted, /^  ci:\n    workflows: \[ci\]$/mu);
   assert.deepEqual(readSettingsFacet(inserted).ci.workflows, ["ci"]);
+  const cleared = writeRepositorySettingsFacet(inserted, { ...readSettingsFacet(inserted), ci: { workflows: [] } });
+  assert.match(cleared, /^  ci:\n    workflows: \[\]$/mu);
+  assert.deepEqual(readSettingsFacet(cleared).ci.workflows, []);
   const replaced = writeRepositorySettingsFacet(`${body}\n  ci:\n    workflows: [legacy]\n`, readSettingsFacet(body));
   assert.doesNotMatch(replaced, /legacy/u);
   assert.deepEqual(readSettingsFacet(replaced).ci.workflows, ["rewrite-ci"]);

--- a/packages/preset/src/preset-process-service.ts
+++ b/packages/preset/src/preset-process-service.ts
@@ -158,7 +158,7 @@ export function createPresetProcessService(options: PresetProcessServiceOptions)
           "Run input must contain presetId, entrypoint, optional taskId, object inputs, and idempotencyKey.",
         );
       const defaults = presetRuntimeDefaults(options.readSettings()),
-        resolved = createRuntime({ userRoot: options.userRoot }).resolveInternal({
+        resolved = createRuntime({ userRoot: options.userRoot, ciWorkflows: defaults.ciWorkflows }).resolveInternal({
           presetId: input.presetId,
           entrypoint: input.entrypoint,
           verticalId: defaults.verticalId,

--- a/packages/preset/src/preset-resolver-types.ts
+++ b/packages/preset/src/preset-resolver-types.ts
@@ -28,6 +28,8 @@ export interface PresetResolverOptions {
   readonly kernelVersion?: string;
   readonly projectScaffold?: string;
   readonly projectRoot?: string;
+  /** Repository settings.ci.workflows; an empty list drops the `ci` completion gate from the resolved profile. */
+  readonly ciWorkflows?: readonly string[];
 }
 
 export interface Candidate {

--- a/packages/preset/src/preset-runtime.ts
+++ b/packages/preset/src/preset-runtime.ts
@@ -200,7 +200,12 @@ export function createRuntime(options: PresetResolverOptions): {
         profile: {
           id: profile.id,
           outputShape: leafManifest.outputShape,
-          completionGateIds: profile.completionGates,
+          // A repository that configures no CI witness workflows cannot satisfy the ci gate;
+          // resolution drops it so the effective gate set (and digest) stays honest.
+          completionGateIds:
+            options.ciWorkflows !== undefined && options.ciWorkflows.length === 0
+              ? profile.completionGates.filter((gateId) => gateId !== "ci")
+              : profile.completionGates,
         },
         guidance: {
           description: leaf.document.description,

--- a/packages/preset/src/preset-system.ts
+++ b/packages/preset/src/preset-system.ts
@@ -44,6 +44,7 @@ interface Defaults {
   readonly locale: string;
   readonly taskOverlay: string;
   readonly repositoryOverlay: string;
+  readonly ciWorkflows: readonly string[];
 }
 export async function runPresetAction(input: {
   readonly rootDir: string;
@@ -218,6 +219,7 @@ export function presetRuntimeDefaults(settings: SettingsV1): Defaults {
     locale: settings.locale,
     taskOverlay: settings.scaffolds.task,
     repositoryOverlay: settings.scaffolds.repository,
+    ciWorkflows: settings.ci.workflows,
   };
 }
 function presetResolverOptions(rootDir: string, defaults: Defaults) {
@@ -229,6 +231,7 @@ function presetResolverOptions(rootDir: string, defaults: Defaults) {
   return {
     userRoot: presetUserRoot(rootDir),
     projectRoot,
+    ciWorkflows: defaults.ciWorkflows,
     ...(existsSync(projectScaffold) ? { projectScaffold } : {}),
   };
 }

--- a/packages/preset/test/preset-resolver-discovery-shadowing.test.ts
+++ b/packages/preset/test/preset-resolver-discovery-shadowing.test.ts
@@ -301,3 +301,23 @@ test("profile precedence is explicit action, then projected settings", () => {
     rmSync(rootDir, { recursive: true, force: true });
   }
 });
+
+test("a repository without CI witness workflows resolves the standard task without the ci gate", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-preset-ci-gate-"));
+  try {
+    const compile = (settings: Parameters<typeof compileRepoTaskPackage>[0]["settings"]) =>
+      compileRepoTaskPackage({
+        rootDir,
+        settings,
+        taskId: "task-ci-gate",
+        action: { kind: "task-create", title: "Witness", presetId: "standard-task" },
+      }).snapshot;
+    const witnessed = compile(INITIAL_SETTINGS_V1);
+    assert.deepEqual(witnessed.profile.completionGateIds, ["ci", "code-doc-reconciliation"]);
+    const witnessless = compile({ ...INITIAL_SETTINGS_V1, ci: { workflows: [] } });
+    assert.deepEqual(witnessless.profile.completionGateIds, ["code-doc-reconciliation"]);
+    assert.notEqual(witnessless.digest, witnessed.digest);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
# English

## Summary

The `ci` completion gate used to be mandatory for every repository: a green run of the configured workflow on `main` plus an uploaded `ci-observation-*` artifact, judged only by run conclusion (artifact content was never read). A peer Python repository could configure a workflow name but still fail with `ci_missing` forever because its `ci.yml` produces no artifacts — the artifact requirement was pure friction with no evidentiary value. Per dec_81224BE1C03CCB37A1BB6D9A1D (泽宇 2026-09-12 口头裁决, in_effect): a repository with an empty `settings.ci.workflows` carries no `ci` gate at all; a repository with a configured workflow still needs a green `main` run witnessed via `ha ci observe pull`, but a run that uploads no `ci-observation-*` artifacts now synthesizes one empty-tests/gates observation from the run summary (workflow, headSha, branch, conclusion, attempt) instead of being silently skipped. `settings.ci.workflows: []` is now a legal, explicit opt-out (schema `minItems: 1` removed on both the JSON-Schema side and the YAML-facet reader/writer, and the settings-update action contract's `ciWorkflows` validation now accepts an empty array). The preset resolver (`preset-runtime.ts`) drops the `ci` gate id from the resolved profile's `completionGateIds` when `ciWorkflows` is empty, so the gate set — and its digest — change at resolution time rather than at gate-evaluation time.

## Architectural Justification

Smallest correct change per dec_81224BE1C03CCB37A1BB6D9A1D: no new gate-evaluation branch was added to `completion-readiness.ts`/`closeout-readiness.ts` (the task-plan's originally named surface) — the gate set is already fixed once, at preset-resolution time, so filtering `"ci"` out of `completionGateIds` in `preset-runtime.ts` when `ciWorkflows` is empty is sufficient, and the existing digest-mismatch/`preset upgrade` path already propagates the change to in-flight tasks. This did require touching `packages/kernel/src/domain/settings.ts` and `settings-action-contract.ts` — the settings read/write path was rejecting an empty `ci.workflows` array outright, so making the opt-out settable at all meant relaxing that validation; these two files were not named in the task's Execution Surface list.

## What Changed

- `packages/daemon/src/ci-observation-actions.ts`: `fetchCiObservations` no longer returns `{ fetched: null }` when the artifact-pattern download fails; it falls through to a synthesized single-artifact observation (`tests: []`, `gates: []`) built from the run summary. Receipt text changed from "artifact(s)" to "observation(s)".
- `packages/kernel/src/domain/settings.ts` and `packages/kernel/src/domain/settings-action-contract.ts`: removed the `minItems: 1` / non-empty-array constraints on `ci.workflows` in the JSON-Schema, the YAML-facet reader, and the `settings-update` action's `ciWorkflows` validation, so `[]` round-trips as an explicit value instead of being rejected.
- `packages/preset/src/{preset-resolver-types,preset-runtime,preset-process-service,preset-system}.ts`: threaded `settings.ci.workflows` through to `createRuntime`/`resolveInternal`; when the list is empty, `"ci"` is filtered out of `profile.completionGates` before it becomes `completionGateIds`.
- `docs-release/architecture/{en,zh}/04-gates-in-the-pipeline.md`: rewrote the CI-gate-axis table row to describe the new conditional-gate, artifact-optional semantics (this is the only public doc describing the mechanism; root README only carries a badge).
- Tests: new `packages/daemon/test/ci-observation-synthesis.test.ts` (artifact-less green run → synthesized observation → `readLatestCiEvidence` pass); `repo-cell-settings.integration.test.ts` gained a clear-to-`[]` round-trip case; `settings-action.test.ts` and `harness-settings.test.ts` updated so an empty list is accepted (removed from the reject-list, added an explicit accept case); `preset-resolver-discovery-shadowing.test.ts` gained a case asserting the `ci` gate is present with default settings and absent (with a different digest) when `ci.workflows` is `[]`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +48/-11 production; tests +180/-3.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_701d4027550e416fb255220532 (parent none)
- Branch: `codex/ci-witness-optional`
- Public scope: CI completion-gate opt-out for repositories with no configured workflow, plus artifact-optional synthesis for repositories that do configure one
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: By design, left untouched: `completion-readiness.ts` / `closeout-readiness.ts` — the gate set is fixed at preset-resolution time (`preset-runtime.ts`) rather than at gate-evaluation time, so readiness naturally follows the resolved `completionGateIds`, and the existing `preset_snapshot_mismatch` → `ha preset upgrade` mechanism already handles settings drift by rewriting `completionGateIds` on upgrade. `repo-cell-task-progress.ts` (`readLatestCiEvidence`) was also left alone — its call sites already guard on `gates.includes("ci")`, so no gate-membership branch had to move there.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/ci-witness-optional`
- Private evidence commit/path: task_701d4027550e416fb255220532 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- 12 touched-surface test files run individually through `dispatch-isolated-test.mjs` against the Ubuntu isolated target, each exit 0, covering three red-to-green axes: artifact-less green run synthesizes and passes (`ci-observation-synthesis.test.ts`), empty `ci.workflows` resolves without the `ci` gate and with a changed digest, and this repo's existing artifact-bearing path (11 tests) does not regress. `npm run test:fast`: 735/729/6, the 6 failures identical by name to a pristine-tree baseline (pre-existing debt, not introduced here). `tsc`, eslint, line-density, `run-manifest-gates.mjs`, file-complexity, canonical-event-compat, and `production-delta.mjs` all green (file-complexity was red once when the first draft of the synthesis test file reached 779 lines and tripped the 715-line ratchet; splitting it into its own file fixed this without touching the gate). GitHub CI for this branch has not run: the commit is local-only, not pushed, no PR opened.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Per the report's stated residuals: the CLI's repeated-flag convention cannot express "clear to empty" for `ciWorkflows` (RPC and GUI backends can send `[]`, so the capability exists end-to-end, but there is no supported CLI syntax for it — an operator without direct RPC access has no way to opt a repository out of the `ci` gate). The GUI has no settings editor for `ci.workflows` at all, so this is currently a headless/RPC-only capability. Existing tasks created before a repository clears its workflows keep their previously-resolved `completionGateIds` (including `ci`) until `ha preset upgrade` is run against them — clearing settings does not retroactively update in-flight task packages. None of this was verified against a real GitHub remote (the new synthesis path was only exercised against a local git fixture with a stubbed `gh` CLI) or through the GUI/Windows lanes.

## References

- Task: task_701d4027550e416fb255220532

---

# 中文

## 概要

此前 `ci` 完成门对所有仓库强制：main 上配置 workflow 的绿 run，且必须上传 `ci-observation-*` 工件，而判定其实只看 run conclusion（工件内容从不参与判定）。对等 Python 仓即便配好 workflow 名，因其 `ci.yml` 不产工件也会永远卡在 `ci_missing`——工件要求是没有证据价值的纯摩擦。按 dec_81224BE1C03CCB37A1BB6D9A1D（泽宇 2026-09-12 口头裁决，state=in_effect）：`settings.ci.workflows` 为空的仓库完全不挂 `ci` 门；配置了 workflow 的仓库仍需经 `ha ci observe pull` 见证 main 上的绿 run，但当该 run 未上传 `ci-observation-*` 工件时，现在会用 run 摘要（workflow、headSha、branch、conclusion、attempt）合成一条空 tests/gates 的观测，而不是被静默跳过。`settings.ci.workflows: []` 现在是合法的显式退出选项（JSON-Schema 与 YAML facet 读写两侧的 `minItems: 1` 都已删除，`settings-update` 动作契约的 `ciWorkflows` 校验也接受空数组）。preset 解析层（`preset-runtime.ts`）在 `ciWorkflows` 为空时把 `"ci"` 从解析出的 profile 的 `completionGateIds` 中过滤掉，门集合与其 digest 因此在解析时就改变，而不是在门判定时改变。

## 架构辩护

按 dec_81224BE1C03CCB37A1BB6D9A1D 的最小正确改法:没有在 `completion-readiness.ts`/`closeout-readiness.ts`(task_plan 原本点名的面)里新增门判定分支——门集合本就在 preset 解析时一次性固化,所以只需在 `preset-runtime.ts` 里当 `ciWorkflows` 为空时把 `"ci"` 从 `completionGateIds` 过滤掉即可,既有的 digest 不匹配/`preset upgrade` 通路已经会把变化传导到在飞任务。但这确实牵动了 `packages/kernel/src/domain/settings.ts` 与 `settings-action-contract.ts`——settings 读写路径此前直接拒绝空 `ci.workflows` 数组,要让这个退出选项可写入就必须放松该校验;这两个文件并未出现在任务的 Execution Surface 点名列表里。

## 改动内容

- `packages/daemon/src/ci-observation-actions.ts`:`fetchCiObservations` 在工件模式下载失败时不再返回 `{ fetched: null }`,改为落入从 run 摘要合成的单条观测(`tests: []`、`gates: []`)。回执文案由「artifact(s)」改为「observation(s)」。
- `packages/kernel/src/domain/settings.ts` 与 `settings-action-contract.ts`:删除 `ci.workflows` 在 JSON-Schema、YAML facet 读取器与 `settings-update` 动作 `ciWorkflows` 校验上的 `minItems: 1` / 非空约束,`[]` 现在能原样往返而不被拒绝。
- `packages/preset/src/{preset-resolver-types,preset-runtime,preset-process-service,preset-system}.ts`:把 `settings.ci.workflows` 一路传进 `createRuntime`/`resolveInternal`;列表为空时在写入 `completionGateIds` 之前从 `profile.completionGates` 里过滤掉 `"ci"`。
- `docs-release/architecture/{en,zh}/04-gates-in-the-pipeline.md`:重写 CI 门轴表行以描述新的「按仓库可选、工件可选」语义(这是唯一描述该机制的公开文档,根 README 只有 badge)。
- 测试:新增 `packages/daemon/test/ci-observation-synthesis.test.ts`(无工件绿 run → 合成观测 → `readLatestCiEvidence` pass);`repo-cell-settings.integration.test.ts` 新增清空为 `[]` 的往返用例;`settings-action.test.ts` 与 `harness-settings.test.ts` 把空数组从拒绝列表移出、加入显式接受用例;`preset-resolver-discovery-shadowing.test.ts` 新增用例断言默认 settings 下有 `ci` 门、`ci.workflows` 为 `[]` 时无该门且 digest 不同。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+48/-11 production; tests +180/-3。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_701d4027550e416fb255220532（父 none）
- 分支：`codex/ci-witness-optional`
- 公开范围：无配置 workflow 的仓库跳过 ci 完成门,且有配置的仓库允许工件缺失时合成见证
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：按设计未动:`completion-readiness.ts` / `closeout-readiness.ts`——门集合在 preset 解析时(`preset-runtime.ts`)就已固化,而非在门判定时才决定,readiness 天然跟随解析出的 `completionGateIds`,既有的 `preset_snapshot_mismatch` → `ha preset upgrade` 机制已经通过升级时重写 `completionGateIds` 承接 settings 漂移。`repo-cell-task-progress.ts`(`readLatestCiEvidence`)同样未动——其调用点已有 `gates.includes("ci")` 守卫,门归属分支无需搬到这里。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/ci-witness-optional`
- 私有证据路径：task_701d4027550e416fb255220532 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 12 个触碰面测试文件经 `dispatch-isolated-test.mjs`(ubuntu 目标机)逐个跑,均 exit=0,覆盖三条红绿轴:无工件绿 run 合成并判 pass(`ci-observation-synthesis.test.ts`);`ci.workflows` 为空时解析出无 `ci` 门且 digest 改变;本仓既有工件路径(11 测试)不回归。`npm run test:fast`:735/729/6,6 个失败与 pristine 树基线逐名一致(存量债,非本次引入)。`tsc`、eslint、line-density、`run-manifest-gates.mjs`、file-complexity、canonical-event-compat、`production-delta.mjs` 全绿(file-complexity 曾红一次:合成测试初版单文件到 779 行触发 715 行棘轮,拆成独立文件后绿,门本身未动)。本分支 GitHub CI 未跑:commit 只在本地,未 push、未开 PR。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 按 report 点名的残留:CLI 的重复 flag 语法无法表达把 `ciWorkflows` 清空(RPC 与 GUI 后端能传 `[]`,能力链路是通的,但没有对应的 CLI 写法——没有直接 RPC 访问权限的操作者无法让仓库退出 `ci` 门)。GUI 完全没有 `ci.workflows` 的编辑入口,目前是纯 headless/RPC 能力。清空 settings 之前创建的存量任务仍保留旧的 `completionGateIds`(含 `ci`)直到对它们跑 `ha preset upgrade`——清空 settings 不会回溯更新在飞任务包。以上均未在真实 GitHub 远端(合成路径只跑过本地 git fixture + 打桩 `gh` CLI)或 GUI/Windows lane 上验证过。

## 参考

- 任务：task_701d4027550e416fb255220532

