### PR TITLE
fix: reject a Summary naming several delivery commits with its own wording

### DIFF
--- a/packages/daemon/src/repo-cell-submit.ts
+++ b/packages/daemon/src/repo-cell-submit.ts
@@ -39,9 +39,14 @@ export function deriveCloseoutSubmission(
     prose = submissionFromCloseout(document.body, { commitSha: "0".repeat(40), deliverables: [], outputs: [] }),
     anchors = artifactAnchors(prose.completionClaim),
     named = [...new Set(prose.completionClaim.replace(/artifact:[^\s`<>]+/gu, "").match(/\b[0-9a-f]{40}\b/gu) ?? [])];
+  if (named.length > 1)
+    throw cell.cellCodedError(
+      "invalid_submission",
+      `Summary names ${named.length} delivery commits; one execution has exactly one delivery cut, ` +
+        "so name only the commit being delivered.",
+    );
   if (
     (named.length === 1) === anchors.length > 0 ||
-    named.length > 1 ||
     (prose.completionClaim.match(/artifact:/gu) ?? []).length !== anchors.length
   )
     throw cell.cellCodedError(

--- a/packages/daemon/test/closeout-submission-cut.test.ts
+++ b/packages/daemon/test/closeout-submission-cut.test.ts
@@ -145,7 +145,7 @@ test("missing dispatch requires an explicit Summary cut and rejects ambiguous co
   put(root, "src/live.ts", "export const liveValue = 3;\n");
   const sha = commit(root);
   assert.throws(() => derive(root, "Completed the live path."), { code: "invalid_submission" });
-  assert.throws(() => derive(root, `Delivered ${base} and ${sha}.`), { code: "invalid_submission" });
+  assert.throws(() => derive(root, `Delivered ${base} and ${sha}.`), /names 2 delivery commits/u);
   assert.throws(() => derive(root, `Delivered ${"f".repeat(40)}.`), { code: "invalid_submission" });
 });
 


### PR DESCRIPTION
# English

## Summary

`deriveCloseoutSubmission` rejected a closeout Summary that names several 40-hex commits with the same generic message used for a Summary that names nothing ("Summary must explicitly name one commit or artifact anchors"). The task_146e0fa8 acceptance boundary requires that case to have its own rejection, since it is a different mistake: the author named too many cuts, not too few. This change gives `named.length > 1` a dedicated `invalid_submission` rejection that states how many commits were named and that one execution has exactly one delivery cut.

## Architectural Justification

Splits one overloaded rejection into two so the next action is unambiguous; no new mechanism.

## What Changed

- `packages/daemon/src/repo-cell-submit.ts`: a dedicated throw for `named.length > 1` placed before the generic shape check; the generic condition no longer includes that case.
- `packages/daemon/test/closeout-submission-cut.test.ts`: the ambiguous-commits assertion in `missing dispatch requires an explicit Summary cut and rejects ambiguous commits` now matches the new wording.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +5/-1 production; tests +1/-1.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_8db7e5dde5d07b033e58aaf325 (parent task_146e0fa851280a569c57c978eb)
- Branch: `codex/named-cut-wording`
- Public scope: daemon closeout submission derivation and its unit test.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: No change to which submissions are accepted; only the rejection wording for the multi-commit case.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/named-cut-wording`
- Private evidence commit/path: task_8db7e5dde5d07b033e58aaf325 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node tools/run-node-tests.mjs --file packages/daemon/test/closeout-submission-cut.test.ts` exit 0; eslint and prettier clean on both files.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- None beyond wording; the multi-commit case was already rejected.

## References

- Task: task_8db7e5dde5d07b033e58aaf325

---

# 中文

## 概要

`deriveCloseoutSubmission` 对 Summary 点名多个 40-hex 提交的情况，用的是和「什么都没点名」相同的通用文案。task_146e0fa8 的验收边界要求这两种错误各有独立拒绝——点名太多和点名太少是两回事。本次给 `named.length > 1` 单独的 `invalid_submission` 拒绝，说明点名了几个提交、一个执行只有一个交付切点。

## 架构辩护

把一个过载的拒绝拆成两个，让下一步动作无歧义；不加机制。

## 改动内容

- `packages/daemon/src/repo-cell-submit.ts`：`named.length > 1` 独立 throw，放在通用形状检查之前；通用条件不再包含该情况。
- `packages/daemon/test/closeout-submission-cut.test.ts`：ambiguous-commits 断言改匹配新文案。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+5/-1 production; tests +1/-1。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_8db7e5dde5d07b033e58aaf325（父 task_146e0fa851280a569c57c978eb）
- 分支：`codex/named-cut-wording`
- 公开范围：daemon closeout 提交推导及其单元测试。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：不改接受范围，只改多提交情况的拒绝文案。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/named-cut-wording`
- 私有证据路径：task_8db7e5dde5d07b033e58aaf325 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node tools/run-node-tests.mjs --file packages/daemon/test/closeout-submission-cut.test.ts` exit 0；两文件 eslint、prettier 干净。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 仅文案；该情况原本就被拒绝。

## 参考

- 任务：task_8db7e5dde5d07b033e58aaf325

