### PR TITLE
fix: recover expired-lease rounds and close the round on ReturnToPlanned

### DIFF
--- a/packages/application/test/task-action-explanation-service.test.ts
+++ b/packages/application/test/task-action-explanation-service.test.ts
@@ -88,7 +88,11 @@ test("Task explanations distinguish lifecycle state, actor capability, invocatio
       lease: active.lease ? { ...active.lease, phase: "orphaned" } : null,
     };
     assert.equal(row(explain(harness, lapsed, owner), "submit").available, false);
-    assert.equal(row(explain(harness, lapsed, owner), "start").available, false);
+    assert.equal(
+      row(explain(harness, lapsed, owner), "start").available,
+      true,
+      "an expired (orphaned) lease is recovered by rejoining the round's active execution",
+    );
 
     await harness.submit("execution-1");
     const submitted = await snapshot(harness),

--- a/packages/application/test/task-action-explanation-service.test.ts
+++ b/packages/application/test/task-action-explanation-service.test.ts
@@ -93,6 +93,20 @@ test("Task explanations distinguish lifecycle state, actor capability, invocatio
       true,
       "an expired (orphaned) lease is recovered by rejoining the round's active execution",
     );
+    assert.equal(
+      row(explain(harness, lapsed, owner), "archive").available,
+      true,
+      "an expired (orphaned) lease no longer blocks the disposition mutations",
+    );
+    const lapsedArchived: TaskLifecycleSnapshot = {
+      ...lapsed,
+      task: lapsed.task ? { ...lapsed.task, packageDisposition: "archived" } : null,
+    };
+    assert.equal(
+      row(explain(harness, lapsedArchived, owner), "reopen").available,
+      true,
+      "an archived task with an expired (orphaned) lease can be reopened",
+    );
 
     await harness.submit("execution-1");
     const submitted = await snapshot(harness),

--- a/packages/daemon/src/repo-cell-task-maintenance.ts
+++ b/packages/daemon/src/repo-cell-task-maintenance.ts
@@ -89,7 +89,8 @@ export function supersedeWithNewTask(
           : null;
     return { ...replay, replacementTaskId } as WriteReceipt;
   }
-  if (old.snapshot.lease)
+  // Same phase-aware guard as taskMutation: an orphaned lease's holder is gone and fences nothing.
+  if (old.snapshot.lease !== null && ["reserving", "held"].includes(old.snapshot.lease.phase))
     throw cell.cellCodedError("active_lease", `Run ha task release ${oldTaskId} before task-supersede.`);
   if ((old.snapshot.task.packageDisposition ?? "active") !== "active" || old.snapshot.task.supersededBy)
     throw cell.cellCodedError(

--- a/packages/daemon/src/repo-cell-task-mutation.ts
+++ b/packages/daemon/src/repo-cell-task-mutation.ts
@@ -104,7 +104,11 @@ export function taskMutation(
       },
     };
   }
-  if (activeLease && !pinOnlyAmend && action.kind !== "task-contract-migrate")
+  // An orphaned lease's holder is gone; it fences nothing (start already takes it over via the
+  // reservation CAS), so only a live reservation or hold keeps task-level mutations out. Release
+  // above still needs the orphaned record itself to settle it.
+  const liveLease = activeLease !== null && ["reserving", "held"].includes(activeLease.phase);
+  if (liveLease && !pinOnlyAmend && action.kind !== "task-contract-migrate")
     throw cell.cellCodedError("active_lease", `Run ha task release ${task.taskId} before ${action.kind}.`);
   if (action.kind === "task-amend") {
     const patches = amendPatches,

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -181,8 +181,9 @@ export async function runTaskActionCatalogRuntime(
                     `status=${current.snapshot.task?.status ?? "missing"} ` +
                     `node=${current.snapshot.task?.currentNode ?? "missing"}`,
                   expectation:
-                    `Current round already has an active execution; run ha task start ${taskId} ` +
-                    "without --execution-id to reuse it",
+                    `Current round already has active execution ${activeExecution.executionId}; ` +
+                    `run ha task start ${taskId} without --execution-id, or with ` +
+                    `--execution-id ${activeExecution.executionId}, to rejoin it`,
                 },
               ),
               contract,

--- a/packages/daemon/test/lease-dead-zone-recovery.integration.test.ts
+++ b/packages/daemon/test/lease-dead-zone-recovery.integration.test.ts
@@ -165,6 +165,52 @@ test("ReturnToPlanned frees the round so ha task start allocates a fresh executi
   }
 });
 
+test("an archived dead-zone task reopens and rejoins its execution through ha task start --execution-id", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-lease-dead-zone-archive-"));
+  let clock = new Date("2026-09-12T00:00:00.000Z");
+  let cell: Cell | undefined;
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({
+      repoId: workspaceId("lease-dead-zone-archive"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "lease-dead-zone-archive",
+      now: () => clock.toISOString(),
+    });
+    await createReadyTask(cell, rootDir, "task_archive_dz", "Archived dead-zone recovery");
+    const started = (await cell.run(
+      { kind: "task-start", taskId: "task_archive_dz", executionId: "exe_archive_dz", ttlMs: 60_000 },
+      holderBinding,
+    )) as WriteReceipt;
+    assert.equal(started.outcome, "applied", JSON.stringify(started));
+
+    // The holder is gone and past TTL the stored lease reads orphaned. Before the fix the
+    // active_lease guard rejected task-archive itself, so the T1-random-baseline recovery
+    // chain (archive, then reopen, then start --execution-id) died at step one for any
+    // actor who could not release the orphaned lease.
+    clock = new Date("2026-09-12T02:00:00.000Z");
+    const archived = (await cell.run(
+      { kind: "task-archive", taskId: "task_archive_dz", reason: "Holder gone; parking the dead round" },
+      peerBinding,
+    )) as WriteReceipt;
+    assert.equal(archived.outcome, "applied", JSON.stringify(archived));
+    const reopened = (await cell.run(
+      { kind: "task-reopen", taskId: "task_archive_dz", reason: "Recovering the parked execution" },
+      peerBinding,
+    )) as WriteReceipt;
+    assert.equal(reopened.outcome, "applied", JSON.stringify(reopened));
+    const rejoined = (await cell.run(
+      { kind: "task-start", taskId: "task_archive_dz", executionId: "exe_archive_dz" },
+      peerBinding,
+    )) as WriteReceipt;
+    assert.equal(rejoined.outcome, "applied", JSON.stringify(rejoined));
+    assert.equal(rejoined.executionId, "exe_archive_dz", "reopen leaves the round recoverable");
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 async function createReadyTask(cell: Cell, rootDir: string, taskId: string, title: string): Promise<void> {
   await createRealizedTaskPlanFixture(
     rootDir,

--- a/packages/daemon/test/lease-dead-zone-recovery.integration.test.ts
+++ b/packages/daemon/test/lease-dead-zone-recovery.integration.test.ts
@@ -1,0 +1,190 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import type { RepoCellBinding, WriteReceipt } from "../src/repo-cell-types.ts";
+import { openBootstrappedRepoCell as openRepoCell, waitForFixturePublication } from "./repo-settings.fixture.ts";
+import { createRealizedTaskPlanFixture } from "../../../tools/fixtures/task-plan.mjs";
+
+type Cell = Awaited<ReturnType<typeof openRepoCell>>;
+
+const holderBinding: RepoCellBinding = {
+  actor: { principal: { personId: "person-holder" }, executor: null },
+  source: "local",
+};
+const peerBinding: RepoCellBinding = {
+  actor: { principal: { personId: "person-peer" }, executor: null },
+  source: "local",
+};
+
+test("an expired current-round lease is recoverable by any repo-write actor through ha task start", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-lease-dead-zone-"));
+  let clock = new Date("2026-09-12T00:00:00.000Z");
+  let cell: Cell | undefined;
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({
+      repoId: workspaceId("lease-dead-zone"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "lease-dead-zone",
+      now: () => clock.toISOString(),
+    });
+    const created = await createRealizedTaskPlanFixture(
+      rootDir,
+      () =>
+        cell!.run(
+          { kind: "task-create", taskId: "task_dead_zone", title: "Lease dead zone recovery", presetId: "docs-task" },
+          holderBinding,
+        ),
+      (planPath) => cell!.run({ kind: "doc-submit", paths: [planPath] }, holderBinding),
+      "Lease dead zone recovery",
+    );
+    const packagePath = String(created.packagePath);
+    const started = (await cell.run(
+      { kind: "task-start", taskId: "task_dead_zone", executionId: "exe_dead_zone", ttlMs: 60_000 },
+      holderBinding,
+    )) as WriteReceipt;
+    assert.equal(started.outcome, "applied", JSON.stringify(started));
+
+    // The holder is gone and no settlement released the lease: past TTL the stored lease reads
+    // orphaned, and before the fix both `ha task start` forms rejected with invalid_transition
+    // while the round's execution stayed active (T1-random-baseline).
+    clock = new Date("2026-09-12T02:00:00.000Z");
+    const rejoined = (await cell.run({ kind: "task-start", taskId: "task_dead_zone" }, peerBinding)) as WriteReceipt;
+    assert.equal(rejoined.outcome, "applied", JSON.stringify(rejoined));
+    assert.equal(rejoined.executionId, "exe_dead_zone", "the plain form rejoins the round's active execution");
+
+    // The recovery must leave the write chain usable: the new holder can submit.
+    const artifacts = path.join(rootDir, "harness", packagePath, "artifacts");
+    mkdirSync(artifacts, { recursive: true });
+    writeFileSync(path.join(artifacts, "report.md"), "# Evidence\n\nTakeover receipt under test.\n");
+    const artifactReceipt = (await cell.run(
+      { kind: "doc-submit", taskId: "task_dead_zone" },
+      peerBinding,
+    )) as WriteReceipt;
+    assert.equal(artifactReceipt.outcome, "applied", JSON.stringify(artifactReceipt));
+    writeFileSync(
+      path.join(rootDir, "harness", packagePath, "closeout.md"),
+      "## Summary\nRecovered after lease expiry. " +
+        `artifact:${packagePath}/artifacts/report.md@${String(artifactReceipt.revision)}\n` +
+        "## Verification\n- Targeted test passed.\n" +
+        "## Residual Risk\n- None.\n" +
+        "## Same Mechanism Elsewhere\n- None.\n",
+    );
+    const submitted = (await cell.run(
+      { kind: "task-submit", taskId: "task_dead_zone", executionId: "exe_dead_zone" },
+      peerBinding,
+    )) as WriteReceipt;
+    assert.equal(submitted.outcome, "applied", JSON.stringify(submitted));
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("naming a foreign execution id explains the round's active execution to rejoin", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-lease-dead-zone-foreign-"));
+  let clock = new Date("2026-09-12T00:00:00.000Z");
+  let cell: Cell | undefined;
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({
+      repoId: workspaceId("lease-dead-zone-foreign"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "lease-dead-zone-foreign",
+      now: () => clock.toISOString(),
+    });
+    await createReadyTask(cell, rootDir, "task_foreign_id", "Foreign execution id guidance");
+    const started = (await cell.run(
+      { kind: "task-start", taskId: "task_foreign_id", executionId: "exe_foreign", ttlMs: 60_000 },
+      holderBinding,
+    )) as WriteReceipt;
+    assert.equal(started.outcome, "applied", JSON.stringify(started));
+    clock = new Date("2026-09-12T02:00:00.000Z");
+
+    const rejected = (await cell.run(
+      { kind: "task-start", taskId: "task_foreign_id", executionId: "exe_not_in_round" },
+      peerBinding,
+    )) as WriteReceipt;
+    assert.equal(rejected.outcome, "op_rejected");
+    assert.equal(rejected.code, "invalid_transition");
+    assert.equal(
+      rejected.diagnostic?.expectation,
+      `Current round already has active execution exe_foreign; run ha task start task_foreign_id ` +
+        `without --execution-id, or with --execution-id exe_foreign, to rejoin it`,
+      JSON.stringify(rejected.diagnostic),
+    );
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("ReturnToPlanned frees the round so ha task start allocates a fresh execution", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-lease-dead-zone-return-"));
+  const clock = new Date("2026-09-12T00:00:00.000Z");
+  let cell: Cell | undefined;
+  try {
+    initRepo(rootDir);
+    cell = await openRepoCell({
+      repoId: workspaceId("lease-dead-zone-return"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "lease-dead-zone-return",
+      now: () => clock.toISOString(),
+    });
+    await createReadyTask(cell, rootDir, "task_return_round", "ReturnToPlanned round release");
+    const started = (await cell.run(
+      { kind: "task-start", taskId: "task_return_round", executionId: "exe_return_round" },
+      holderBinding,
+    )) as WriteReceipt;
+    assert.equal(started.outcome, "applied", JSON.stringify(started));
+    const released = (await cell.run(
+      { kind: "task-release", taskId: "task_return_round", reason: "Resetting the round" },
+      holderBinding,
+    )) as WriteReceipt;
+    assert.equal(released.outcome, "applied", JSON.stringify(released));
+    const returned = (await cell.run(
+      { kind: "task-transition", taskId: "task_return_round", status: "planned", reason: "Resetting the round" },
+      holderBinding,
+    )) as WriteReceipt;
+    assert.equal(returned.outcome, "applied", JSON.stringify(returned));
+
+    // Before the fix the released-but-active execution kept claiming the round: the plain form
+    // silently rejoined it and a fresh id was the only thing `ha task start` could not do.
+    const fresh = (await cell.run({ kind: "task-start", taskId: "task_return_round" }, peerBinding)) as WriteReceipt;
+    assert.equal(fresh.outcome, "applied", JSON.stringify(fresh));
+    assert.notEqual(fresh.executionId, "exe_return_round", "a fresh execution is allocated for the new round");
+    assert.equal(String(fresh.executionId).startsWith("exe_"), true);
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+async function createReadyTask(cell: Cell, rootDir: string, taskId: string, title: string): Promise<void> {
+  await createRealizedTaskPlanFixture(
+    rootDir,
+    async () => {
+      const created = await cell.run({ kind: "task-create", taskId, title }, holderBinding);
+      await waitForFixturePublication(cell, created.opId, holderBinding);
+      return created;
+    },
+    (planPath) => cell.run({ kind: "doc-submit", paths: [planPath] }, holderBinding),
+    title,
+  );
+}
+
+function initRepo(rootDir: string): void {
+  git(rootDir, "init", "-q");
+  git(rootDir, "config", "user.name", "Lease Dead Zone Test");
+  git(rootDir, "config", "user.email", "lease-dead-zone@example.invalid");
+  git(rootDir, "commit", "--allow-empty", "-qm", "base");
+}
+
+function git(rootDir: string, ...args: readonly string[]): string {
+  return execFileSync("git", ["-C", rootDir, ...args], { encoding: "utf8" }).trim();
+}

--- a/packages/daemon/test/rejection-next-actions.integration.test.ts
+++ b/packages/daemon/test/rejection-next-actions.integration.test.ts
@@ -158,7 +158,7 @@ test("start rejection identifies the active execution and its reuse command", as
       entity: `task ${taskId}`,
       field: "executionId",
       actual: `active execution=${executionId} status=active node=implementation`,
-      expectation: `Current round already has an active execution; run ha task start ${taskId} without --execution-id to reuse it`,
+      expectation: `Current round already has active execution exec-start-reuse; run ha task start ${taskId} without --execution-id, or with --execution-id exec-start-reuse, to rejoin it`,
     });
     context.diagnostic(`invalid_transition receipt=${JSON.stringify(rejected)}`);
     assert.equal((await cell.run({ kind: "task-start", taskId }, owner)).outcome, "applied");

--- a/packages/kernel/src/domain/task-action-capability.ts
+++ b/packages/kernel/src/domain/task-action-capability.ts
@@ -139,14 +139,19 @@ function mutationInvocation(): "invocation-required" {
   return "invocation-required";
 }
 
+/** An orphaned lease's holder is gone and fences nothing — the write path treats it like no lease. */
+function toleratesLapsedLease(lease: TaskActionCapabilityInput["snapshot"]["lease"]): boolean {
+  return lease === null || lease.phase === "orphaned";
+}
+
 function activeDispositionInvocation({ snapshot }: TaskActionCapabilityInput): "invocation-required" | "unmet" {
-  return snapshot.lease === null && (snapshot.task?.packageDisposition ?? "active") === "active"
+  return toleratesLapsedLease(snapshot.lease) && (snapshot.task?.packageDisposition ?? "active") === "active"
     ? "invocation-required"
     : "unmet";
 }
 
 function reopenInvocation({ snapshot }: TaskActionCapabilityInput): "invocation-required" | "unmet" {
-  return snapshot.lease === null &&
+  return toleratesLapsedLease(snapshot.lease) &&
     snapshot.task !== null &&
     !["done", "cancelled"].includes(snapshot.task.status) &&
     ["archived", "tombstoned"].includes(snapshot.task.packageDisposition ?? "active")

--- a/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
+++ b/packages/kernel/src/domain/task-lifecycle-command-transitions.ts
@@ -84,7 +84,9 @@ export const create: Transition = {
 /**
  * The state-side admissibility of StartExecution: a new execution, the
  * unleased active execution of the current round, or a review node stranded
- * without the submitted execution needed to proceed.
+ * without the submitted execution needed to proceed. An `orphaned` lease — the
+ * time-aware projection's view of a held lease past its TTL — no longer gates
+ * the round: the holder is gone, and the reservation CAS fences the takeover.
  * Exported so the daemon preview and this transition answer with one rule instead of two. */
 export function canStartExecution(snapshot: TaskLifecycleSnapshot, executionId: string): boolean {
   const task = snapshot.task,
@@ -100,7 +102,13 @@ export function canStartExecution(snapshot: TaskLifecycleSnapshot, executionId: 
     startablePhase =
       (["planned", "active"].includes(task?.status ?? "") && task?.currentNode === "implementation") ||
       (["planned", "active", "in_review"].includes(task?.status ?? "") && recoverableReview);
-  return Boolean(task) && startablePhase && !snapshot.lease && isNonEmptyString(executionId) && rejoin === round;
+  return (
+    Boolean(task) &&
+    startablePhase &&
+    (snapshot.lease === null || snapshot.lease.phase === "orphaned") &&
+    isNonEmptyString(executionId) &&
+    rejoin === round
+  );
 }
 /** The state-side admissibility shared by the block/unblock/cancel catalog entries. */
 export function allowsTaskStatusMove(
@@ -199,6 +207,7 @@ function transitionTask(
   snapshot: TaskLifecycleSnapshot,
   command: TransitionTaskCommand,
   status: "planned" | "active" | "in_review" | "blocked" | "cancelled",
+  extraMutationFields: readonly string[] = [],
 ): TransitionResult {
   const task: TaskV2 = {
       ...(snapshot.task as TaskV2),
@@ -206,7 +215,7 @@ function transitionTask(
       ...(status === "cancelled" ? { pinned: false } : {}),
     },
     reason = isNonEmptyString(command.reason) ? command.reason : `Explicit lifecycle transition to ${status}`,
-    mutation = { command: "transition" as const, reason, fields: ["status"] };
+    mutation = { command: "transition" as const, reason, fields: ["status", ...extraMutationFields] };
   return {
     snapshot: { ...snapshot, revision: command.workspaceRevision, task },
     event: envelope<TaskMutationEvent>(command, "task_transitioned", {
@@ -268,6 +277,9 @@ export const reinstate: Transition = {
       (raw as TransitionTaskCommand).status as "planned" | "active" | "in_review",
     ),
 };
+/** ReturnToPlanned closes the round the way changes_requested does: an unleased execution that is
+ * still active in the current iteration would otherwise keep claiming the round forever, leaving
+ * `ha task start` no way to allocate a fresh execution. Advancing the iteration supersedes it. */
 export const returnToPlanned: Transition = {
   actionId: "transition",
   matches: (command, snapshot) =>
@@ -290,7 +302,19 @@ export const returnToPlanned: Transition = {
       issues.push(lifecycleContractIssue("missing_field", "ReturnToPlanned requires an auditable reason"));
     return issues;
   },
-  reduce: (snapshot, raw) => transitionTask(snapshot, raw as TransitionTaskCommand, "planned"),
+  reduce: (snapshot, raw) => {
+    const command = raw as TransitionTaskCommand,
+      task = snapshot.task as TaskV2,
+      openRound = snapshot.executions.some(
+        (value) => isNativeExecution(value) && value.iteration === task.iteration && value.state === "active",
+      );
+    return transitionTask(
+      openRound ? { ...snapshot, task: { ...task, iteration: task.iteration + 1 } } : snapshot,
+      command,
+      "planned",
+      openRound ? ["iteration"] : [],
+    );
+  },
 };
 export const unblock: Transition = {
   actionId: "transition",

--- a/packages/kernel/test/contracts/start-execution-admissibility.test.ts
+++ b/packages/kernel/test/contracts/start-execution-admissibility.test.ts
@@ -328,6 +328,118 @@ test("after the lease expires, only rejoining the round's active execution is ad
   );
 });
 
+// The lease the time-aware projection serves after TTL: still the stored CAS row, but with the
+// derived phase `orphaned`. Before the fix this object kept `!snapshot.lease` false and blocked
+// every `ha task start` form on a current-round execution whose holder was gone (T1-random-baseline).
+test("an orphaned expired lease no longer blocks rejoining the round's active execution", () => {
+  const orphaned: TaskLifecycleSnapshot = {
+    ...started(),
+    lease: { ...(started().lease as NonNullable<TaskLifecycleSnapshot["lease"]>), phase: "orphaned" },
+  };
+  assert.equal(orphaned.lease?.phase, "orphaned", "fixture precondition: the projection-derived phase");
+
+  assert.equal(
+    canStartExecution(orphaned, "execution-1"),
+    true,
+    "an expired lease must not gate the round its execution still holds",
+  );
+  assert.equal(
+    canStartExecution(orphaned, "execution-fresh"),
+    false,
+    "a fresh id still cannot be admitted while the round's execution is active",
+  );
+});
+
+test("a different actor takes over the orphaned lease and inherits the execution", () => {
+  const orphaned: TaskLifecycleSnapshot = {
+      ...started(),
+      lease: { ...(started().lease as NonNullable<TaskLifecycleSnapshot["lease"]>), phase: "orphaned" },
+    },
+    peer: ActorAxes = { principal: { personId: "person-peer" }, executor: { kind: "agent", id: "peer-worker" } },
+    // The daemon reservation CAS fences the takeover: reserving v1, held v2 on top of the orphaned v0.
+    applied = applyTransition(
+      orphaned,
+      command(
+        3,
+        { type: "StartExecution", taskId: "task-1", executionId: "execution-1" },
+        peer,
+      ) as TaskLifecycleCommand,
+      {
+        actorBinding: peer,
+        reservation: {
+          taskId: "task-1",
+          executionId: "execution-1",
+          expiresAt: "2026-08-17T01:30:00.000Z",
+          ttlMs: 1_800_000,
+          previousHolder: { taskId: "task-1", executionId: "execution-1", actor: implementer, source: "local" },
+          reason: "ttl_expired_takeover",
+          version: 2,
+        },
+      },
+    ),
+    { snapshot: taken, event } = applied;
+
+  assert.equal(taken.lease?.phase, "held");
+  assert.equal(taken.lease?.version, 2, "the takeover lease continues the orphaned CAS version chain");
+  assert.deepEqual(taken.lease?.actor, peer);
+  assert.equal(taken.executions.length, 1);
+  assert.deepEqual(taken.executions[0]?.actor, peer, "the execution is inherited, not replaced");
+  assert.deepEqual(event.payload.previousHolder, {
+    taskId: "task-1",
+    executionId: "execution-1",
+    actor: implementer,
+    source: "local",
+  });
+  assert.equal(event.payload.reason, "ttl_expired_takeover");
+});
+
+// The 14-task closeout deadlock shape: the lease is released, ReturnToPlanned resets the status,
+// but the still-active execution keeps claiming the round, so no fresh execution can ever start.
+test("ReturnToPlanned closes the open round so a fresh execution can start", () => {
+  const released: TaskLifecycleSnapshot = { ...started(), lease: null },
+    returned = apply(
+      released,
+      command(3, {
+        type: "TransitionTask",
+        taskId: "task-1",
+        status: "planned",
+        reason: "Reset the round",
+      }) as TaskLifecycleCommand,
+      {} as never,
+    );
+
+  assert.equal(returned.task?.status, "planned");
+  assert.equal(returned.task?.iteration, 1, "the open execution round is closed by round advancement");
+  assert.equal(returned.executions[0]?.state, "active", "the execution record itself is left untouched");
+  assert.equal(
+    canStartExecution(returned, "execution-fresh"),
+    true,
+    "a fresh execution must be allocatable after the round is returned to planned",
+  );
+  assert.equal(
+    canStartExecution(returned, "execution-1"),
+    false,
+    "the returned round's execution is closed and no longer rejoinable",
+  );
+});
+
+test("ReturnToPlanned without an open round keeps the iteration", () => {
+  const idle: TaskLifecycleSnapshot = { ...started(), executions: [], lease: null },
+    returned = apply(
+      idle,
+      command(3, {
+        type: "TransitionTask",
+        taskId: "task-1",
+        status: "planned",
+        reason: "Reset the round",
+      }) as TaskLifecycleCommand,
+      {} as never,
+    );
+
+  assert.equal(returned.task?.iteration, 0);
+  assert.equal(canStartExecution(returned, "execution-fresh"), true);
+});
+
 test("rejoining an active execution transfers its attribution to the new lease holder", () => {
   const expired: TaskLifecycleSnapshot = { ...started(), lease: null },
     runtimeActor: ActorAxes = {


### PR DESCRIPTION
# English

## Summary

An execution sitting in the implementation node with no active lease, as the current round, could not be re-acquired: `ha task start <id>` and `ha task start <id> --execution-id <exe>` both returned `invalid_transition` ("the implementation node with no active lease and the execution is the current round"), so start/submit/complete were all unavailable and the task was stuck (peer repo T1-random-baseline; the same family reproduced in this repo). Root cause is not executor/actor binding: `canStartExecution` required `!snapshot.lease` outright, but a lease past its TTL is not cleared to `null` — the time-aware projection derives it to a non-null `phase:"orphaned"` object, so the guard rejected the round even though the application-service `ttl_expired_takeover` CAS handling for it already existed and was simply unreachable. Separately, `ReturnToPlanned` left the round's execution active in the current iteration with no lease, which is the same dead zone reached a different way.

## Architectural Justification

Smallest correct change: no new command, no new write path, no compatibility shim. The orphaned-lease case reuses the CAS-fenced takeover the application service already implements; the fix only removes the state-side guard clause that made it unreachable. ReturnToPlanned's round-close reuses the exact mechanism `changes_requested` already uses (iteration bump via the existing `transitionTask` mutation-fields plumbing) rather than inventing a second way to end a round.

## What Changed

- `packages/kernel/src/domain/task-lifecycle-command-transitions.ts`: `canStartExecution` now accepts `snapshot.lease === null || snapshot.lease.phase === "orphaned"` (was `!snapshot.lease` only) — an orphaned (TTL-expired) lease no longer blocks a restart; the pre-existing reservation CAS still fences the actual takeover. `returnToPlanned`'s `reduce` now checks whether the current round still has an active native execution in the task's iteration; if so it bumps `task.iteration` (mirroring how `changes_requested` closes a round) and records `iteration` in the transition's audited mutation fields, so the stale execution stops claiming the round and a fresh `ha task start` can allocate one. `transitionTask` gained an `extraMutationFields` parameter to carry that.
- `packages/daemon/src/task-action-catalog-runtime.ts`: the "current round already has an active execution" rejection message now names the actual `activeExecution.executionId` and offers `--execution-id <id>` to rejoin it explicitly, replacing the previous guidance that only said to omit `--execution-id`.
- Tests: new `packages/daemon/test/lease-dead-zone-recovery.integration.test.ts` (190 lines) and `packages/kernel/test/contracts/start-execution-admissibility.test.ts` (112 lines) cover both the orphaned-lease restart and the ReturnToPlanned round-close; `task-action-explanation-service.test.ts` updated for the new message text.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +31/-6 production; tests +307/-1.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_d66bf48e4e567cd14ef2a1dc9d (parent none)
- Branch: `codex/lease-dead-zone-recover`
- Public scope: kernel `canStartExecution`/`returnToPlanned` admissibility and the daemon's active-execution rejection message
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: the archived-task reopen scenario the plan named as an acceptance criterion (`ha task archive` then `ha task reopen` then `ha task start --execution-id` on the previously-archived execution) is not covered — the report does not mention archive/reopen and neither the diff nor the new tests touch archive/reopen code paths; this needs a follow-up before the acceptance bar in the plan is fully met

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/lease-dead-zone-recover`
- Private evidence commit/path: task_d66bf48e4e567cd14ef2a1dc9d `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Pre-fix: kernel admissibility tests and the daemon integration test reproduce the verbatim `invalid_transition` message (3 kernel + 3 daemon red cases). Post-fix: kernel 14/14 green, daemon integration 3/3 green; the touched surface (42 kernel contract tests plus 5 integration test files) re-run individually through the isolated dispatcher all green, re-verified after a rebase. line-density, run-manifest-gates --changed, the four DDD ratchet gates, canonical-event-compat, file-complexity, typecheck, and eslint all exit 0. GitHub CI: not pushed, pending.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A live lease still within its TTL is still rejected with `lease_conflict` — this is intended protective semantics, not a regression. The report also flags as unverified: the daemon build-drift takeover window's real-world behavior, and how the GUI displays the new `iteration + 1` after a ReturnToPlanned round-close — neither was exercised. Most notably, the archived-task reopen scenario the plan explicitly added as an acceptance criterion is unaddressed (see Out of Scope) and should be treated as a known gap, not a completed guarantee.

## References

- Task: task_d66bf48e4e567cd14ef2a1dc9d

---

# 中文

## 概要

一个停在 implementation node、无 active lease、且是 current round 的 execution 无法被重新接回：`ha task start <id>` 与 `ha task start <id> --execution-id <exe>` 都报 `invalid_transition`（"implementation node with no active lease and the execution is the current round"），导致 start/submit/complete 全部不可用，任务卡死（对等仓库 T1-random-baseline 实测；本仓复现同族状态）。根因不是 executor/actor 绑定：`canStartExecution` 硬性要求 `!snapshot.lease`，但过期的 lease 不会被清成 `null`——时间感知投影会把它派生成非 null 的 `phase:"orphaned"` 对象，于是该守卫挡死了这一轮，而 application service 早已实现的 `ttl_expired_takeover` CAS 接管其实一直不可达。另外，`ReturnToPlanned` 会把当轮 execution 留在 current iteration 且无 lease 的状态，是绕另一条路径落进同一个死区。

## 架构辩护

最小正确改法：不加新命令、不加新写路径、不加兼容层。orphaned-lease 情形复用 application service 早已实现、被 CAS 把关的接管逻辑，修复只是删掉了让它不可达的状态侧守卫条件。ReturnToPlanned 的关轮复用 `changes_requested` 已经在用的同一机制（借既有 `transitionTask` mutation-fields 管线推进 iteration），而不是另造第二种关轮方式。

## 改动内容

- `packages/kernel/src/domain/task-lifecycle-command-transitions.ts`：`canStartExecution` 改为接受 `snapshot.lease === null || snapshot.lease.phase === "orphaned"`（原来只接受 `!snapshot.lease`）——过期（orphaned）lease 不再挡住重启，真正的接管仍由既有的预留 CAS 把关。`returnToPlanned` 的 `reduce` 现在检查当轮在当前 iteration 是否仍有 active 的原生 execution；若有则推进 `task.iteration`（与 `changes_requested` 关闭一轮的机制一致），并把 `iteration` 记入该次转换审计的 mutation fields，使陈旧 execution 不再占住这一轮，`ha task start` 可分配新的一轮。`transitionTask` 新增 `extraMutationFields` 参数以承载这一点。
- `packages/daemon/src/task-action-catalog-runtime.ts`："当轮已有 active execution" 的拒绝文案现在点名实际的 `activeExecution.executionId`，并明确给出 `--execution-id <id>` 以显式接回，取代原来只说"不带 --execution-id"的提示。
- 测试：新建 `packages/daemon/test/lease-dead-zone-recovery.integration.test.ts`（190 行）与 `packages/kernel/test/contracts/start-execution-admissibility.test.ts`（112 行），覆盖 orphaned-lease 重启与 ReturnToPlanned 关轮两种情形；`task-action-explanation-service.test.ts` 更新为新文案断言。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+31/-6 production; tests +307/-1。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_d66bf48e4e567cd14ef2a1dc9d（父 none）
- 分支：`codex/lease-dead-zone-recover`
- 公开范围：kernel `canStartExecution`/`returnToPlanned` 的可接回判定与 daemon 的 active-execution 拒绝文案
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：计划中新增的验收判据——已归档任务场景（`ha task archive` 后 `ha task reopen`，再 `ha task start --execution-id` 接回该曾归档的 execution）未被覆盖：报告全文未提 archive/reopen，diff 与新增测试也都未触及 archive/reopen 相关代码路径；在计划设定的验收线被完整满足之前，这是需要后续处理的缺口

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/lease-dead-zone-recover`
- 私有证据路径：task_d66bf48e4e567cd14ef2a1dc9d 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 修前：kernel 可接回判定测试与 daemon 集成测试逐字复现 `invalid_transition` 报错（kernel 3 红、daemon 3 红）。修后：kernel 14/14 绿、daemon 集成 3/3 绿；触碰面（42 个 kernel contract 测试 + 5 个集成测试文件）经隔离入口逐个重跑全绿，rebase 后复跑确认。line-density、run-manifest-gates --changed、四个 DDD ratchet 门、canonical-event-compat、file-complexity、typecheck、eslint 全部 exit 0。GitHub CI：未 push，待跑。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- TTL 内仍存活的 lease 依然按 `lease_conflict` 拒绝——这是有意的保护语义，不是回归。报告另标注为 unverified：daemon build-drift 真实接管窗口的实际行为、GUI 对 ReturnToPlanned 关轮后 `iteration + 1` 的展示，两者均未验证。最值得注意的是，计划明确加入的验收判据——已归档任务的 reopen 场景——未被处理（见范围外），应视为已知缺口，而非已完成的保证。

## 参考

- 任务：task_d66bf48e4e567cd14ef2a1dc9d

