### PR TITLE
test: lock self-describing submit-packet and code-doc reconcile rejections

### DIFF
--- a/packages/daemon/test/rejection-next-actions.integration.test.ts
+++ b/packages/daemon/test/rejection-next-actions.integration.test.ts
@@ -374,6 +374,77 @@ test("symptom task_6edcc0d990dae7e42f4bc93ff9 (review-execution before submit): 
   }
 });
 
+test("symptom task_6edcc0d990dae7e42f4bc93ff9 (submit packet): a submission packet on task submit names the closeout route instead of a bare invalid_command", async () => {
+  const rootDir = workspace("submit-packet"),
+    taskId = "task-submit-packet",
+    executionId = "exec-submit-packet",
+    holder = binding("holder");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({
+      repoId: workspaceId("submit-packet"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "submit-packet",
+    });
+    const created = await cell.run({ kind: "task-create", taskId, title: "Submit packet" }, holder);
+    assert.equal(created.outcome, "applied");
+    await waitForFixturePublication(cell, created.opId, holder);
+    await realizeTaskPlanFixture(rootDir, String((created as Record<string, unknown>).packagePath), (planPath) =>
+      cell!.run({ kind: "doc-submit", paths: [planPath] }, holder),
+    );
+    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, holder)).outcome, "applied");
+    const rejected = await cell.run({ kind: "task-submit", taskId, executionId, fromFile: "sub.json" }, holder);
+    assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
+    assert.equal(rejected.code, "invalid_command", JSON.stringify(rejected));
+    assert.match(String(rejected.rejectionExplanation), /Write closeout\.md/u);
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("symptom task_6edcc0d990dae7e42f4bc93ff9 (complete --path): code-doc reconcile against a ledger-internal path names the Git-root requirement instead of a bare invalid_proof", async () => {
+  const rootDir = workspace("reconcile-wrong-root"),
+    taskId = "task-reconcile-wrong-root",
+    executionId = "exec-reconcile-wrong-root",
+    holder = binding("holder");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({
+      repoId: workspaceId("reconcile-wrong-root"),
+      rootDir: canonicalRoot(rootDir),
+      ownerId: "reconcile-wrong-root",
+    });
+    const created = await cell.run({ kind: "task-create", taskId, title: "Reconcile wrong root" }, holder);
+    assert.equal(created.outcome, "applied");
+    await waitForFixturePublication(cell, created.opId, holder);
+    await realizeTaskPlanFixture(rootDir, String((created as Record<string, unknown>).packagePath), (planPath) =>
+      cell!.run({ kind: "doc-submit", paths: [planPath] }, holder),
+    );
+    assert.equal((await cell.run({ kind: "task-start", taskId, executionId }, holder)).outcome, "applied");
+    writeCloseout(rootDir, (created as Record<string, unknown>).packagePath);
+    assert.equal((await cell.run({ kind: "task-submit", taskId, executionId }, holder)).outcome, "applied");
+    const rejected = await cell.run(
+      { kind: "task-code-doc-reconcile", taskId, paths: ["harness/agents/x.json"] },
+      withRoleBinding(holder, "repo-write"),
+    );
+    assert.equal(rejected.outcome, "op_rejected", JSON.stringify(rejected));
+    assert.equal(rejected.code, "invalid_proof", JSON.stringify(rejected));
+    assert.match(String(rejected.rejectionExplanation), /harness\/agents\/x\.json/u);
+    assert.match(String(rejected.rejectionExplanation), /relative to the Git repository/u);
+    assert.deepEqual(rejected.diagnostic, {
+      kind: "validation",
+      entity: "code-doc reconciliation",
+      field: "paths[0]",
+      actual: "harness/agents/x.json",
+      expectation: "Path must be relative to the Git repository that owns the submitted commit",
+    });
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("symptom task_356fe6c7a05cb987d93a807b46: relation relate against a nonexistent entity names the missing ref instead of a bare entity_not_found", async () => {
   const rootDir = workspace("relation-entity-not-found"),
     repoId = workspaceId("relation-entity-not-found");


### PR DESCRIPTION
# English

## Summary

task_6edcc0d9 recorded three CLI rejections with no hint: `ha task submit` without a commitSha, `ha task review-execution` on an execution that was never submitted, and a code-doc reconcile against the wrong cut. On current main all three already self-describe (the fixes landed in earlier PRs: submit-packet next-actions, review-before-submit guard, reconcile criterion wording), so this delivery is verification plus the two regression tests that were missing — nothing in production changes.

## Architectural Justification

Regression guards for behaviour that is already the single production path.

## What Changed

- `packages/daemon/test/rejection-next-actions.integration.test.ts`: two new cases lock the self-describing rejections for a submit packet missing its commit and for a code-doc reconcile against a non-submitted cut (the review-before-submit guard was already covered). The three CLI probes with their raw output are in the task's report.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-0 production; tests +71/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_6edcc0d990dae7e42f4bc93ff9 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/submit-hints`
- Public scope: daemon rejection next-action tests only.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: No source change; the symptoms' fixes were merged earlier and are cited in the report.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9733caf35`
- Branch merge-base with `origin/main`: `9733caf35`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/submit-hints`
- Private evidence commit/path: task_6edcc0d990dae7e42f4bc93ff9 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node tools/run-node-tests.mjs --file packages/daemon/test/rejection-next-actions.integration.test.ts` exit 0 (11 tests; CEO re-run); line-density G36 pass; check-file-complexity clean; production-delta +0/-0.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- None; tests only.

## References

- Task: task_6edcc0d990dae7e42f4bc93ff9

---

# 中文

## 概要

task_6edcc0d9 记录了三条无 hint 的 CLI 拒绝：`ha task submit` 缺 commitSha、`review-execution` 对未 submit 的执行、code-doc reconcile 对错误 cut。当前 main 上三者都已自描述（修复随更早的 PR 落地：submit packet next-actions、review-before-submit 守护、reconcile 准则文案），本交付是现状核验 + 补上缺失的两条回归测试，生产代码不变。

## 架构辩护

为已是唯一生产路径的行为加回归守护。

## 改动内容

- `packages/daemon/test/rejection-next-actions.integration.test.ts`：两个新用例钉住「submit packet 缺提交」与「对未 submit 的 cut 做 code-doc reconcile」的自描述拒绝（review-before-submit 守护已有覆盖）。三条 CLI 探针原文在任务报告里。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+0/-0 production; tests +71/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_6edcc0d990dae7e42f4bc93ff9（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/submit-hints`
- 公开范围：仅 daemon 拒绝 next-action 测试。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：无源码改动；症状的修复早已合入，报告里引用。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9733caf35`
- 分支与 `origin/main` 的 merge-base：`9733caf35`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/submit-hints`
- 私有证据路径：task_6edcc0d990dae7e42f4bc93ff9 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node tools/run-node-tests.mjs --file packages/daemon/test/rejection-next-actions.integration.test.ts` exit 0（11 个，CEO 复跑）；line-density G36 pass；check-file-complexity 干净；production-delta +0/-0。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 无；仅测试。

## 参考

- 任务：task_6edcc0d990dae7e42f4bc93ff9

