### PR TITLE
fix: stop task complete from inlining the code-doc reconcile action

### DIFF
--- a/packages/daemon/src/repo-cell-command.ts
+++ b/packages/daemon/src/repo-cell-command.ts
@@ -220,7 +220,12 @@ export function buildCommand(
   }
   if (action.kind === "task-code-doc-reconcile") {
     if (!canonicalCodeDocPaths(action.paths, true))
-      throw cellCodedError("invalid_command", "Pass explicit canonical completion.codeDocPaths to code-doc reconcile.");
+      throw cellCodedError(
+        "invalid_command",
+        "Pass explicit canonical file paths as completion.codeDocPaths to code-doc reconcile; " +
+          "each --path must name one file relative to the Git repository root, and directories " +
+          "are not accepted.",
+      );
     const witness = submittedExecutionWitness(action, snapshot, taskId, ["kind", "taskId", "paths"], action.paths);
     if (witness.commitSha === null)
       throw cellCodedError("invalid_proof", "Code/doc reconciliation requires a code delivery.");

--- a/packages/daemon/src/repo-cell-task-progress.ts
+++ b/packages/daemon/src/repo-cell-task-progress.ts
@@ -504,28 +504,8 @@ export async function completeTask(
       steps.push(step);
       continue;
     }
-    if (blocker.code === "code_doc_missing" && submittedExecution?.submission) {
-      const submitted = current.snapshot.executions.find(
-        (candidate) =>
-          candidate.executionId === executionId && candidate.iteration === current.snapshot.task?.iteration,
-      );
-      if (!submitted?.submission)
-        throw cell.cellCodedError(
-          "invalid_transition",
-          "Complete requires a submitted execution before code-doc reconciliation.",
-        );
-      const step = await cell.lifecycleAction(
-        {
-          kind: "task-code-doc-reconcile",
-          taskId,
-          paths,
-        },
-        binding,
-      );
-      steps.push(step);
-      if (step.outcome === "applied") continue;
-      return cell.completionSettlement(step, current.snapshot, executionId, steps, "code-doc-settlement");
-    }
+    // A missing code/doc witness stops completion with the reconcile command; complete never
+    // writes another Action's witness under its own declaration.
     if (blocker.code === "doc_sync_required") {
       let step: WriteReceipt;
       try {

--- a/packages/daemon/test/repo-cell-command-code-doc.test.ts
+++ b/packages/daemon/test/repo-cell-command-code-doc.test.ts
@@ -119,8 +119,9 @@ test("reconcile requires an explicit canonical path list while preserving an exp
         "/repo",
         submitted,
       );
-  assert.throws(() => reconcile(), /explicit canonical completion\.codeDocPaths/u);
-  assert.throws(() => reconcile(["../escape"]), /explicit canonical completion\.codeDocPaths/u);
+  assert.throws(() => reconcile(), /completion\.codeDocPaths/u);
+  assert.throws(() => reconcile(["../escape"]), /directories are not accepted/u);
+  assert.throws(() => reconcile(["docs/"]), /directories are not accepted/u);
   const empty = reconcile([]);
   assert.equal(empty.type, "ReconcileCodeDoc");
   if (empty.type === "ReconcileCodeDoc") assert.deepEqual(empty.paths, []);

--- a/packages/daemon/test/repo-cell-task-progress-evidence.test.ts
+++ b/packages/daemon/test/repo-cell-task-progress-evidence.test.ts
@@ -1,15 +1,24 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test, { after } from "node:test";
-import type { CiRunObservationEventV3, CompletionEvidenceV1 } from "../../kernel/src/index.ts";
+import {
+  getExecutableEntityAction,
+  readSettingsFacet,
+  reviewDigest,
+  submissionDigest,
+  type CiRunObservationEventV3,
+  type CompletionEvidenceV1,
+} from "../../kernel/src/index.ts";
+import { compileRepoTaskPackage } from "../../preset/src/index.ts";
 import type { RepoCellOperationalContext } from "../src/repo-cell-action-context.ts";
 import type { RepoCellBinding, Snapshot } from "../src/repo-cell-types.ts";
 import { completeTask, prepareSubmissionEvidence, readLatestCiEvidence } from "../src/repo-cell-task-progress.ts";
-import { projectionReady } from "../src/repo-cell-settlement.ts";
+import { completionSettlement, completionStopped, projectionReady } from "../src/repo-cell-settlement.ts";
+import { deriveActionResult } from "../src/entity-action-catalog-executor.ts";
 
 const actor = { principal: { personId: "owner" }, executor: null } as const;
 const binding = { actor, source: "local" } as RepoCellBinding;
@@ -355,6 +364,167 @@ test("pending projection cannot select stale green and failed reconciliation sto
   assert.equal(steps.length, 1);
   assert.equal(steps[0]?.code, "publication_indeterminate");
   assert.deepEqual(rejected.calls, []);
+});
+
+test("complete without a code-doc witness stops on code_doc_missing under its own criterion", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "ha-complete-reconcile-"));
+  try {
+    init(root);
+    mkdirSync(path.join(root, "packages/daemon/src"), { recursive: true });
+    writeFileSync(path.join(root, "packages/daemon/src/live.ts"), "export {};\n");
+    git(root, "add", ".");
+    git(root, "commit", "-qm", "deliverable");
+    const sha = git(root, "rev-parse", "HEAD"),
+      deliverables = ["packages/daemon/src/live.ts"],
+      submitted = execution(sha, deliverables),
+      pinned = submissionDigest(submitted.submission!),
+      review = {
+        schema: "review/v1",
+        reviewId: "review-complete",
+        taskId: "task",
+        executionId: "execution",
+        verdict: "approved",
+        actor,
+        capabilityRef: "default@5",
+        reason: "Approved.",
+        evidenceChecked: ["tests"],
+        commitSha: sha,
+        iteration: 0,
+        contentDigest: `sha256:${"1".repeat(64)}`,
+        submissionDigest: pinned,
+        reviewedAt: "2026-09-12T00:02:00.000Z",
+      } as Snapshot["reviews"][number],
+      settings = readSettingsFacet(""),
+      packagePath = "tasks/task-complete-reconcile",
+      presetSnapshotDigest = compileRepoTaskPackage({
+        rootDir: root,
+        settings,
+        taskId: "task",
+        action: { kind: "task-create", title: "Complete Reconcile Criterion" },
+      }).snapshot.digest,
+      snapshot = {
+        revision: 1,
+        task: {
+          taskId: "task",
+          status: "in_review",
+          currentNode: "review",
+          iteration: 0,
+          completionGateIds: ["code-doc-reconciliation"],
+          createdBy: actor,
+          taskClass: "standard",
+          presetSnapshotDigest,
+        },
+        executions: [submitted],
+        reviews: [review],
+        consents: [
+          {
+            schema: "review-consent/v1",
+            consentId: "consent-complete",
+            taskId: "task",
+            executionId: "execution",
+            reviewId: "review-complete",
+            reviewDigest: reviewDigest(review),
+            contentDigest: review.contentDigest,
+            submissionDigest: pinned,
+            actor,
+            source: "local",
+            consentedAt: "2026-09-12T00:03:00.000Z",
+          },
+        ],
+        codeDocWitnesses: [],
+        gateWitnesses: [],
+        lease: null,
+        decisionRelations: [],
+      } as unknown as Snapshot,
+      read = { snapshot, packagePath, status: "ready", watermark: 2, sourceRevision: 2 },
+      calls: unknown[] = [],
+      readiness = {
+        closeout: "ready",
+        closeoutPath: `${packagePath}/closeout.md`,
+        eligibleDirtyPaths: [],
+        producesFactCount: 1,
+        projectionStatus: "ready",
+      },
+      cell = {
+        rootDir: root,
+        projectionReady,
+        input: { repoId: "repo" },
+        settings: { read: () => settings },
+        requiredCellText: (value: string) => value,
+        operationId: () => "facade-op",
+        completeRetryCommand: () => "ha task complete task",
+        completionContext: () => readiness,
+        completionStopped,
+        completionSettlement,
+        service: { read: async () => read },
+        projection: {
+          read: () => read,
+          readTaskCompletion: () => null,
+          readRelationQuery: (query: { readonly relationType?: string }) =>
+            query.relationType === "produces"
+              ? { rows: [{ targetRef: "fact/one", state: "active" }], status: "ready" }
+              : { rows: [], status: "ready" },
+          readDecisions: () => ({ decisions: [], status: "ready" }),
+          readDocument: (target: string) => ({
+            watermark: 2,
+            sourceRevision: 2,
+            document: {
+              path: target,
+              blobSha256: "0".repeat(64),
+              body: target.endsWith("task-contract.json")
+                ? JSON.stringify({
+                    title: "Complete Reconcile Criterion",
+                    documents: [{ slot: "task.closeout", path: "closeout.md" }],
+                  })
+                : "## Summary\nDone.\n## Verification\nVerified.\n## Residual Risk\nNone.\n" +
+                  "## Same Mechanism Elsewhere\nChecked.\n",
+            },
+          }),
+        },
+        cellCodedError: (code: string, message: string) => Object.assign(new Error(message), { code }),
+        lifecycleAction: async (action: unknown) => {
+          calls.push(action);
+          return {
+            outcome: "op_rejected",
+            opId: "reconcile-op",
+            code: "invalid_command",
+            unmetCriteria: [
+              {
+                ref: "task-lifecycle-review-transitions/reconcile.validate",
+                failureCode: "invalid_proof",
+                explain: "The witness binds canonical document paths to the submitted commit.",
+              },
+            ],
+          };
+        },
+      } as unknown as RepoCellOperationalContext,
+      action = { kind: "task-complete", taskId: "task", executionId: "execution" };
+    const receipt = (await completeTask(cell, action, {
+      ...binding,
+      authorizationDecision: { outcome: "allowed" },
+    } as RepoCellBinding)) as unknown as Record<string, unknown>;
+    // The facade receipt settles under the complete Action's own criteria; a leaked
+    // reconcile criterion used to abort settlement with invalid_store.
+    const settled = deriveActionResult(
+      getExecutableEntityAction("task-complete")!,
+      action as Parameters<typeof deriveActionResult>[1],
+      receipt as Parameters<typeof deriveActionResult>[2],
+    );
+    assert.deepEqual(calls, []);
+    assert.equal(receipt.outcome, "op_rejected");
+    assert.equal(receipt.code, "code_doc_missing");
+    assert.match(String(receipt.rejectionExplanation), /no canonical code\/doc witness/u);
+    assert.match(
+      String((receipt.next as { readonly action: string }[])[0]?.action),
+      /ha task code-doc reconcile task --path 'packages\/daemon\/src\/live\.ts'/u,
+    );
+    assert.deepEqual(
+      settled.unmetCriteria?.map(({ ref }) => ref),
+      ["closeout-readiness/closeoutReadiness"],
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("completed receipt replay does not inspect a newer red or unavailable CI observation", async () => {


### PR DESCRIPTION
# English

## Summary

After all gates on a submitted execution had passed, `ha task complete` still failed with `invalid_store: Action task.complete does not declare criterion task-lifecycle-review-transitions/reconcile.validate` (hit on a peer repo across 3 tasks). Root cause: when the code-doc-reconciliation gate was outstanding, `completeTask` inlined a direct call to the `task-code-doc-reconcile` lifecycle action and pushed its receipt into `task.complete`'s own settlement, so the rejected step's `reconcile.validate` criterion reached a contract (`complete.validate`/`closeoutReadiness`) that never declared it. The fix deletes that inline block entirely: a missing code-doc witness now falls through to the existing `completionStopped` path, which already returns `code_doc_missing` with the runnable `ha task code-doc reconcile <task> --path ...` command — `task.complete` never executes another action's write under its own declaration again.

## Architectural Justification

Smallest correct change: no new error channel, no new declared criterion, no compatibility shim. The single deleted block was the only place `task.complete` executed another action's write under its own contract; removing it lets the pre-existing `completion-readiness` stop (which already carries the actionable `ha task code-doc reconcile` command) do the job it was designed for.

## What Changed

- `packages/daemon/src/repo-cell-task-progress.ts`: deleted the `code_doc_missing` branch that called `cell.lifecycleAction({kind: "task-code-doc-reconcile", ...})` inline inside `completeTask` (was lines ~507-528); replaced with a one-line comment noting complete must stop and hand back the reconcile command instead of writing that action's witness itself. Control now falls through to the pre-existing `completionStopped(facadeOpId, ...)` return, unchanged.
- `packages/daemon/src/repo-cell-command.ts`: expanded the `invalid_command` message on `task-code-doc-reconcile` when `canonicalCodeDocPaths` rejects the paths, spelling out that `--path` must be an explicit file path relative to the Git root and that directories are not accepted.
- Tests: `repo-cell-command-code-doc.test.ts` updated for the new message text; `repo-cell-task-progress-evidence.test.ts` gained the red (verbatim `invalid_store`/`reconcile.validate` reproduction) to green (`code_doc_missing` stop, zero `lifecycleAction` calls, reconcile command in the receipt) cases, plus regression coverage that a submission with an existing witness still completes as `applied`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +8/-23 production; tests +176/-5.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_b22d6fb50a3fcb319e0a17909e (parent none)
- Branch: `codex/complete-reconcile-criterion`
- Public scope: task.complete's code-doc-reconciliation stop path and its criterion declaration
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: not touched: the two other criterion-leak sites the report also found (see Residual Risk) — fixing them was out of this task's scope

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/complete-reconcile-criterion`
- Private evidence commit/path: task_b22d6fb50a3fcb319e0a17909e `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Directed reproduction: pre-fix run reproduces the verbatim `invalid_store`/`reconcile.validate` error; post-fix 16/16 green on the touched test files. All 8 affected test files green individually through the Ubuntu isolated dispatcher (exit 0), including the json-rpc milestone-closeout facade integration test confirming a submission that already carries a code-doc witness still completes as `applied` (unchanged). `npm run lint`, `line-density --base origin/main`, `run-manifest-gates --changed origin/main`, test-selection, and production-delta gates all exit 0. GitHub CI for this branch: not pushed, pending.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Two sibling criterion-leak sites found by the same investigation are left unfixed as follow-ups: the submit facade's settlement path (`prepareSubmissionEvidence`) can push a rejected reconcile step's criterion the same way, and `completeTask`'s consent step has the identical inline-and-forward shape — both only surface when their sub-step is itself rejected, so they did not reproduce in this task's fixtures and were left out of scope rather than fixed speculatively.

## References

- Task: task_b22d6fb50a3fcb319e0a17909e

---

# 中文

## 概要

所有门都通过之后，`ha task complete` 仍以 `invalid_store: Action task.complete does not declare criterion task-lifecycle-review-transitions/reconcile.validate` 失败（在对等仓库的 3 个任务上复现）。根因：code-doc-reconciliation 门未过时，`completeTask` 内联直接调用 `task-code-doc-reconcile` 生命周期 Action，并把该被拒步骤的回执塞进 `task.complete` 自己的结算层，导致被拒步骤携带的 `reconcile.validate` criterion 进入一个从未声明它的契约（`complete.validate`/`closeoutReadiness`）。修复整段删除该内联块：缺 code-doc 见证时现在落到既有的 `completionStopped` 路径，该路径本就返回带可执行命令 `ha task code-doc reconcile <task> --path ...` 的 `code_doc_missing`——`task.complete` 不再在自己的声明之下代执行另一个 Action 的写入。

## 架构辩护

最小正确改法：不加新错误通道、不加新声明 criterion、不加兼容层。被删的这一整块是 `task.complete` 在自己契约下代执行另一个 Action 写入的唯一地方；删除后交给既有的 `completion-readiness` 停止路径（本就携带可执行的 `ha task code-doc reconcile` 命令）去做它本该做的事。

## 改动内容

- `packages/daemon/src/repo-cell-task-progress.ts`：删除 `completeTask` 内联调用 `cell.lifecycleAction({kind: "task-code-doc-reconcile", ...})` 的 `code_doc_missing` 分支（原约 507-528 行）；替换为一行注释，说明 complete 应停下并回传 reconcile 命令，而不是自己代写该 Action 的见证。控制流落到既有不变的 `completionStopped(facadeOpId, ...)` 返回。
- `packages/daemon/src/repo-cell-command.ts`：`canonicalCodeDocPaths` 拒绝路径时，`task-code-doc-reconcile` 的 `invalid_command` 文案扩写，明确 `--path` 必须是相对 Git 根目录的显式文件路径，不接受目录。
- 测试：`repo-cell-command-code-doc.test.ts` 更新为新文案断言；`repo-cell-task-progress-evidence.test.ts` 新增修前（逐字复现 `invalid_store`/`reconcile.validate`）到修后（`code_doc_missing` 停止、零 `lifecycleAction` 调用、回执含 reconcile 命令）的红绿用例，并补充已有见证的提交仍按 `applied` 完成的回归覆盖。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+8/-23 production; tests +176/-5。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_b22d6fb50a3fcb319e0a17909e（父 none）
- 分支：`codex/complete-reconcile-criterion`
- 公开范围：task.complete 的 code-doc-reconciliation 停止路径及其 criterion 声明
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：未处理：同一次调查发现的另外两处 criterion 泄漏点（见残余风险）——修复它们不在本任务范围内

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/complete-reconcile-criterion`
- 私有证据路径：task_b22d6fb50a3fcb319e0a17909e 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 定向复现：修前逐字复现 `invalid_store`/`reconcile.validate` 报错；修后触碰面测试 16/16 绿。受影响的 8 个测试文件经 Ubuntu 隔离入口逐个跑全绿（exit 0），含 json-rpc 的 milestone-closeout facade 集成测试，确认已带 code-doc 见证的提交仍按 `applied` 完成（行为不变）。`npm run lint`、`line-density --base origin/main`、`run-manifest-gates --changed origin/main`、test-selection、production-delta 全部 exit 0。本分支 GitHub CI：未 push，待跑。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 同一次调查发现的两处同族 criterion 泄漏点留作后续：submit facade 结算路径（`prepareSubmissionEvidence`）可能以同样方式把被拒 reconcile 步骤的 criterion 带出去；`completeTask` 的 consent 步骤是同样的内联转发结构——两者都只在其子步骤本身被拒时才会触发，本任务的 fixture 未复现，因此未做推测性修复，留在范围外。

## 参考

- 任务：task_b22d6fb50a3fcb319e0a17909e

