### PR TITLE
fix: drain forwarded test output before exiting so failing-test details survive a slow pipe

### DIFF
--- a/tools/run-node-tests.mjs
+++ b/tools/run-node-tests.mjs
@@ -235,7 +235,11 @@ const exitCode = await new Promise((resolveRun) => {
 });
 const slowTests = collectSlowTests(output, options.slowThresholdMs);
 console.log(formatSlowTestSummary(slowTests, options.slowThresholdMs, options.slowLimit));
-process.exit(exitCode);
+// A forced exit here discards forwarded output still queued in userspace when stdout is a slow
+// pipe (CI log shipping): the inline ✖ lines survive because they were written earlier, while
+// the failing-tests recap — the assertion details a red lane exists to show — is written last
+// and is exactly what gets lost. Exit naturally so pending writes drain first.
+process.exitCode = exitCode;
 
 function exactNamePattern(names) {
   if (names.length === 0) return null;

--- a/tools/run-node-tests.test.mjs
+++ b/tools/run-node-tests.test.mjs
@@ -1,8 +1,17 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
 import path from "node:path";
 import test from "node:test";
+
+// A bounded wait whose timer never keeps the test process alive on its own.
+function boundedWait(ms) {
+  return new Promise((resolveWait) => {
+    const timer = setTimeout(resolveWait, ms);
+    timer.unref();
+  });
+}
 import {
   collectSlowTests,
   filterTestFilesByNames,
@@ -346,4 +355,42 @@ test("slow test summary parses node test output and formats top entries", () => 
     formatSlowTestSummary(slow, 1000, 1),
     ["Slow test summary: top 1 tests at or above 1000ms", "1. 2200.000ms slower thing"].join("\n"),
   );
+});
+
+test("forwarded failing-test details survive a stdout consumer that lags behind the pipe", async () => {
+  const childEnv = { ...process.env, HARNESS_RUNNER_OUTPUT_DRAIN_FIXTURE: "1" };
+  delete childEnv.NODE_TEST_CONTEXT;
+  const child = spawn(
+    process.execPath,
+    ["tools/run-node-tests.mjs", "--tier", "fast", "--prefix", "tools/test-fixtures/runner-output-drain"],
+    { cwd: repoRoot, env: childEnv, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  // Read stdout the way a slow CI log consumer does: a throttled pump that stays well behind the
+  // fixture's burst, so the OS pipe stays full and the runner's remaining writes sit queued in
+  // its userspace buffer. A runner that force-exits drops that queue — the failing-tests recap
+  // lives at the very end of it — while a runner that exits naturally cannot exit at all until
+  // the pipe drains, so a bounded wait for its exit is what tells the two apart.
+  let stdout = "";
+  const pump = setInterval(() => {
+    const chunk = child.stdout.read(4 * 1024);
+    if (chunk !== null) stdout += chunk;
+  }, 100);
+  await Promise.race([once(child, "exit"), boundedWait(1_500)]);
+  clearInterval(pump);
+  child.stdout.on("data", (text) => {
+    stdout += text;
+  });
+  child.stdout.resume();
+  let guardFired = false;
+  const guard = setTimeout(() => {
+    guardFired = true;
+    child.kill("SIGKILL");
+  }, 30_000);
+  guard.unref();
+  const [status] = await once(child, "close");
+  clearTimeout(guard);
+  assert.equal(guardFired, false, "runner never exited after stdout drained");
+  assert.equal(status, 1, stdout);
+  assert.match(stdout, /✖ failing tests:/u, "failing-tests recap was lost to a backpressured pipe");
+  assert.match(stdout, /runner output drain fixture assertion/u, "assertion details were lost to a backpressured pipe");
 });

--- a/tools/test-fixtures/runner-output-drain/failing-recap.test.mjs
+++ b/tools/test-fixtures/runner-output-drain/failing-recap.test.mjs
@@ -1,0 +1,14 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("runner output drain fixture emits a failing recap when explicitly enabled", () => {
+  if (process.env.HARNESS_RUNNER_OUTPUT_DRAIN_FIXTURE !== "1") return;
+  // Fill the forwarded stream far past the OS pipe capacity (64 KiB on Linux CI runners) so the
+  // runner's final writes — the failing-tests recap carrying the assertion details — can only be
+  // sitting queued in userspace at exit time, exactly like a CI lane whose log consumer lags.
+  for (let index = 0; index < 600; index += 1) {
+    console.log(`${"x".repeat(498)}${index}`);
+  }
+  assert.equal(1, 2, "runner output drain fixture assertion");
+});


### PR DESCRIPTION
# English

## Summary

When the `full-check` lane went red on main (run 34709637871, attempt 1) the log kept only the two inline `✖ <test name>` lines and lost the failing-tests recap with the assertion details, so the failure could not be diagnosed from CI. Root cause: `tools/run-node-tests.mjs` forwards the whole `node --test` stream and then ends with `process.exit(exitCode)`, which discards output still queued in userspace when stdout is a slow pipe (CI log shipping); the recap is written last and is exactly what gets dropped. The runner now sets `process.exitCode` and exits naturally so pending writes drain first.

## Architectural Justification

One-line deletion of a forced exit; the positive-control test is the only addition.

## What Changed

- `tools/run-node-tests.mjs`: `process.exit(exitCode)` → `process.exitCode = exitCode` plus a four-line comment stating the invariant.
- `tools/run-node-tests.test.mjs`: positive control — the runner is driven with a backpressured stdout consumer and an env-gated failing fixture; before the change the `✖ failing tests:` recap is absent from the captured stream (red), after it is present (green).
- `tools/test-fixtures/runner-output-drain/failing-recap.test.mjs` (fast tier): the env-gated fixture, a no-op unless the gating variable is set.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +5/-1 production (tools/run-node-tests.mjs); tests +62/-1.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_9f2d9a3e3fad320b58d4922c20 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/full-check-failure-details`
- Public scope: test runner exit path and its tests.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: No workflow change; `run-gui-tests`/`run-gui-e2e-tests` use inherited stdio and are not affected.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `tools/run-node-tests.mjs` (test runner used by every CI test lane) — exit path only: `process.exit(exitCode)` becomes `process.exitCode = exitCode`; test selection, tiers, watchdog and exit codes are unchanged
- Authority: task task_9f2d9a3e3fad320b58d4922c20 (CEO-filed defect: full-check lane loses failing-test details) under the standing test-isolation policy dec_E6E62653DA534ACDD1B7C0A388; no gate is weakened
- Machine-check boundary: `tools/run-node-tests.test.mjs` (positive control: recap lost before, present after) and `tools/run-node-tests-process-group.test.mjs`, 26/26 green
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/full-check-failure-details`
- Private evidence commit/path: task_9f2d9a3e3fad320b58d4922c20 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO: `run-node-tests --file tools/run-node-tests.test.mjs --file tools/run-node-tests-process-group.test.mjs` exit 0 (26 tests); line-density G36 pass; check-file-complexity clean. Worker: positive control red before / green after; `npm run test:fast` 746 pass / 5 fail with the same 5 (pr-merge ×2, run-local-line-budget ×3) failing on the unmodified runner at clean base (environment-bound).

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A natural exit waits for the event loop to drain; the runner's existing watchdog and process-group handling already close child handles, and the process-group tests still pass.

## References

- Task: task_9f2d9a3e3fad320b58d4922c20

---

# 中文

## 概要

main 的 `full-check` 车道红时（run 34709637871 attempt 1）日志只剩两行内联 `✖ <测试名>`，带断言细节的 failing-tests 汇总丢了，CI 上无法诊断。根因：`tools/run-node-tests.mjs` 转发整条 `node --test` 输出后以 `process.exit(exitCode)` 结束，stdout 是慢管道（CI 日志上传）时用户态还没写出去的输出被丢弃；汇总最后写，正好丢的就是它。改为设 `process.exitCode` 自然退出，先 drain 再退。

## 架构辩护

删一处强制退出；唯一新增是阳性对照测试。

## 改动内容

- `tools/run-node-tests.mjs`：`process.exit(exitCode)` → `process.exitCode = exitCode`，加四行注释说明不变量。
- `tools/run-node-tests.test.mjs`：阳性对照——用带背压的 stdout 消费方驱动 runner + env 门控的失败夹具；修前捕获流里没有 `✖ failing tests:` 汇总（红），修后有（绿）。
- `tools/test-fixtures/runner-output-drain/failing-recap.test.mjs`（fast 层）：env 门控夹具，未设变量时为空操作。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+5/-1 production (tools/run-node-tests.mjs); tests +62/-1。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_9f2d9a3e3fad320b58d4922c20（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/full-check-failure-details`
- 公开范围：测试 runner 退出路径及其测试。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：不改工作流；`run-gui-tests`/`run-gui-e2e-tests` 用继承 stdio，不受影响。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是
- 受保护面范围：`tools/run-node-tests.mjs`（所有 CI 测试车道共用的 runner）——仅退出路径：`process.exit(exitCode)` 改为 `process.exitCode = exitCode`；测试选择、分层、watchdog、退出码不变
- 授权：任务 task_9f2d9a3e3fad320b58d4922c20（CEO 立的缺陷：full-check 车道丢失失败详情），在常设测试隔离策略 dec_E6E62653DA534ACDD1B7C0A388 之下；不削任何门
- 机器检查边界：`tools/run-node-tests.test.mjs`（阳性对照：修前汇总丢失、修后存在）与 `tools/run-node-tests-process-group.test.mjs`，26/26 绿
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/full-check-failure-details`
- 私有证据路径：task_9f2d9a3e3fad320b58d4922c20 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO：`run-node-tests --file tools/run-node-tests.test.mjs --file tools/run-node-tests-process-group.test.mjs` exit 0（26 个）；line-density G36 pass；check-file-complexity 干净。worker：阳性对照修前红/修后绿；`npm run test:fast` 746 pass / 5 fail，同样 5 个在未改 runner 的干净 base 上也失败（环境相关）。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 自然退出要等事件循环排空；runner 既有 watchdog 与进程组处理已关闭子句柄，进程组测试仍绿。

## 参考

- 任务：task_9f2d9a3e3fad320b58d4922c20

