### PR TITLE
fix: accept a published closeout cut without a dispatch HEAD relationship

### DIFF
--- a/packages/daemon/src/repo-cell-submit.ts
+++ b/packages/daemon/src/repo-cell-submit.ts
@@ -79,24 +79,17 @@ export function deriveCloseoutSubmission(
   const root = publishedRoot,
     commitSha = git.run(root, ["rev-parse", `${named[0]!}^{commit}`]).stdout;
   // One execution may dispatch through several cwds (delivery worktree, then closeout prep at
-  // the canonical root). The named cut must still be explained by one of them: it is that
-  // directory's HEAD, contains a dispatch HEAD, or is already published to origin/main.
-  if (directories.length) {
-    const published = git.run(root, ["merge-base", "--is-ancestor", commitSha, "origin/main"]).ok;
-    if (
-      !directories.some((directory) => {
-        const head = git.run(directory, ["rev-parse", "HEAD"]).stdout;
-        return (
-          head === commitSha ||
-          (published && (head ? git.run(root, ["merge-base", "--is-ancestor", head, commitSha]).ok : true))
-        );
-      })
-    )
-      throw cell.cellCodedError(
-        "invalid_submission",
-        "Summary commit must be the bound worktree HEAD or its published merge commit.",
-      );
-  }
+  // the canonical root). A cut already published to origin/main needs nothing else; an
+  // unpublished cut must be the HEAD of one of those directories.
+  if (
+    directories.length &&
+    !git.run(root, ["merge-base", "--is-ancestor", commitSha, "origin/main"]).ok &&
+    !directories.some((directory) => git.run(directory, ["rev-parse", "HEAD"]).stdout === commitSha)
+  )
+    throw cell.cellCodedError(
+      "invalid_submission",
+      "Summary commit must be the bound worktree HEAD or its published merge commit.",
+    );
   const mergeBase = git.run(root, ["merge-base", "origin/main", commitSha]);
   const base =
     mergeBase.ok && mergeBase.stdout !== commitSha

--- a/packages/daemon/test/closeout-submission-cut.test.ts
+++ b/packages/daemon/test/closeout-submission-cut.test.ts
@@ -191,7 +191,9 @@ test("already merged dispatch preserves earlier branch changes and rejects unrel
   dispatch(root, root);
   assert.deepEqual(derive(root, `Delivery ${merged}`).deliverables, ["src/first.ts", "src/second.ts"]);
   assert.equal(derive(root, `Delivery ${merged}`).commitSha, merged);
-  assert.throws(() => derive(root, `Delivery ${base}`), /bound worktree HEAD/u);
+  // Naming an older published commit is still rejected, by the comparison-cut check rather than
+  // by any relationship to the dispatch HEAD.
+  assert.throws(() => derive(root, `Delivery ${base}`), /no verifiable comparison cut/u);
   assert.throws(() => derive(root, "Worktree delivery."), { code: "invalid_submission" });
 });
 
@@ -226,6 +228,25 @@ test("one execution with two dispatch directories accepts its published merge cu
   git(root, "update-ref", "refs/remotes/origin/main", merged);
   dispatch(root, worker);
   dispatch(root, root, "dispatch_222222222222222222222222");
+  const packet = derive(root, `Delivery ${merged}.`);
+  assert.equal(packet.commitSha, merged);
+  assert.deepEqual(packet.deliverables, ["src/delivery.ts"]);
+});
+
+test("a published cut is accepted even when no dispatch HEAD explains it", (t) => {
+  const { root } = fixture(t),
+    worker = path.join(root, "worker");
+  git(root, "worktree", "add", "-qb", "worker", worker);
+  put(worker, "src/delivery.ts", "delivery\n");
+  commit(worker);
+  git(root, "merge", "--no-ff", "-qm", "test: merge delivery", "worker");
+  const merged = git(root, "rev-parse", "HEAD");
+  git(root, "update-ref", "refs/remotes/origin/main", merged);
+  // The worker moved on to an unrelated commit after the merge: its HEAD is neither the named
+  // cut nor an ancestor of it.
+  put(worker, "src/unrelated.ts", "unrelated\n");
+  commit(worker);
+  dispatch(root, worker);
   const packet = derive(root, `Delivery ${merged}.`);
   assert.equal(packet.commitSha, merged);
   assert.deepEqual(packet.deliverables, ["src/delivery.ts"]);


### PR DESCRIPTION
# English

## Summary

`deriveCloseoutSubmission` (`packages/daemon/src/repo-cell-submit.ts`) still required, for an execution with dispatch directories, that some dispatch cwd HEAD equal the named commit or be an ancestor of it, even when the named commit was already merged to `origin/main`. The independent closeout review of task_146e0fa8 (PR #2569) flagged this as a partial implementation of the ruling that a published cut needs only main ancestry. A worker whose worktree moved on after the merge (rebase onto main, then new commits) could therefore no longer submit its own merged delivery. This change makes a published cut sufficient on its own; an unpublished cut must still be the HEAD of one of the dispatch directories.

## Architectural Justification

Deletion of a redundant guard: the case it protected (naming an older published commit) was already rejected downstream by the comparison-cut check, so the guard only blocked legitimate submissions.

## What Changed

- `packages/daemon/src/repo-cell-submit.ts`: the dispatch-directory check now runs only when the named commit is not an ancestor of `origin/main`, and then only accepts an exact dispatch HEAD; the `published && head is-ancestor-of commit` branch is deleted (11 added / 18 removed).
- `packages/daemon/test/closeout-submission-cut.test.ts`: new test `a published cut is accepted even when no dispatch HEAD explains it` (worker commits an unrelated change after the merge, then names the merge commit); the existing `already merged dispatch … rejects unrelated Summary cut` test now expects the downstream `no verifiable comparison cut` rejection for an older published commit, since that rejection was already what protected that case.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +11/-18 production; tests +22/-1.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_0f15dfa794963ed568eca61055 (parent task_146e0fa851280a569c57c978eb)
- Branch: `codex/published-ancestry`
- Public scope: daemon closeout submission derivation and its unit test.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: No change to how the comparison cut, ledger fallback, or artifact anchors are derived; no CLI or GUI change.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/published-ancestry`
- Private evidence commit/path: task_0f15dfa794963ed568eca61055 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node tools/run-node-tests.mjs --file packages/daemon/test/closeout-submission-cut.test.ts` exit 0 (all tests in the file); negative control: with the source change reverted, the new test fails (`published merge commit` rejection) and passes with it. eslint and prettier clean on both files.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Naming an unrelated but published commit as the delivery is no longer rejected by the dispatch-HEAD rule; it is still rejected when it yields no comparison cut, and the independent closeout reviewer verifies that the named commit actually carries the delivery.

## References

- Task: task_0f15dfa794963ed568eca61055

---

# 中文

## 概要

`deriveCloseoutSubmission` 在执行有 dispatch 目录时，即使 named commit 已合入 `origin/main`，仍要求某个 dispatch cwd 的 HEAD 等于该提交或是其祖先。task_146e0fa8（PR #2569）的独立 closeout 评审指出这只部分实现了「已发布的 cut 只需 main 祖先关系」的裁决：worker 在合并后继续前进（rebase 到 main 再提交）就再也提交不了自己已合入的交付。本次改为：已发布的 cut 自身即足够；未发布的 cut 仍必须是某个 dispatch 目录的 HEAD。

## 架构辩护

删除冗余护栏：它保护的场景（点名更早的已发布提交）本来就被下游比较 cut 检查拒绝，护栏只拦住了合法提交。

## 改动内容

- `packages/daemon/src/repo-cell-submit.ts`：dispatch 目录检查只在 named commit 不是 `origin/main` 祖先时运行，且只接受精确的 dispatch HEAD；删除了 `published && head 是 commit 祖先` 分支（+11/-18）。
- `packages/daemon/test/closeout-submission-cut.test.ts`：新增测试「已发布 cut 在没有任何 dispatch HEAD 解释它时也被接受」（worker 合并后再提交无关改动，然后点名 merge commit）；既有的「拒绝无关 Summary cut」测试改为期待下游的 `no verifiable comparison cut` 拒绝——保护该场景的本来就是这条检查。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+11/-18 production; tests +22/-1。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_0f15dfa794963ed568eca61055（父 task_146e0fa851280a569c57c978eb）
- 分支：`codex/published-ancestry`
- 公开范围：daemon closeout 提交推导及其单元测试。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：不改比较 cut、ledger 回退、artifact 锚的推导；不改 CLI/GUI。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/published-ancestry`
- 私有证据路径：task_0f15dfa794963ed568eca61055 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node tools/run-node-tests.mjs --file packages/daemon/test/closeout-submission-cut.test.ts` exit 0（整文件）；阴性对照：还原源码改动后新测试红（`published merge commit` 拒绝），恢复后绿。两文件 eslint、prettier 干净。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 点名一个无关但已发布的提交不再被 dispatch-HEAD 规则拒绝；它在推不出比较 cut 时仍被拒绝，且独立 closeout 评审会核实 named commit 确实承载了交付。

## 参考

- 任务：task_0f15dfa794963ed568eca61055

