### PR TITLE
fix: default consent-at and consent-channel when approving via --consent-by

### DIFF
--- a/packages/cli/src/cli/thin-command-decision-lifecycle.ts
+++ b/packages/cli/src/cli/thin-command-decision-lifecycle.ts
@@ -38,6 +38,17 @@ export function parseDecisionRepin(
   });
 }
 
+// The flag catalog keeps --consent-at/--consent-channel as required peers of --consent-by, but
+// human approval at the CLI is one flag: absent peers default to the command moment and "cli".
+function withDefaultConsent(tokens: readonly string[]): readonly string[] {
+  const present = (name: string) => tokens.some((token) => token === name || token.startsWith(`${name}=`));
+  if (!present("--consent-by")) return tokens;
+  const defaults: string[] = [];
+  if (!present("--consent-at")) defaults.push(`--consent-at=${new Date().toISOString()}`);
+  if (!present("--consent-channel")) defaults.push("--consent-channel=cli");
+  return defaults.length > 0 ? [...tokens, ...defaults] : tokens;
+}
+
 export function parseDecisionTransition(
   args: readonly string[],
   rootDir: SafePath,
@@ -56,7 +67,7 @@ export function parseDecisionTransition(
       "Use decision transition <in_effect|rejected|deferred|superseded|outcome_retired> <id>.",
       json,
     );
-  const f = readFlags("decision-transition", args.slice(4), inputs);
+  const f = readFlags("decision-transition", withDefaultConsent(args.slice(4)), inputs);
   if (!f.ok) return rejected(f.code, f.nextAction, json);
   if (f.one.has("--consent-by") && !["in_effect", "rejected"].includes(targetState ?? ""))
     return rejected("invalid_field", "Human consent is only valid for in_effect or rejected.", json);

--- a/packages/cli/test/thin-command-fact-decision.test.ts
+++ b/packages/cli/test/thin-command-fact-decision.test.ts
@@ -514,24 +514,51 @@ test("Decision F06 and distill leaf commands preserve their complete structured 
   assert.equal(parseThinCommand(["decision", "amend", "dec_1"]).ok, false);
 });
 
-test("Decision human consent has one explicit, complete transition input", () => {
+test("Decision human consent defaults absent consent-at and consent-channel at the CLI plane", () => {
   const base = ["decision", "transition", "in_effect", "dec_TEST"],
-    approval = ["--consent-by", "person-test", "--consent-at", "2026-09-12T01:02:03Z", "--consent-channel", "chat"],
-    parsed = parseThinCommand([...base, ...approval]);
-  assert.equal(parsed.ok, true);
-  if (parsed.ok)
-    assert.deepEqual(
-      {
+    consentOf = (args: readonly string[]) => {
+      const parsed = parseThinCommand(args);
+      assert.equal(parsed.ok, true, JSON.stringify(args));
+      if (!parsed.ok) throw new Error("parse failed");
+      return {
         consentBy: parsed.command.action.consentBy,
         consentAt: parsed.command.action.consentAt,
         consentChannel: parsed.command.action.consentChannel,
-      },
-      { consentBy: "person-test", consentAt: "2026-09-12T01:02:03Z", consentChannel: "chat" },
-    );
+      };
+    };
+  assert.deepEqual(
+    consentOf([
+      ...base,
+      "--consent-by",
+      "person-test",
+      "--consent-at",
+      "2026-09-12T01:02:03Z",
+      "--consent-channel",
+      "chat",
+    ]),
+    { consentBy: "person-test", consentAt: "2026-09-12T01:02:03Z", consentChannel: "chat" },
+  );
+  assert.deepEqual(consentOf([...base, "--consent-by", "person-test", "--consent-at", "2026-09-12T01:02:03Z"]), {
+    consentBy: "person-test",
+    consentAt: "2026-09-12T01:02:03Z",
+    consentChannel: "cli",
+  });
+  const before = Date.now(),
+    defaulted = consentOf([...base, "--consent-by", "person-test"]),
+    channelOnly = consentOf([...base, "--consent-by", "person-test", "--consent-channel", "chat"]),
+    after = Date.now();
+  for (const consent of [defaulted, channelOnly]) {
+    assert.equal(consent.consentBy, "person-test");
+    assert.equal(consent.consentChannel, consent === channelOnly ? "chat" : "cli");
+    assert.match(String(consent.consentAt), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/u);
+    const at = Date.parse(String(consent.consentAt));
+    assert.ok(at >= before && at <= after, `consentAt ${String(consent.consentAt)} outside [${before}, ${after}]`);
+  }
   for (const args of [
-    [...base, "--consent-by", "person-test"],
-    [...base, ...approval.slice(0, -1), "email"],
-    ["decision", "transition", "deferred", "dec_TEST", ...approval],
+    [...base, "--consent-at", "2026-09-12T01:02:03Z"],
+    [...base, "--consent-by", "person-test", "--consent-channel", "email"],
+    [...base, "--consent-by", "person-test", "--consent-at"],
+    ["decision", "transition", "deferred", "dec_TEST", "--consent-by", "person-test"],
   ])
     assert.equal(parseThinCommand(args).ok, false, JSON.stringify(args));
 });


### PR DESCRIPTION
# English

## Summary

Approving a decision from the CLI as a human (`ha decision transition … --consent-by <person>`) was rejected with `--consent-by requires --consent-at, --consent-channel`, so the one-flag path did not exist and the operator had to fall back to the GUI. The flag catalog keeps the three consent fields as a unit; the CLI now fills the missing peers itself: consent-at defaults to the command moment (ISO timestamp) and consent-channel to `cli`. Explicit values still win.

## Architectural Justification

One-path rule: a human approval is one flag at the CLI; defaults belong to the presentation layer, so the kernel contract stays a strict triple.

## What Changed

- `packages/cli/src/cli/thin-command-decision-lifecycle.ts`: `withDefaultConsent` appends `--consent-at=<now>` / `--consent-channel=cli` when `--consent-by` is present and the peer is absent, before `readFlags` runs; the kernel contract (three fields together) is unchanged.
- `packages/cli/test/thin-command-fact-decision.test.ts`: the transition parsing cases now cover consent-by alone, consent-by with one explicit peer, and fully explicit consent (red before the change on the missing-channel combination).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +12/-1 production; tests +40/-13.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_50ded6aea6f60eb75553e3e4ac (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/consent-by-defaults`
- Public scope: CLI decision transition argument handling and its unit test.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: GUI approval path and kernel consent contract untouched; no new flags.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/consent-by-defaults`
- Private evidence commit/path: task_50ded6aea6f60eb75553e3e4ac `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node tools/run-node-tests.mjs --file packages/cli/test/thin-command-fact-decision.test.ts` exit 0 (CEO re-run); `--prefix packages/cli/test` exit 0 in the worker report; eslint clean; line-density G36 pass; `tsc -p tsconfig.build.json` exit 0.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Defaulted consent-at is the CLI process time, not a daemon-assigned time; this matches what an explicit human value would have been anyway.

## References

- Task: task_50ded6aea6f60eb75553e3e4ac

---

# 中文

## 概要

人在 CLI 批准 decision（`ha decision transition … --consent-by <person>`）被 `--consent-by requires --consent-at, --consent-channel` 拒绝，一条路不存在，只能退回 GUI。flag 目录仍把三个 consent 字段当整体；现在 CLI 自己补缺席的同伴：consent-at 默认命令时刻（ISO 时间戳），consent-channel 默认 `cli`；显式值仍优先。

## 架构辩护

一条路：人的批准在 CLI 是一个 flag；默认值属于呈现层，kernel 契约仍是严格三元组。

## 改动内容

- `packages/cli/src/cli/thin-command-decision-lifecycle.ts`：`withDefaultConsent` 在 `readFlags` 之前，`--consent-by` 存在而同伴缺席时追加 `--consent-at=<now>` / `--consent-channel=cli`；kernel 契约（三字段同现）不变。
- `packages/cli/test/thin-command-fact-decision.test.ts`：transition 解析用例覆盖只有 consent-by、consent-by 加一个显式同伴、三者全显式（改前缺 channel 组合为红）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+12/-1 production; tests +40/-13。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_50ded6aea6f60eb75553e3e4ac（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/consent-by-defaults`
- 公开范围：CLI decision transition 参数处理及其单元测试。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：GUI 批准路径与 kernel consent 契约不动；不加新 flag。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/consent-by-defaults`
- 私有证据路径：task_50ded6aea6f60eb75553e3e4ac 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node tools/run-node-tests.mjs --file packages/cli/test/thin-command-fact-decision.test.ts` exit 0（CEO 复跑）；worker 报告 `--prefix packages/cli/test` exit 0；eslint 干净；line-density G36 pass；`tsc -p tsconfig.build.json` exit 0。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 默认 consent-at 取 CLI 进程时刻而非 daemon 时刻；与人手填的值本来就一样。

## 参考

- 任务：task_50ded6aea6f60eb75553e3e4ac

