### PR TITLE
fix: skip backup entries that vanish after enumeration instead of failing

### DIFF
--- a/packages/kernel/src/store/ledger-backup.ts
+++ b/packages/kernel/src/store/ledger-backup.ts
@@ -211,7 +211,8 @@ function copyWorkingTree(rootDir: string, authoredRoot: string, payloadRoot: str
     recursive: true,
     errorOnExist: true,
     verbatimSymlinks: true,
-    filter: (candidate) => included.has(candidate),
+    filter: (candidate) =>
+      candidate === authoredRoot || (included.has(candidate) && !vanishedAfterEnumeration(candidate)),
   });
 }
 
@@ -223,14 +224,23 @@ function copySource(rootDir: string, sourcePath: string, payloadRoot: string): v
     recursive: true,
     errorOnExist: true,
     verbatimSymlinks: true,
-    // A repository nested inside a source (a tool worktree under .claude/, a checkout someone
-    // left in the tree) is tool state, not ledger content.
-    filter: (candidate) => candidate === sourcePath || !nestedRepository(candidate),
+    filter: (candidate) => candidate === sourcePath || !skippedFromSource(candidate),
   });
 }
 
-function nestedRepository(candidate: string): boolean {
-  return fileSystem.lstat(candidate).isDirectory() && fileSystem.exists(path.join(candidate, ".git"));
+// An entry that vanishes between its enumeration and this stat — Git's transient
+// gc/maintenance locks under .git/, a write path replacing a temp file — no longer needs
+// backing up. Tolerating only the missing-entry case is not a retry: every other stat
+// error still fails the backup.
+function vanishedAfterEnumeration(candidate: string): boolean {
+  return fileSystem.lstat(candidate, { throwIfNoEntry: false }) === undefined;
+}
+
+// A repository nested inside a source (a tool worktree under .claude/, a checkout someone
+// left in the tree) is tool state, not ledger content, and is skipped like a vanished entry.
+function skippedFromSource(candidate: string): boolean {
+  const stat = fileSystem.lstat(candidate, { throwIfNoEntry: false });
+  return stat === undefined || (stat.isDirectory() && fileSystem.exists(path.join(candidate, ".git")));
 }
 
 function vacuumSqlite(rootDir: string, databasePath: string, payloadRoot: string): void {

--- a/packages/kernel/test/store/ledger-backup-vanishing-source.fixture.ts
+++ b/packages/kernel/test/store/ledger-backup-vanishing-source.fixture.ts
@@ -1,0 +1,13 @@
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { parentPort, workerData } from "node:worker_threads";
+
+const input = workerData as { readonly sourceDir: string; readonly triggerPath: string; readonly prefix: string };
+// 1 ms sleeps: coarse enough to land after the copy's directory enumeration, fine enough
+// to overtake entries it has not visited yet.
+const sleeper = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+parentPort!.postMessage({ ready: true });
+while (!existsSync(input.triggerPath)) Atomics.wait(sleeper, 0, 0, 1);
+const vanished = readdirSync(input.sourceDir).filter((name) => name.startsWith(input.prefix));
+for (const name of vanished) rmSync(path.join(input.sourceDir, name), { force: true });
+parentPort!.postMessage({ vanished: vanished.length });

--- a/packages/kernel/test/store/ledger-backup.integration.test.ts
+++ b/packages/kernel/test/store/ledger-backup.integration.test.ts
@@ -17,7 +17,13 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { DatabaseSync } from "node:sqlite";
-import { createLedgerBackup, drillLedgerBackup, readOfflineLedgerEvents } from "../../src/store/ledger-backup.ts";
+import { Worker } from "node:worker_threads";
+import {
+  createLedgerBackup,
+  drillLedgerBackup,
+  readOfflineLedgerEvents,
+  readVerifiedLedgerBackup,
+} from "../../src/store/ledger-backup.ts";
 import { openSqliteEventStore, sqliteLedgerPath } from "../../src/store/sqlite-event-store.ts";
 import { sha256Bytes, sha256Text } from "../../src/integrity/stable-hash.ts";
 import { event, flatLedgerFixture } from "./task-event-store.fixtures.ts";
@@ -223,6 +229,67 @@ test("restore drill rolls shadows by retention, preserves unrelated directories 
     );
     assert.equal(single.removedShadowRoots.length, 2);
   } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(backupDir, { recursive: true, force: true });
+  }
+});
+
+// Git's own gc/maintenance briefly creates and deletes lock files inside .git/ while a
+// backup walks it (#2543): a vanishing worker deletes enumerated-but-unvisited entries
+// mid-traversal, and the backup must skip them instead of failing on lstat ENOENT.
+test("backup skips entries that vanish after enumeration instead of failing", async () => {
+  const root = fixture("vanish"),
+    backupDir = path.join(os.tmpdir(), `ha-backup-vanish-${process.pid}-${Date.now()}`),
+    gitDir = path.join(root, "harness", ".git"),
+    fillerCount = 1000,
+    lockCount = 30;
+  let worker: Worker | undefined;
+  try {
+    for (let index = 0; index < fillerCount; index += 1)
+      writeFileSync(path.join(gitDir, `vanish-f-${index}.pack`), "x");
+    for (let index = 0; index < lockCount; index += 1)
+      writeFileSync(path.join(gitDir, `vanish-lock-${index}.lock`), "transient\n");
+    const ready = new Promise<void>((resolve) => {
+      worker = new Worker(new URL("./ledger-backup-vanishing-source.fixture.ts", import.meta.url), {
+        execArgv: process.execArgv.filter(
+          (argument) => argument === "--experimental-strip-types" || argument === "--enable-source-maps",
+        ),
+        workerData: {
+          sourceDir: gitDir,
+          // The payload .git directory appears after the source .git was enumerated.
+          triggerPath: path.join(backupDir, "payload", "harness", ".git"),
+          prefix: "vanish-lock-",
+        },
+      });
+      worker.on("message", (message: unknown) => {
+        if ((message as { readonly ready?: boolean }).ready === true) resolve();
+      });
+    });
+    await ready;
+    const manifest = createLedgerBackup({ rootInput: root, backupDir }),
+      report = new Promise<number>((resolve, reject) => {
+        worker!.on("message", (message: unknown) => {
+          const vanished = (message as { readonly vanished?: number }).vanished;
+          if (typeof vanished === "number") resolve(vanished);
+        });
+        worker!.once("error", reject);
+        worker!.once("exit", (code) => {
+          if (code !== 0) reject(new Error(`vanishing worker exited ${code}`));
+        });
+      });
+    assert.equal(await report, lockCount);
+    const manifestLocks = manifest.files.filter(({ path: file }) => file.startsWith("harness/.git/vanish-lock-"));
+    assert.ok(
+      manifestLocks.length < lockCount,
+      `vanishing must overtake at least one enumerated entry (copied ${manifestLocks.length})`,
+    );
+    assert.equal(
+      manifest.files.some(({ path: file }) => file === "harness/.git/HEAD"),
+      true,
+    );
+    readVerifiedLedgerBackup(backupDir);
+  } finally {
+    await worker?.terminate();
     rmSync(root, { recursive: true, force: true });
     rmSync(backupDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
# English

## Summary

The ledger backup walked `harness/.git` with readdir followed by lstat and failed the whole backup with ENOENT when an entry vanished between the two calls — Git's transient gc/maintenance locks under `.git/`, or a write path swapping a temp file (seen during #2543). The walk now treats an entry that no longer exists at stat time as not needing backup; every other stat error still fails the backup, so this is a single missing-entry tolerance, not a retry.

## Architectural Justification

One tolerance at the exact call that raced, expressed as a predicate the existing filter already consumed; no retry loop, no wrapper.

## What Changed

- `packages/kernel/src/store/ledger-backup.ts`: `vanishedAfterEnumeration()` (lstat with `throwIfNoEntry: false`) used by the include filter; the nested-repository check becomes `skippedFromSource()` which folds the same vanish case in, replacing `nestedRepository()`.
- `packages/kernel/test/store/ledger-backup.integration.test.ts` + `ledger-backup-vanishing-source.fixture.ts`: new test `backup skips entries that vanish after enumeration instead of failing`, deleting an enumerated file from a concurrent poller while the walk runs (red before, green after).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +16/-6 production; tests +81/-1.

## Per-Write Cost

The G1 probe (`node tools/gates/cost-budget.mjs`, same machine, base = canonical main 377a7bd7d, head = this branch 5a0665fc5) has no backup operation; the nine write operations it does measure are reported below and are identical before/after, as expected for a change confined to the backup walk's stat predicate (all 14 probed operations were compared; the 5 read operations are also identical).

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| decision-reckon | sqlRowsRead | 75 | 75 | 75 | 75 |
| decision-reckon | sha256Calls | 28 | 28 | 28 | 28 |
| decision-reckon | sha256Bytes | 8494 | 8535 | 8494 | 8535 |
| decision-reckon | gitProcesses | 6 | 6 | 6 | 6 |
| decision-reckon | fileReadBytes | 1237 | 1245 | 1237 | 1245 |
| decision-reject | sqlRowsRead | 101 | 101 | 101 | 101 |
| decision-reject | sha256Calls | 40 | 40 | 40 | 40 |
| decision-reject | sha256Bytes | 29259 | 29290 | 29259 | 29290 |
| decision-reject | gitProcesses | 6 | 6 | 6 | 6 |
| decision-reject | fileReadBytes | 7219 | 7227 | 7219 | 7227 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_cdf108fbcdc295fde16c09c147 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/backup-lstat-flake`
- Public scope: kernel ledger backup walk and its integration test.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Retention (`drillLedgerBackup`) walk and the CLI's surfacing of backup failure causes (task_89573195) are untouched.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `1c70703b1`
- Branch merge-base with `origin/main`: `1c70703b1`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/backup-lstat-flake`
- Private evidence commit/path: task_cdf108fbcdc295fde16c09c147 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO: three consecutive `run-node-tests --file packages/kernel/test/store/ledger-backup.integration.test.ts` runs exit 0; line-density G36 pass; check-file-complexity clean. Worker: the four integration files importing ledger-backup (cli ×3, daemon ×1) through the isolated dispatcher on Ubuntu exit 0; typecheck/lint clean.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; commit authorship and scope checked.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The new test's race is driven by a 1 ms poller against a multi-millisecond walk; under extreme scheduling it could miss the window and pass vacuously (never fail spuriously). The retention walk still has the same readdir→lstat window; flagged for the retention task rather than widened here.

## References

- Task: task_cdf108fbcdc295fde16c09c147

---

# 中文

## 概要

ledger 备份用 readdir→lstat 遍历 `harness/.git`，两次调用之间条目消失（Git 的瞬时 gc/maintenance 锁、写路径换临时文件；#2543 期间出现）就整个备份 ENOENT 失败。现在 stat 时已不存在的条目视为无需备份；其它 stat 错误照旧让备份失败——只容忍「条目消失」这一种情况，不是重试。

## 架构辩护

在真正竞态的那一次调用上加一处容忍，表达为既有过滤器已消费的谓词；无重试循环、无包装层。

## 改动内容

- `packages/kernel/src/store/ledger-backup.ts`：`vanishedAfterEnumeration()`（lstat 带 `throwIfNoEntry: false`）进入 include 过滤；嵌套仓库判断改为 `skippedFromSource()`，把同一「消失」情形并入，替换 `nestedRepository()`。
- `ledger-backup.integration.test.ts` + `ledger-backup-vanishing-source.fixture.ts`：新测试「backup skips entries that vanish after enumeration instead of failing」，遍历进行中由并发轮询删掉一个已枚举文件（改前红、改后绿）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+16/-6 production; tests +81/-1。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_cdf108fbcdc295fde16c09c147（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/backup-lstat-flake`
- 公开范围：kernel ledger 备份遍历及其集成测试。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：retention（`drillLedgerBackup`）遍历与 CLI 对备份失败原因的呈现（task_89573195）不动。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`1c70703b1`
- 分支与 `origin/main` 的 merge-base：`1c70703b1`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/backup-lstat-flake`
- 私有证据路径：task_cdf108fbcdc295fde16c09c147 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO：`run-node-tests --file …ledger-backup.integration.test.ts` 连续三次 exit 0；line-density G36 pass；check-file-complexity 干净。worker：引用 ledger-backup 的四个 integration 文件（cli ×3、daemon ×1）经 Ubuntu 隔离派测 exit 0；typecheck/lint 干净。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过提交人与范围。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 新测试的竞态靠 1 ms 轮询对多毫秒遍历，极端调度下可能错过窗口而空过（不会误红）。retention 遍历仍有同样的 readdir→lstat 窗口，留给 retention 任务而非在此扩面。

## 参考

- 任务：task_cdf108fbcdc295fde16c09c147

