### PR TITLE
fix: judge closeout readiness with the effective gate set on read faces

### DIFF
--- a/packages/application/src/task-action-explanation-service.ts
+++ b/packages/application/src/task-action-explanation-service.ts
@@ -7,6 +7,7 @@ import {
   type ActorIdentity,
   type AuthorizationDecision,
   type BaseEntity,
+  type CloseoutGate,
   type EntityActionContract,
   type EntityActionCriterionExplanationV1,
   type EntityActionExplanationSetV1,
@@ -30,6 +31,7 @@ export interface TaskActionExplanationObjectInput {
   readonly entity: BaseEntity<"task">;
   readonly snapshot: TaskLifecycleSnapshot;
   readonly evaluatedAtCut: string;
+  readonly closeoutGates?: Readonly<Record<CloseoutGate, boolean>>;
 }
 
 export interface TaskActionExplanationService {
@@ -126,10 +128,12 @@ function objectRow(
   dependencies: TaskActionExplanationServiceDependencies,
 ): EntityActionExplanationV1 {
   const evaluated = new Map(
-      evaluateTaskActionCapability({ action, snapshot: input.snapshot, actor: dependencies.actor }).map((criterion) => [
-        criterion.criterionRef,
-        criterion,
-      ]),
+      evaluateTaskActionCapability({
+        action,
+        snapshot: input.snapshot,
+        actor: dependencies.actor,
+        closeoutGates: input.closeoutGates,
+      }).map((criterion) => [criterion.criterionRef, criterion]),
     ),
     criteria = Object.freeze(
       action.criteria.map((criterion): EntityActionCriterionExplanationV1 => {

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -84,7 +84,7 @@ import {
 } from "./repo-cell-authorization.ts";
 import { admitRepoMode, entityActionCommandTopology } from "./repo-mode.ts";
 import { makeTaskQueryReadModel } from "./task-query-read.ts";
-import { chainRepoCellWrite, repoCellTaskQueryJudgments } from "./repo-cell.ts";
+import { chainRepoCellWrite, repoCellTaskQueryJudgmentsFor } from "./repo-cell.ts";
 import { executeVerticalScriptAction, publishExecutedVerticalScript } from "./vertical-script-actions.ts";
 import { deriveActionResult } from "./entity-action-catalog-executor.ts";
 import { workspaceSummaryFromProjection } from "./workspace-summary-read.ts";
@@ -932,7 +932,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
     makeTaskQueryReadModel({
       rootDir: context.rootDir,
       projection: context.projection,
-      judgments: repoCellTaskQueryJudgments,
+      judgments: repoCellTaskQueryJudgmentsFor(context.projection),
     });
   Object.assign(context.extracted, { taskListQueryFromAction, queryRead, relationQueryFromAction });
   // The runtime publication turn verifies any executor claim before it authorizes and executes.

--- a/packages/daemon/src/repo-cell-proxy.ts
+++ b/packages/daemon/src/repo-cell-proxy.ts
@@ -32,7 +32,7 @@ import { requiredCellText } from "./repo-cell-settlement.ts";
 import { makeRepoCellSettingsState } from "./repo-cell-settings-state.ts";
 import { listTasks, type TaskQueryCell } from "./repo-cell-task-query.ts";
 import type { RepoCell, RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
-import { repoCellTaskQueryJudgments } from "./repo-cell.ts";
+import { repoCellTaskQueryJudgmentsFor } from "./repo-cell.ts";
 import { makeSquadCoordinator } from "./squad-coordinator.ts";
 import { makeTaskQueryReadModel } from "./task-query-read.ts";
 import { openWriterSupervisor } from "./writer-supervisor.ts";
@@ -289,7 +289,7 @@ export async function openRepoCellProxy(
           makeTaskQueryReadModel({
             rootDir: input.rootDir,
             projection: projection as TaskProjection,
-            judgments: repoCellTaskQueryJudgments,
+            judgments: repoCellTaskQueryJudgmentsFor(projection),
           }).guiTasks(taskListQuery(payload)),
         ) as never;
       return query((projection) => readAtCut(projection, method, payload, binding)) as never;

--- a/packages/daemon/src/repo-cell-settings-state.ts
+++ b/packages/daemon/src/repo-cell-settings-state.ts
@@ -3,6 +3,8 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import {
   consumeKnownError,
+  DEFAULT_CLOSEOUT_SETTINGS,
+  effectiveCloseoutGates,
   INITIAL_SETTINGS_V1,
   SETTINGS_LOCAL_PATH,
   compileSettingsChangedEvent,
@@ -13,9 +15,12 @@ import {
   serializeLocalSettings,
   validateRepositorySettings,
   writeRepositorySettingsFacet,
+  type CloseoutGate,
+  type CloseoutSettingsV1,
   type RepositorySettingsV1,
   type SettingsLocale,
   type SettingsV1,
+  type TaskProjectionQueries,
 } from "../../kernel/src/index.ts";
 import { writeFileDurably } from "./durable-file.ts";
 import type { RepoCellActionContext, RepoCellSettingsState } from "./repo-cell-action-context.ts";
@@ -103,4 +108,19 @@ export function makeRepoCellSettingsState(cell: RepoCellActionContext): RepoCell
   };
 
   return { initialize, initializeFromAuthoredDocument, read, readRepository, writeLocal };
+}
+
+/**
+ * The effective closeout gate set for read-side judgments. Reads the settings facet from
+ * the same projection cut as the task being judged; a repository with no settings entity
+ * (or a pre-closeout settings event) reads the same standard default bootstrap would mint.
+ */
+export function readEffectiveCloseoutGates(
+  projection: Pick<TaskProjectionQueries, "getEntity">,
+  taskGateIds: readonly string[],
+): Readonly<Record<CloseoutGate, boolean>> {
+  const projected = projection.getEntity("settings", "repository")?.value as
+    | { readonly closeout?: CloseoutSettingsV1 }
+    | undefined;
+  return effectiveCloseoutGates(projected?.closeout ?? DEFAULT_CLOSEOUT_SETTINGS, taskGateIds);
 }

--- a/packages/daemon/src/repo-cell-task-progress.ts
+++ b/packages/daemon/src/repo-cell-task-progress.ts
@@ -351,8 +351,7 @@ export async function completeTask(
       cell.completeRetryCommand(taskId, executionId, action),
     ),
   );
-  const closeout = cell.settings.readRepository().closeout,
-    closeoutGates = effectiveCloseoutGates(closeout, initial.snapshot.task?.completionGateIds),
+  const closeoutGates = preparedContext.closeoutGates!,
     codeDoc =
       closeoutGates.codeDoc && submittedExecution?.submission?.commitSha
         ? verifyCodeDocCommitPaths({ rootDir: cell.rootDir, commitSha: submittedExecution.submission.commitSha, paths })

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -50,7 +50,7 @@ export function repoCellTaskQueryJudgmentsFor(projection: TaskProjectionQueries)
         availability,
         readEffectiveCloseoutGates(projection, snapshot.task?.completionGateIds ?? []),
       ),
-    blocking: blockingOf,
+    blocking: (tasks, relations, state) => blockingOf(tasks, relations, state),
   };
 }
 

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -9,6 +9,7 @@ import {
   makeTaskEventStore,
   makeTaskProjection,
   type DaemonRepoMode,
+  type TaskProjectionQueries,
 } from "../../kernel/src/index.ts";
 import { makeAgentRuntimeReadModel } from "./agent-runtime-read.ts";
 import {
@@ -20,6 +21,7 @@ import {
 import { makeEntityActionCatalogExecutor } from "./entity-action-catalog-executor.ts";
 import { openReplicaCutSource } from "./fleet/replica-cut-store.ts";
 import { cellErrorCode, cellErrorMessage } from "./repo-cell-errors.ts";
+import { readEffectiveCloseoutGates } from "./repo-cell-settings-state.ts";
 import type { DaemonLifecycleRecorder } from "./lifecycle-log.ts";
 import type { RepoCellAttachProgress, RepoCellBinding } from "./repo-cell-types.ts";
 import { resolveWriteSessionIdentity } from "./session-identity/index.ts";
@@ -39,10 +41,18 @@ export type {
   RuntimeIngressAction,
 } from "./repo-cell-types.ts";
 
-export const repoCellTaskQueryJudgments: TaskQueryJudgments = {
-  closeout: (snapshot, availability) => closeoutReadiness(snapshot, availability),
-  blocking: (tasks, relations, state) => blockingOf(tasks, relations, state),
-};
+/** Read judgments bound to one projection cut: the closeout verdict follows the effective gate set. */
+export function repoCellTaskQueryJudgmentsFor(projection: TaskProjectionQueries): TaskQueryJudgments {
+  return {
+    closeout: (snapshot, availability) =>
+      closeoutReadiness(
+        snapshot,
+        availability,
+        readEffectiveCloseoutGates(projection, snapshot.task?.completionGateIds ?? []),
+      ),
+    blocking: blockingOf,
+  };
+}
 
 export interface RepoCellCoreInput {
   readonly input: {

--- a/packages/daemon/src/task-action-catalog-runtime.ts
+++ b/packages/daemon/src/task-action-catalog-runtime.ts
@@ -10,6 +10,7 @@ import {
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
 import { actionCriterionFailure, attributeCellCriterion } from "./repo-cell-errors.ts";
+import { readEffectiveCloseoutGates } from "./repo-cell-settings-state.ts";
 import { assertCurrentSubmittedExecution } from "./repo-cell-execution-selection.ts";
 import { leaseTtlMs, type RepoCellBinding, type RepoTaskAction, type Snapshot } from "./repo-cell-types.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
@@ -38,6 +39,7 @@ export async function runTaskActionCatalogRuntime(
             action: contract,
             snapshot: current.snapshot,
             actor: binding.actor,
+            closeoutGates: readEffectiveCloseoutGates(cell.projection, current.snapshot.task?.completionGateIds ?? []),
             invocation: {
               taskId,
               ...(typeof action.executionId === "string" ? { executionId: action.executionId } : {}),

--- a/packages/daemon/src/task-action-explanation-read.ts
+++ b/packages/daemon/src/task-action-explanation-read.ts
@@ -30,6 +30,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { authorizeRepoCellAction } from "./repo-cell-authorization.ts";
 import { compiledArtifactKinds } from "./artifact-entity-action.ts";
+import { readEffectiveCloseoutGates } from "./repo-cell-settings-state.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 
 export interface TaskActionExplanationReadDependencies {
@@ -230,7 +231,12 @@ export function readTaskActionExplanation(
               pinned: task.pinned,
               disposition: task.packageDisposition ?? "active",
             });
-          subject = taskService.object({ entity: entityWitness, snapshot, evaluatedAtCut: cut }).subjects[0]!;
+          subject = taskService.object({
+            entity: entityWitness,
+            snapshot,
+            evaluatedAtCut: cut,
+            closeoutGates: readEffectiveCloseoutGates(dependencies.projection, task.completionGateIds),
+          }).subjects[0]!;
         }
       } else {
         const row = dependencies.projection.getEntity("squad", entity.id),

--- a/packages/daemon/src/task-completion-read.ts
+++ b/packages/daemon/src/task-completion-read.ts
@@ -9,6 +9,7 @@ import {
   type TaskProjectionQueries,
 } from "../../kernel/src/index.ts";
 import { readTaskTransitionDocument } from "./transition-document-access.ts";
+import { readEffectiveCloseoutGates } from "./repo-cell-settings-state.ts";
 
 /** Explicit --consent is recorded under every profile; the profile only decides whether absence blocks. */
 export function completionBlockersForAction(
@@ -60,6 +61,7 @@ export function readCompletionContext(
     closeout: assessment.ready ? "ready" : "placeholder",
     closeoutPath: document.path,
     closeoutMissingSections: assessment.missingSections,
+    closeoutGates: readEffectiveCloseoutGates(projection, snapshot.task?.completionGateIds ?? []),
     eligibleDirtyPaths: [],
     producesFactCount: facts.rows.filter((row) => row.targetRef.startsWith("fact/")).length,
     projectionStatus: facts.status,

--- a/packages/daemon/test/closeout-profile-read.test.ts
+++ b/packages/daemon/test/closeout-profile-read.test.ts
@@ -1,0 +1,80 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  reduceTaskEvent,
+  taskCompletionNext,
+  type CloseoutSettingsV1,
+  type TaskLifecycleSnapshot,
+  type TaskProjectionQueries,
+} from "../../kernel/src/index.ts";
+import { lifecycleFixture } from "../../kernel/test/store/task-lifecycle-fixture.ts";
+import { repoCellTaskQueryJudgmentsFor } from "../src/repo-cell.ts";
+import { readCompletionContext } from "../src/task-completion-read.ts";
+
+const submitted: TaskLifecycleSnapshot = lifecycleFixture().events.slice(0, 3).reduce(reduceTaskEvent, {
+  revision: 0,
+  task: null,
+  executions: [],
+  reviews: [],
+  consents: [],
+  codeDocWitnesses: [],
+  gateWitnesses: [],
+  edgesTaken: [],
+  lease: null,
+});
+
+/** Settings-facet-aware read projection stub: one submitted unreviewed in_review cut and a valid closeout. */
+function projection(closeout: CloseoutSettingsV1 | null): TaskProjectionQueries {
+  return {
+    read: () => ({
+      snapshot: submitted,
+      packagePath: "harness/tasks/task-1",
+      status: "ready",
+      watermark: 2,
+      sourceRevision: 2,
+    }),
+    readDocument: (target: string) => ({
+      watermark: 2,
+      sourceRevision: 2,
+      document: {
+        path: target,
+        blobSha256: "0".repeat(64),
+        workspaceRevision: 2,
+        body: target.endsWith("task-contract.json")
+          ? JSON.stringify({ documents: [{ slot: "task.closeout", path: "closeout.md" }] })
+          : "## Summary\nDelivered.\n## Verification\nVerified.\n## Residual Risk\nNone.\n" +
+            "## Same Mechanism Elsewhere\nChecked.\n",
+      },
+    }),
+    readRelationQuery: () => ({ rows: [{ targetRef: "fact/f-read-side", state: "active" }], status: "ready" }),
+    getEntity: (kind: string, id: string) =>
+      kind === "settings" && id === "repository" && closeout ? { value: { closeout } } : null,
+  } as unknown as TaskProjectionQueries;
+}
+
+test("standard profile read side reports no closed-gate completion blockers", () => {
+  const context = readCompletionContext(projection({ profile: "standard" }), "task-1", submitted, "ready");
+  assert.deepEqual(context.closeoutGates, { review: false, consent: false, factDisposition: false, codeDoc: false });
+  assert.equal(taskCompletionNext(submitted, context).blocker, null);
+});
+
+test("strict profile read side keeps demanding review and consent", () => {
+  const context = readCompletionContext(projection({ profile: "strict" }), "task-1", submitted, "ready");
+  assert.deepEqual(context.closeoutGates, { review: true, consent: true, factDisposition: true, codeDoc: true });
+  assert.equal(taskCompletionNext(submitted, context).blocker?.code, "review_missing");
+});
+
+test("a repository without a settings entity reads the standard default gates", () => {
+  const context = readCompletionContext(projection(null), "task-1", submitted, "ready");
+  assert.equal(taskCompletionNext(submitted, context).blocker, null);
+});
+
+test("the task query closeout judgment follows the effective gate set", () => {
+  const availability = { consents: "known", codeDocWitnesses: "known", gateWitnesses: "known" } as const,
+    standard = repoCellTaskQueryJudgmentsFor(projection({ profile: "standard" })).closeout(submitted, availability),
+    strict = repoCellTaskQueryJudgmentsFor(projection({ profile: "strict" })).closeout(submitted, availability);
+  assert.equal(standard.readiness, "ready");
+  assert.equal(strict.readiness, "incomplete");
+  assert.equal(strict.blocker, "review");
+});

--- a/packages/daemon/test/repo-cell-task-progress-evidence.test.ts
+++ b/packages/daemon/test/repo-cell-task-progress-evidence.test.ts
@@ -448,6 +448,7 @@ test("complete without a code-doc witness stops on code_doc_missing under its ow
         eligibleDirtyPaths: [],
         producesFactCount: 1,
         projectionStatus: "ready",
+        closeoutGates: { review: false, consent: false, factDisposition: false, codeDoc: true },
       },
       cell = {
         rootDir: root,
@@ -463,6 +464,7 @@ test("complete without a code-doc witness stops on code_doc_missing under its ow
         service: { read: async () => read },
         projection: {
           read: () => read,
+          getEntity: () => null,
           readTaskCompletion: () => null,
           readRelationQuery: (query: { readonly relationType?: string }) =>
             query.relationType === "produces"
@@ -556,6 +558,7 @@ test("completed receipt replay does not inspect a newer red or unavailable CI ob
   });
   Object.assign(prepared.cell.projection, {
     read: () => read,
+    getEntity: () => null,
     readTaskCompletion: () => completedEvent,
     readCiRunObservations: () => {
       assert.fail("completed replay must not read newer CI observations");

--- a/packages/daemon/test/task-query-read.test.ts
+++ b/packages/daemon/test/task-query-read.test.ts
@@ -497,6 +497,7 @@ test("single-task completion read carries the canonical next and validates its r
         reads.push(id);
         return { ...readyCut, snapshot, packagePath: "tasks/task-1" };
       },
+      getEntity: () => null,
       readDocument: (documentPath: string) => ({
         ...readyCut,
         document: {

--- a/packages/kernel/src/domain/completion-readiness.ts
+++ b/packages/kernel/src/domain/completion-readiness.ts
@@ -1,6 +1,5 @@
 import type { TaskLifecycleSnapshot } from "./task-lifecycle.contract.ts";
 import { closeoutReadiness, currentExecutionCuts, lineageOrphan } from "./closeout-readiness.ts";
-import { approvedReviewsForExecution } from "./review.ts";
 import type { TransitionDocumentMissingSection } from "./transition-document-readiness.ts";
 import type { CloseoutGate } from "./settings-closeout.ts";
 
@@ -165,8 +164,8 @@ function evaluateCompletion(
       `ha task release ${task.taskId}`,
       "The held execution lease must be released by its current holder.",
     );
-  const assessment = closeoutReadiness(snapshot),
-    closeoutGates = context.closeoutGates ?? { review: true, consent: true, factDisposition: true, codeDoc: true };
+  const closeoutGates = context.closeoutGates ?? { review: true, consent: true, factDisposition: true, codeDoc: true },
+    assessment = closeoutReadiness(snapshot, undefined, closeoutGates);
   const gate = assessment.gates.find(
     ({ gateId, status }) =>
       status !== "passed" &&
@@ -221,15 +220,16 @@ function evaluateCompletion(
       "Publish eligible closeout and artifact edits through doc-sync.",
     );
   if (!includeReview) return [];
-  const approved = approvedReviewsForExecution(snapshot.reviews, execution);
-  if (closeoutGates.review && approved.length === 0)
+  // The assessment already carries the gate judgment; re-deriving review or consent here
+  // would duplicate the one closeout-readiness decision.
+  if (assessment.blocker === "review")
     return one(
       "review_missing",
       "review",
       `ha task complete ${task.taskId}`,
       "Dispatch an independent reviewer for the current submitted cut.",
     );
-  if (closeoutGates.consent && assessment.blocker === "consent")
+  if (assessment.blocker === "consent")
     return one(
       "consent_missing",
       "consent",

--- a/packages/kernel/src/domain/index.ts
+++ b/packages/kernel/src/domain/index.ts
@@ -272,7 +272,8 @@ export {
   writeRepositorySettingsFacet,
 } from "./settings.ts";
 export type { RepositorySettingsV1, SettingsLocale, SettingsV1 } from "./settings.ts";
-export { effectiveCloseoutGates } from "./settings-closeout.ts";
+export { DEFAULT_CLOSEOUT_SETTINGS, effectiveCloseoutGates } from "./settings-closeout.ts";
+export type { CloseoutGate, CloseoutSettingsV1 } from "./settings-closeout.ts";
 export { compileSettingsChangedEvent, isSettingsEvent } from "./settings-event.ts";
 export {
   applyVerticalKindCommand,

--- a/packages/kernel/src/domain/task-action-capability.ts
+++ b/packages/kernel/src/domain/task-action-capability.ts
@@ -8,6 +8,7 @@ import { revisionIssues } from "./task-lifecycle-contract-support.ts";
 import type { TaskLifecycleCommand } from "./task-lifecycle.contract.ts";
 import type { TaskLifecycleSnapshot } from "./task-lifecycle-contract-internal-types.ts";
 import type { ActorIdentity } from "./actor-identity.ts";
+import type { CloseoutGate } from "./settings-closeout.ts";
 
 export interface TaskActionCapabilityCriterionResult {
   readonly criterionRef: string;
@@ -20,6 +21,8 @@ export interface TaskActionCapabilityInput {
   readonly snapshot: TaskLifecycleSnapshot;
   readonly actor: ActorIdentity;
   readonly invocation?: TaskActionCapabilityInvocation;
+  /** The effective closeout gate set; absent means the strict read every gate still demands. */
+  readonly closeoutGates?: Readonly<Record<CloseoutGate, boolean>>;
 }
 
 export interface TaskActionCapabilityInvocation {
@@ -87,7 +90,8 @@ const taskCapabilityEvaluators = Object.freeze(
     [key("complete", "task-lifecycle-contract-support/revisionIssues"), revisionCurrent],
     [
       key("complete", "closeout-readiness/closeoutReadiness"),
-      ({ snapshot }) => (closeoutReadiness(snapshot).readiness === "ready" ? "met" : "unmet"),
+      ({ snapshot, closeoutGates }) =>
+        closeoutReadiness(snapshot, undefined, closeoutGates).readiness === "ready" ? "met" : "unmet",
     ],
     [
       key("complete", "task-lifecycle-review-transitions/complete.validate"),

--- a/packages/kernel/test/contracts/closeout-profile-completion.test.ts
+++ b/packages/kernel/test/contracts/closeout-profile-completion.test.ts
@@ -1,7 +1,13 @@
 // harness-test-tier: contract
 import assert from "node:assert/strict";
 import test from "node:test";
-import { reduceTaskEvent, type TaskEventV1, type TaskLifecycleSnapshot } from "../../src/index.ts";
+import {
+  evaluateTaskActionCapability,
+  getExecutableEntityAction,
+  reduceTaskEvent,
+  type TaskEventV1,
+  type TaskLifecycleSnapshot,
+} from "../../src/index.ts";
 import {
   applyTransition,
   normalizeTaskLifecycleCommand,
@@ -96,4 +102,16 @@ test("legacy completion replay without recorded gates still demands consent", ()
   assert.equal(fixture.events[5]!.type, "task_completed");
   assert.equal(reduceTaskEvent(snapshot, legacy).task?.status, "done");
   assert.throws(() => reduceTaskEvent({ ...snapshot, consents: [] }, legacy), /accepted task and execution state/u);
+});
+
+test("read-side complete capability follows the effective closeout gate set", () => {
+  const action = getExecutableEntityAction("task-complete");
+  if (!action) throw new Error("The task-complete Action contract is unavailable.");
+  const readiness = (closeoutGates?: typeof standardGates) =>
+    evaluateTaskActionCapability({ action, snapshot: snapshotAfter(3), actor: implementer, closeoutGates }).find(
+      ({ criterionRef }) => criterionRef === "closeout-readiness/closeoutReadiness",
+    )!.status;
+  assert.equal(readiness(standardGates), "met");
+  assert.equal(readiness(strictGates), "unmet");
+  assert.equal(readiness(undefined), "unmet", "a caller that passes no gate set keeps the strict read");
 });


### PR DESCRIPTION
# English

## Summary

After PR #2575 the kernel completion transition judges against the effective closeout gate set, but the read faces still judged with the strict set: on a `standard` repository an in_review task showed a consent/review blocker in `ha task show` completion-next, the action-capability `closeoutReadiness` criterion and the task query judgments even though `ha task complete` succeeded. The read faces now receive the same effective gate set (resolved once from repository settings plus the task's own gate ids) and `closeoutReadiness` takes it as an explicit argument; the duplicated review re-derivation in the completion evaluator is deleted because the readiness assessment already carries that judgment. Strict repositories see no change.

## Architectural Justification

Reads and writes now share one gate-set resolution; the removed duplicate check is the deletion that makes the two faces unable to disagree.

## What Changed

- `packages/kernel/src/domain/completion-readiness.ts`, `task-action-capability.ts`: `closeoutReadiness(snapshot, …, closeoutGates)`; the capability criterion passes the gate set through; the separate `approvedReviewsForExecution` re-check is removed.
- `packages/daemon/src/repo-cell-settings-state.ts` (new, 20 lines): one place that resolves the effective gate set for a task from the settings facet; `repo-cell.ts`, `repo-cell-api.ts`, `repo-cell-proxy.ts`, `task-completion-read.ts`, `task-action-explanation-read.ts`, `task-action-catalog-runtime.ts` thread it into the read paths; `packages/application/src/task-action-explanation-service.ts` accepts it.
- Tests: new `packages/daemon/test/closeout-profile-read.test.ts` (standard repository: no blocker on the read faces; strict: unchanged), extended `closeout-profile-completion.test.ts`, one assertion each in `task-query-read` and `repo-cell-task-progress-evidence`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +71/-23 production; tests +103/-1.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_f81158d6601e10b330a388b5d4 (parent task_9e96326a111f8e1380df3500e8)
- Branch: `codex/read-side-gates`
- Public scope: kernel completion readiness, daemon read faces and their tests.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: GUI rendering and CLI presentation untouched; write path (#2575) unchanged.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/read-side-gates`
- Private evidence commit/path: task_f81158d6601e10b330a388b5d4 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO re-run after delivery: `tsc -b` clean, line-density G36 pass, check-file-complexity clean, `run-node-tests --file` on closeout-profile-read, closeout-profile-completion, task-query-read, repo-cell-task-progress-evidence exit 0. Worker: 12 touched test files individually exit 0, `tools/gates/test/task-lifecycle-transitions.test.mjs` 7/7, integration files through the isolated dispatcher (ubuntu) exit 0, typecheck/lint/test-selection/run-manifest-gates exit 0.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- None known beyond the new settings-state resolver being one more call on read paths; it reads the already-loaded settings facet.

## References

- Task: task_f81158d6601e10b330a388b5d4

---

# 中文

## 概要

PR #2575 之后 kernel 的完成转换按有效 closeout 门集判定，但读侧仍按 strict 集判：`standard` 仓库上 in_review 任务在 `ha task show` 的 completion-next、action-capability 的 `closeoutReadiness` criterion 与任务查询判断里仍显示 consent/review blocker，而 `ha task complete` 实际能过。现在读侧拿到同一有效门集（由仓库设置 + 任务自身门 id 解析一次），`closeoutReadiness` 显式接收它；完成评估器里重复的 review 再推导删掉——readiness 评估已经带了这个判断。strict 仓库不变。

## 架构辩护

读写共用一套门集解析；删掉的重复检查正是让两面无法再不一致的那一刀。

## 改动内容

- `packages/kernel/src/domain/completion-readiness.ts`、`task-action-capability.ts`：`closeoutReadiness(snapshot, …, closeoutGates)`；capability criterion 透传门集；删除单独的 `approvedReviewsForExecution` 复查。
- `packages/daemon/src/repo-cell-settings-state.ts`（新，20 行）：从 settings facet 为任务解析有效门集的唯一位置；`repo-cell.ts`、`repo-cell-api.ts`、`repo-cell-proxy.ts`、`task-completion-read.ts`、`task-action-explanation-read.ts`、`task-action-catalog-runtime.ts` 把它接进读路径；`packages/application/src/task-action-explanation-service.ts` 接收。
- 测试：新 `packages/daemon/test/closeout-profile-read.test.ts`（standard 仓库读侧无 blocker；strict 不变），扩展 `closeout-profile-completion.test.ts`，`task-query-read` 与 `repo-cell-task-progress-evidence` 各加一条断言。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+71/-23 production; tests +103/-1。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_f81158d6601e10b330a388b5d4（父 task_9e96326a111f8e1380df3500e8）
- 分支：`codex/read-side-gates`
- 公开范围：kernel 完成就绪判断、daemon 读侧及其测试。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：GUI 渲染与 CLI 呈现不动；写路径（#2575）不变。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/read-side-gates`
- 私有证据路径：task_f81158d6601e10b330a388b5d4 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO 交付后复跑：`tsc -b` 干净、line-density G36 pass、check-file-complexity 干净、四个定向测试文件 exit 0。worker：12 个触碰测试文件逐个 exit 0，`task-lifecycle-transitions.test.mjs` 7/7，integration 经隔离派测（ubuntu）exit 0，typecheck/lint/test-selection/run-manifest-gates exit 0。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 除读路径多一次 settings-state 解析外无已知风险；它读的是已加载的 settings facet。

## 参考

- 任务：task_f81158d6601e10b330a388b5d4

