### PR TITLE
fix: rebuild daemon dist from git hooks and resolve tsc from the main checkout

### DIFF
--- a/tools/git-hooks/lib.sh
+++ b/tools/git-hooks/lib.sh
@@ -1,0 +1,35 @@
+# Shared helpers for the dist-rebuild hooks (post-checkout, post-commit,
+# post-merge). Each hook sources this from its own directory after cd-ing to
+# its repo root: git fires these hooks from the absolute core.hooksPath of the
+# main checkout even inside linked worktrees, whose own tree may predate this
+# file, so lib.sh must travel with the hook that uses it. $repo_root is
+# already set by the sourcing hook.
+
+# Resolve tsc from the main checkout, not the current one: linked worktrees
+# share the repository but not node_modules, so the relative
+# node_modules/.bin/tsc died with "No such file or directory" in any worktree
+# without its own install. The git common dir anchors the main checkout, whose
+# node_modules npm install keeps populated; inside the main checkout itself
+# this resolves to the same absolute path as the old relative one.
+main_root=$(cd "$(git rev-parse --git-common-dir)/.." && pwd -P)
+hook_tsc="$main_root/node_modules/.bin/tsc"
+
+# Trigger paths for one workspace package's build program: the package roots
+# tsc compiles (tsconfig include + every followed import) plus the npm-level
+# build inputs, so adding an upstream source dependency extends the trigger
+# list with the code instead of a second hand-maintained copy that drifts
+# stale. Same derivation for every rebuilt package; no per-package lists.
+package_trigger_paths() {
+  package_dir=$1
+  trigger_roots=$("$hook_tsc" -p "$package_dir/tsconfig.build.json" --listFilesOnly \
+    | awk -v root="$repo_root" \
+      'index($0, root "/packages/") == 1 { sub(root "/", ""); split($0, seg, "/"); print seg[1] "/" seg[2] }' \
+    | sort -u)
+  trigger_paths="package-lock.json package.json $package_dir/package.json"
+  trigger_paths="$trigger_paths $package_dir/tsconfig.build.json"
+  trigger_paths="$trigger_paths $package_dir/scripts/copy-assets.mjs packages/preset/assets"
+  for trigger_root in $trigger_roots; do
+    trigger_paths="$trigger_paths $trigger_root $trigger_root/package.json"
+  done
+  printf '%s\n' "$trigger_paths"
+}

--- a/tools/git-hooks/post-checkout
+++ b/tools/git-hooks/post-checkout
@@ -4,8 +4,9 @@ set -eu
 # Installed by pointing git at this directory:
 #   git config core.hooksPath tools/git-hooks   (or: npm run hooks:install)
 #
-# Rebuilds CLI dist after a BRANCH checkout that changed CLI source or bundled
-# assets, so local `ha` reflects the branch you switched to.
+# Rebuilds CLI and daemon dist after a BRANCH checkout that changed their
+# sources or bundled assets, so local `ha` and the resident daemon reflect the
+# branch you switched to.
 # Args (git-provided): $1 = previous HEAD, $2 = new HEAD, $3 = 1 for branch
 # checkout / 0 for file checkout.
 
@@ -19,32 +20,35 @@ branch_checkout=$3
 [ "$prev_head" != "$new_head" ] || exit 0
 
 repo_root=$(git rev-parse --show-toplevel)
+hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 cd "$repo_root"
+. "$hook_dir/lib.sh"
 
 # Fresh clone / unborn prev ref: cannot diff, so rebuild conservatively.
 if ! git rev-parse --verify --quiet "$prev_head^{commit}" >/dev/null 2>&1; then
-  echo "post-checkout: initial checkout; rebuilding CLI conservatively."
+  echo "post-checkout: initial checkout; rebuilding CLI and daemon conservatively."
   npm run build -w @harness-anything/cli
+  npm run build -w @harness-anything/daemon
   exit 0
 fi
 
-# CLI triggers are derived from the CLI build program itself (same derivation as
-# post-merge): the package roots tsc compiles for packages/cli/tsconfig.build.json,
-# so adding an upstream source dependency extends the trigger list with the code.
-cli_trigger_roots=$(node_modules/.bin/tsc -p packages/cli/tsconfig.build.json --listFilesOnly \
-  | awk -v root="$repo_root" 'index($0, root "/packages/") == 1 { sub(root "/", ""); split($0, seg, "/"); print seg[1] "/" seg[2] }' | sort -u)
+cli_trigger_paths=$(package_trigger_paths packages/cli)
+daemon_trigger_paths=$(package_trigger_paths packages/daemon)
 
-cli_trigger_paths="package-lock.json package.json packages/cli/package.json packages/cli/tsconfig.build.json packages/cli/scripts/copy-assets.mjs packages/preset/assets"
-for cli_root in $cli_trigger_roots; do
-  cli_trigger_paths="$cli_trigger_paths $cli_root $cli_root/package.json"
-done
+cli_changed_paths=$(git diff --name-only "$prev_head" "$new_head" -- $cli_trigger_paths)
+daemon_changed_paths=$(git diff --name-only "$prev_head" "$new_head" -- $daemon_trigger_paths)
 
-changed_paths=$(git diff --name-only "$prev_head" "$new_head" -- $cli_trigger_paths)
-
-if [ -z "$changed_paths" ]; then
-  echo "post-checkout: no CLI source or asset changes; skipping CLI build."
+if [ -z "$cli_changed_paths" ] && [ -z "$daemon_changed_paths" ]; then
+  echo "post-checkout: no CLI or daemon source changes; skipping builds."
   exit 0
 fi
 
-echo "post-checkout: CLI source or assets changed; rebuilding @harness-anything/cli."
-npm run build -w @harness-anything/cli
+if [ -n "$cli_changed_paths" ]; then
+  echo "post-checkout: CLI source, assets, or upstream packages changed; rebuilding @harness-anything/cli."
+  npm run build -w @harness-anything/cli
+fi
+
+if [ -n "$daemon_changed_paths" ]; then
+  echo "post-checkout: daemon source or upstream packages changed; rebuilding @harness-anything/daemon."
+  npm run build -w @harness-anything/daemon
+fi

--- a/tools/git-hooks/post-commit
+++ b/tools/git-hooks/post-commit
@@ -4,12 +4,15 @@ set -eu
 # Installed by pointing git at this directory:
 #   git config core.hooksPath tools/git-hooks   (or: npm run hooks:install)
 #
-# Keeps the workspace CLI dist fresh after LOCAL commits that changed CLI source
-# or bundled assets, so local `ha` shims that point at dist do not go stale.
+# Keeps the workspace CLI and daemon dist fresh after LOCAL commits that
+# changed their sources or bundled assets, so local `ha` shims that point at
+# dist do not go stale.
 # post-commit cannot abort the commit; a failed build only prints, never blocks.
 
 repo_root=$(git rev-parse --show-toplevel)
+hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 cd "$repo_root"
+. "$hook_dir/lib.sh"
 
 # Merge commits are handled by post-merge; skip here to avoid a double build.
 if git rev-parse --verify --quiet HEAD^2 >/dev/null 2>&1; then
@@ -18,28 +21,29 @@ fi
 
 parent=$(git rev-parse --verify --quiet HEAD~1 || true)
 if [ -z "$parent" ]; then
-  echo "post-commit: root commit; rebuilding CLI conservatively."
+  echo "post-commit: root commit; rebuilding CLI and daemon conservatively."
   npm run build -w @harness-anything/cli
+  npm run build -w @harness-anything/daemon
   exit 0
 fi
 
-# CLI triggers are derived from the CLI build program itself (same derivation as
-# post-merge): the package roots tsc compiles for packages/cli/tsconfig.build.json,
-# so adding an upstream source dependency extends the trigger list with the code.
-cli_trigger_roots=$(node_modules/.bin/tsc -p packages/cli/tsconfig.build.json --listFilesOnly \
-  | awk -v root="$repo_root" 'index($0, root "/packages/") == 1 { sub(root "/", ""); split($0, seg, "/"); print seg[1] "/" seg[2] }' | sort -u)
+cli_trigger_paths=$(package_trigger_paths packages/cli)
+daemon_trigger_paths=$(package_trigger_paths packages/daemon)
 
-cli_trigger_paths="package-lock.json package.json packages/cli/package.json packages/cli/tsconfig.build.json packages/cli/scripts/copy-assets.mjs packages/preset/assets"
-for cli_root in $cli_trigger_roots; do
-  cli_trigger_paths="$cli_trigger_paths $cli_root $cli_root/package.json"
-done
+cli_changed_paths=$(git diff --name-only "$parent" HEAD -- $cli_trigger_paths)
+daemon_changed_paths=$(git diff --name-only "$parent" HEAD -- $daemon_trigger_paths)
 
-changed_paths=$(git diff --name-only "$parent" HEAD -- $cli_trigger_paths)
-
-if [ -z "$changed_paths" ]; then
-  echo "post-commit: no CLI source or asset changes; skipping CLI build."
+if [ -z "$cli_changed_paths" ] && [ -z "$daemon_changed_paths" ]; then
+  echo "post-commit: no CLI or daemon source changes; skipping builds."
   exit 0
 fi
 
-echo "post-commit: CLI source or assets changed; rebuilding @harness-anything/cli."
-npm run build -w @harness-anything/cli
+if [ -n "$cli_changed_paths" ]; then
+  echo "post-commit: CLI source, assets, or upstream packages changed; rebuilding @harness-anything/cli."
+  npm run build -w @harness-anything/cli
+fi
+
+if [ -n "$daemon_changed_paths" ]; then
+  echo "post-commit: daemon source or upstream packages changed; rebuilding @harness-anything/daemon."
+  npm run build -w @harness-anything/daemon
+fi

--- a/tools/git-hooks/post-merge
+++ b/tools/git-hooks/post-merge
@@ -4,32 +4,29 @@ set -eu
 # Installed by pointing git at this directory:
 #   git config core.hooksPath tools/git-hooks   (or: npm run hooks:install)
 #
-# Keeps the workspace CLI dist fresh after merges that changed CLI source or
-# bundled assets, so local `ha` shims that point at dist do not go stale.
+# Keeps the workspace CLI, daemon, and GUI dist fresh after merges that changed
+# their sources or bundled assets, so local `ha` shims that point at dist do
+# not go stale and the resident daemon does not run an old build. Fast-forward
+# pulls run this hook too.
 
 repo_root=$(git rev-parse --show-toplevel)
+hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 cd "$repo_root"
+. "$hook_dir/lib.sh"
 
 previous_head=$(git rev-parse --verify ORIG_HEAD 2>/dev/null || true)
 if [ -z "$previous_head" ]; then
-  echo "post-merge: ORIG_HEAD unavailable; rebuilding CLI conservatively."
+  echo "post-merge: ORIG_HEAD unavailable; rebuilding CLI and daemon conservatively."
   npm run build -w @harness-anything/cli
+  npm run build -w @harness-anything/daemon
   exit 0
 fi
 
-# CLI triggers are derived from the CLI build program itself: the package roots tsc
-# compiles for packages/cli/tsconfig.build.json (tsconfig include + every followed
-# import), so adding an upstream source dependency extends the trigger list with the
-# code instead of a second hand-maintained copy that drifts stale.
-cli_trigger_roots=$(node_modules/.bin/tsc -p packages/cli/tsconfig.build.json --listFilesOnly \
-  | awk -v root="$repo_root" 'index($0, root "/packages/") == 1 { sub(root "/", ""); split($0, seg, "/"); print seg[1] "/" seg[2] }' | sort -u)
-
-cli_trigger_paths="package-lock.json package.json packages/cli/package.json packages/cli/tsconfig.build.json packages/cli/scripts/copy-assets.mjs packages/preset/assets"
-for cli_root in $cli_trigger_roots; do
-  cli_trigger_paths="$cli_trigger_paths $cli_root $cli_root/package.json"
-done
+cli_trigger_paths=$(package_trigger_paths packages/cli)
+daemon_trigger_paths=$(package_trigger_paths packages/daemon)
 
 cli_changed_paths=$(git diff --name-only "$previous_head" HEAD -- $cli_trigger_paths)
+daemon_changed_paths=$(git diff --name-only "$previous_head" HEAD -- $daemon_trigger_paths)
 
 # GUI triggers stay an explicit list: the GUI dist is bundled by Vite from relative
 # source imports, and packages/gui's tsconfigs are composite reference projects whose
@@ -50,14 +47,19 @@ gui_changed_paths=$(git diff --name-only "$previous_head" HEAD -- \
   packages/gui/package.json \
   packages/gui/src)
 
-if [ -z "$cli_changed_paths" ] && [ -z "$gui_changed_paths" ]; then
-  echo "post-merge: no CLI, upstream, or GUI source changes; skipping builds."
+if [ -z "$cli_changed_paths" ] && [ -z "$daemon_changed_paths" ] && [ -z "$gui_changed_paths" ]; then
+  echo "post-merge: no CLI, daemon, upstream, or GUI source changes; skipping builds."
   exit 0
 fi
 
 if [ -n "$cli_changed_paths" ]; then
   echo "post-merge: CLI source, assets, or upstream packages changed; rebuilding @harness-anything/cli."
   npm run build -w @harness-anything/cli
+fi
+
+if [ -n "$daemon_changed_paths" ]; then
+  echo "post-merge: daemon source or upstream packages changed; rebuilding @harness-anything/daemon."
+  npm run build -w @harness-anything/daemon
 fi
 
 if [ -n "$gui_changed_paths" ]; then

--- a/tools/rebuild-hooks.test.mjs
+++ b/tools/rebuild-hooks.test.mjs
@@ -1,0 +1,266 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "..");
+const gitShell = process.platform === "win32" ? findGitShell() : "sh";
+const posixShellSkip =
+  process.platform === "win32" && gitShell === null
+    ? "requires Git for Windows' POSIX shell to execute repository hooks"
+    : false;
+
+test("rebuild hooks rebuild only the daemon when daemon-side sources change", { skip: posixShellSkip }, (context) => {
+  const root = makeRebuildRepo(context, "rebuild-daemon-");
+  commitAll(root, "base");
+  writeFileSync(path.join(root, "packages/kernel/src/main.ts"), "kernel v2\n");
+  const kernelChange = commitAll(root, "kernel change");
+  const base = git(root, "rev-parse", "HEAD~1").trim();
+  writeFileSync(path.join(root, "npm.log"), "");
+
+  const result = runHookScript(path.join(root, "tools/git-hooks/post-checkout"), [base, kernelChange, "1"], root);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /rebuilding @harness-anything\/daemon/u);
+  assert.doesNotMatch(result.stdout, /rebuilding @harness-anything\/cli/u);
+  assert.deepEqual(readNpmLog(root), ["@harness-anything/daemon"]);
+});
+
+test("rebuild hooks rebuild only the CLI when CLI-only sources change", { skip: posixShellSkip }, (context) => {
+  const root = makeRebuildRepo(context, "rebuild-cli-");
+  commitAll(root, "base");
+  writeFileSync(path.join(root, "packages/cli/src/main.ts"), "cli v2\n");
+  const cliChange = commitAll(root, "cli change");
+  const base = git(root, "rev-parse", "HEAD~1").trim();
+  writeFileSync(path.join(root, "npm.log"), "");
+
+  const checkout = runHookScript(path.join(root, "tools/git-hooks/post-checkout"), [base, cliChange, "1"], root);
+  assert.equal(checkout.status, 0, checkout.stderr);
+  assert.match(checkout.stdout, /rebuilding @harness-anything\/cli/u);
+  assert.doesNotMatch(checkout.stdout, /rebuilding @harness-anything\/daemon/u);
+
+  const commit = runHookScript(path.join(root, "tools/git-hooks/post-commit"), [], root);
+  assert.equal(commit.status, 0, commit.stderr);
+  assert.match(commit.stdout, /rebuilding @harness-anything\/cli/u);
+
+  assert.deepEqual(readNpmLog(root), ["@harness-anything/cli", "@harness-anything/cli"]);
+});
+
+test("rebuild hooks skip builds when nothing they watch changed", { skip: posixShellSkip }, (context) => {
+  const root = makeRebuildRepo(context, "rebuild-skip-");
+  const base = commitAll(root, "base");
+  writeFileSync(path.join(root, "tools/note.md"), "inert\n");
+  const inert = commitAll(root, "inert change");
+  writeFileSync(path.join(root, "npm.log"), "");
+
+  const checkout = runHookScript(path.join(root, "tools/git-hooks/post-checkout"), [base, inert, "1"], root);
+  assert.equal(checkout.status, 0, checkout.stderr);
+  assert.match(checkout.stdout, /no CLI or daemon source changes; skipping builds/u);
+
+  const commit = runHookScript(path.join(root, "tools/git-hooks/post-commit"), [], root);
+  assert.equal(commit.status, 0, commit.stderr);
+  assert.match(commit.stdout, /no CLI or daemon source changes; skipping builds/u);
+
+  git(root, "update-ref", "ORIG_HEAD", base);
+  const merge = runHookScript(path.join(root, "tools/git-hooks/post-merge"), [], root);
+  assert.equal(merge.status, 0, merge.stderr);
+  assert.match(merge.stdout, /skipping builds/u);
+  assert.deepEqual(readNpmLog(root), []);
+});
+
+test(
+  "post-merge rebuilds the daemon (and GUI) after a daemon-side fast-forward",
+  { skip: posixShellSkip },
+  (context) => {
+    const root = makeRebuildRepo(context, "rebuild-merge-");
+    const base = commitAll(root, "base");
+    writeFileSync(path.join(root, "packages/daemon/src/main.ts"), "daemon v2\n");
+    commitAll(root, "daemon change");
+    writeFileSync(path.join(root, "npm.log"), "");
+
+    git(root, "update-ref", "ORIG_HEAD", base);
+    const result = runHookScript(path.join(root, "tools/git-hooks/post-merge"), [], root);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /rebuilding @harness-anything\/daemon/u);
+    assert.doesNotMatch(result.stdout, /rebuilding @harness-anything\/cli/u);
+    // packages/daemon/src is also on post-merge's explicit GUI trigger list.
+    assert.match(result.stdout, /rebuilding @harness-anything\/gui/u);
+    assert.deepEqual(readNpmLog(root), ["@harness-anything/daemon", "@harness-anything/gui"]);
+  },
+);
+
+test("rebuild hooks work inside a worktree without its own node_modules", { skip: posixShellSkip }, (context) => {
+  const root = makeRebuildRepo(context, "rebuild-worktree-");
+  const base = commitAll(root, "base");
+
+  const worktreeRoot = realpathSync(mkdtempSync(path.join(os.tmpdir(), "rebuild-worktree-wt-")));
+  context.after(() => rmSync(worktreeRoot, { recursive: true, force: true }));
+  const worktreeAdd = spawnSync("git", ["-C", root, "worktree", "add", worktreeRoot, "-b", "linked"], {
+    encoding: "utf8",
+  });
+  assert.equal(worktreeAdd.status, 0, worktreeAdd.stderr);
+  // worktree add performs a checkout too (unborn prev ref): its conservative
+  // rebuild is not what this test asserts.
+  writeFileSync(path.join(worktreeRoot, "npm.log"), "");
+
+  // The linked worktree shares the repository but has no node_modules of its
+  // own; the hooks must still resolve tsc from the main checkout.
+  assert.equal(existsSync(path.join(worktreeRoot, "node_modules")), false);
+
+  writeFileSync(path.join(worktreeRoot, "packages/daemon/src/main.ts"), "daemon v2\n");
+  git(worktreeRoot, "add", "packages", "tools");
+  const commit = spawnSync("git", ["-C", worktreeRoot, "commit", "-q", "-m", "daemon change"], { encoding: "utf8" });
+  assert.equal(commit.status, 0, commit.stderr);
+  assert.deepEqual(readNpmLog(worktreeRoot), ["@harness-anything/daemon"]);
+
+  const checkoutBack = spawnSync("git", ["-C", worktreeRoot, "checkout", "-q", "-b", "back", base], {
+    encoding: "utf8",
+  });
+  assert.equal(checkoutBack.status, 0, checkoutBack.stderr);
+  writeFileSync(path.join(worktreeRoot, "npm.log"), "");
+
+  const checkoutLinked = spawnSync("git", ["-C", worktreeRoot, "checkout", "linked"], { encoding: "utf8" });
+  assert.equal(checkoutLinked.status, 0, checkoutLinked.stderr);
+  // git routes hook output to stderr, so check both streams.
+  const output = checkoutLinked.stdout + checkoutLinked.stderr;
+  assert.doesNotMatch(output, /No such file or directory/u);
+  assert.match(output, /rebuilding @harness-anything\/daemon/u);
+  assert.deepEqual(readNpmLog(worktreeRoot), ["@harness-anything/daemon"]);
+});
+
+// Fixture repository shaped like the minimum the rebuild hooks observe: real
+// npm workspaces whose build scripts record themselves, and a tsc stub in the
+// main checkout's node_modules exactly where lib.sh resolves it. The stub
+// build programs intentionally split cli from daemon+kernel so the two trigger
+// derivations can be asserted independently.
+function makeRebuildRepo(context, prefix) {
+  const root = realpathSync(mkdtempSync(path.join(os.tmpdir(), prefix)));
+  context.after(() => rmSync(root, { recursive: true, force: true }));
+  git(root, "init", "-q");
+  git(root, "config", "user.email", "hook-test@example.invalid");
+  git(root, "config", "user.name", "Hook Test");
+
+  writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify(
+      { name: "rebuild-hooks-fixture", private: true, workspaces: ["packages/cli", "packages/daemon", "packages/gui"] },
+      null,
+      2,
+    ),
+  );
+  for (const [workspace, script] of [
+    ["packages/cli", "node ../../tools/record-build.mjs @harness-anything/cli"],
+    ["packages/daemon", "node ../../tools/record-build.mjs @harness-anything/daemon"],
+    ["packages/gui", "node ../../tools/record-build.mjs @harness-anything/gui"],
+  ]) {
+    mkdirSync(path.join(root, workspace), { recursive: true });
+    writeFileSync(
+      path.join(root, workspace, "package.json"),
+      JSON.stringify(
+        { name: `@harness-anything/${path.basename(workspace)}`, private: true, scripts: { build: script } },
+        null,
+        2,
+      ),
+    );
+    writeFileSync(
+      path.join(root, workspace, "tsconfig.build.json"),
+      JSON.stringify({ include: ["src/**/*.ts"] }, null, 2),
+    );
+  }
+  for (const source of ["packages/cli/src/main.ts", "packages/daemon/src/main.ts", "packages/kernel/src/main.ts"]) {
+    mkdirSync(path.dirname(path.join(root, source)), { recursive: true });
+    writeFileSync(path.join(root, source), "v1\n");
+  }
+
+  mkdirSync(path.join(root, "node_modules/.bin"), { recursive: true });
+  writeFileSync(
+    path.join(root, "node_modules/.bin/tsc"),
+    [
+      "#!/bin/sh",
+      "root=$(pwd -P)",
+      'case "${2-}" in',
+      "  packages/cli/tsconfig.build.json)",
+      "    printf '%s\\n' \"$root/packages/cli/src/main.ts\"",
+      "    ;;",
+      "  packages/daemon/tsconfig.build.json)",
+      '    printf \'%s\\n\' "$root/packages/daemon/src/main.ts" "$root/packages/kernel/src/main.ts"',
+      "    ;;",
+      "esac",
+      "",
+    ].join("\n"),
+  );
+  chmodSync(path.join(root, "node_modules/.bin/tsc"), 0o755);
+
+  const hooks = path.join(root, "tools/git-hooks");
+  mkdirSync(hooks, { recursive: true });
+  for (const name of ["post-checkout", "post-commit", "post-merge", "lib.sh"]) {
+    copyFileSync(path.join(repositoryRoot, "tools/git-hooks", name), path.join(hooks, name));
+    chmodSync(path.join(hooks, name), 0o755);
+  }
+  writeFileSync(
+    path.join(root, "tools/record-build.mjs"),
+    [
+      'import { appendFileSync } from "node:fs";',
+      'appendFileSync(new URL("../npm.log", import.meta.url), `${process.argv[2]}\\n`);',
+      "",
+    ].join("\n"),
+  );
+  // Setup commits silence hooks so incidental rebuilds do not pay npm startup
+  // on every fixture; the tests under assertion fire hooks explicitly.
+  mkdirSync(path.join(root, "no-hooks"));
+  // The real repository points core.hooksPath at the main checkout with an
+  // absolute path, so linked worktrees fire the main checkout's hooks too.
+  git(root, "config", "core.hooksPath", path.join(root, "tools/git-hooks"));
+  return root;
+}
+
+function readNpmLog(root) {
+  const log = path.join(root, "npm.log");
+  return existsSync(log) ? readFileSync(log, "utf8").split(/\r?\n/u).filter(Boolean) : [];
+}
+
+function commitAll(root, message) {
+  git(root, "add", "package.json", "packages", "tools");
+  git(root, "-c", `core.hooksPath=${path.join(root, "no-hooks")}`, "commit", "--quiet", "-m", message);
+  return git(root, "rev-parse", "HEAD").trim();
+}
+
+function runHookScript(script, args, root) {
+  return spawnSync(
+    process.platform === "win32" ? gitShell : script,
+    process.platform === "win32" ? [script, ...args] : args,
+    { cwd: root, encoding: "utf8" },
+  );
+}
+
+function git(root, ...args) {
+  return execFileSync("git", ["-C", root, ...args], { encoding: "utf8" });
+}
+
+function findGitShell() {
+  const result = execFileSync("where.exe", ["git.exe"], { encoding: "utf8" });
+  for (const gitPath of result
+    .split(/\r?\n/u)
+    .map((value) => value.trim())
+    .filter(Boolean)) {
+    const root = path.resolve(path.dirname(gitPath), "..");
+    for (const candidate of [path.join(root, "bin", "sh.exe"), path.join(root, "usr", "bin", "sh.exe")]) {
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
# English

## Summary

The git hooks (post-checkout / post-commit / post-merge) only rebuilt the CLI package, so every deploy that fast-forwarded main had to be followed by a manual `npm run build -w @harness-anything/daemon` or the daemon failed to start (MODULE_NOT_FOUND on packages/daemon/dist/index.js; two incidents on 2026-09-12). The hooks also resolved `node_modules/.bin/tsc` relative to the working tree, which does not exist in a fresh worktree (task_77abbd46). The three hooks now share one library that derives each package's trigger paths from `tsc --listFilesOnly` on its build tsconfig, rebuild the daemon package under the same rule as the CLI, and resolve tsc from the main checkout (`git rev-parse --git-common-dir`).

## Architectural Justification

One rule for both packages, derived from the compiler's own file list instead of a second hand-written dependency map.

## What Changed

- `tools/git-hooks/lib.sh` (new): `main_root`/`hook_tsc` resolution and `package_trigger_paths <package-dir>` (trigger set = package.json/lock/tsconfig/assets plus every workspace package the build actually includes).
- `tools/git-hooks/post-checkout`, `post-commit`, `post-merge`: source the lib, compute CLI and daemon trigger sets, rebuild whichever changed; initial checkout rebuilds both.
- `tools/rebuild-hooks.test.mjs` (fast tier): five cases covering daemon-only change, CLI-only change, kernel change (both), no-op, and tsc resolution from a worktree.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +97/-52 in tools/git-hooks (shell hooks + shared lib); tests +266/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_d57a17c1620803483bc1c6d84c (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/hook-build-daemon`
- Public scope: developer git hooks under tools/git-hooks and their test; no runtime code.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: CI workflows and packages/** untouched; the hooks are not part of any CI gate.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/hook-build-daemon`
- Private evidence commit/path: task_d57a17c1620803483bc1c6d84c `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node tools/run-node-tests.mjs --file tools/rebuild-hooks.test.mjs` exit 0 (5/5; CEO re-run); line-density G36 pass; check-file-complexity clean. Worker also ran the fast tier: 744/749 with the 5 failures reproduced identically on clean origin/main (environment-bound, pr-merge.test.mjs). End-to-end `ha daemon start --service` after a real checkout is verified by the CEO on the next deploy, not by the worker (production daemon is out of the worker's isolation scope).

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Each hook run now invokes `tsc --listFilesOnly` twice (CLI + daemon), adding a few seconds per checkout; accepted over a hand-maintained path list that would drift.

## References

- Task: task_d57a17c1620803483bc1c6d84c

---

# 中文

## 概要

git hooks（post-checkout / post-commit / post-merge）只重建 CLI 包，每次 ff main 部署后都得手跑 `npm run build -w @harness-anything/daemon`，否则 daemon 起不来（packages/daemon/dist/index.js MODULE_NOT_FOUND，2026-09-12 两次）。hooks 还按工作树相对路径找 `node_modules/.bin/tsc`，在新 worktree 里不存在（task_77abbd46）。现在三个 hook 共用一个库：用 `tsc --listFilesOnly` 从各包 build tsconfig 推导触发路径，daemon 与 CLI 同一条规则重建，tsc 从主检出（`git rev-parse --git-common-dir`）解析。

## 架构辩护

两个包一条规则，从编译器自己的文件清单推导，不再手写第二份依赖图。

## 改动内容

- `tools/git-hooks/lib.sh`（新）：`main_root`/`hook_tsc` 解析与 `package_trigger_paths <package-dir>`（触发集 = package.json/lock/tsconfig/assets + 构建实际包含的各 workspace 包）。
- `post-checkout`、`post-commit`、`post-merge`：引用该库，分别算 CLI/daemon 触发集，变了哪个建哪个；首次检出两个都建。
- `tools/rebuild-hooks.test.mjs`（fast 层）：五个用例——只改 daemon、只改 CLI、改 kernel（两个都建）、无关改动、worktree 内 tsc 解析。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+97/-52 in tools/git-hooks (shell hooks + shared lib); tests +266/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_d57a17c1620803483bc1c6d84c（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/hook-build-daemon`
- 公开范围：tools/git-hooks 下的开发者 hooks 及其测试；不碰运行时代码。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：CI 工作流与 packages/** 不动；hooks 不属于任何 CI 门。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/hook-build-daemon`
- 私有证据路径：task_d57a17c1620803483bc1c6d84c 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node tools/run-node-tests.mjs --file tools/rebuild-hooks.test.mjs` exit 0（5/5，CEO 复跑）；line-density G36 pass；check-file-complexity 干净。worker 另跑 fast 层 744/749，5 个失败在干净 origin/main 上同样复现（环境相关，pr-merge.test.mjs）。真实检出后 `ha daemon start --service` 的端到端由 CEO 在下次部署时验证（生产 daemon 不在 worker 隔离范围内）。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 每次 hook 多跑两次 `tsc --listFilesOnly`（CLI + daemon），每次检出多几秒；换取不再手维护会漂移的路径清单。

## 参考

- 任务：task_d57a17c1620803483bc1c6d84c

