### PR TITLE
fix: fact record lists registered types and declares the supersedes/rationale pairing

### DIFF
--- a/packages/cli/src/cli/guidance-plane.ts
+++ b/packages/cli/src/cli/guidance-plane.ts
@@ -184,7 +184,14 @@ export function humanError(receipt: Record<string, unknown>): { readonly code: s
         `Inner receipt: ${typeof receipt.summary === "string" ? receipt.summary : "summary unavailable"}`,
     };
   if (code === "daemon_stopping") return { code, hint: renderTemplate("failure", "daemon-stopping", {}) };
-  if (code === "fact_type_unregistered") return { code, hint: renderTemplate("failure", "fact-type-unregistered", {}) };
+  if (code === "fact_type_unregistered")
+    return {
+      code,
+      hint:
+        typeof receipt.rejectionExplanation === "string"
+          ? `${receipt.rejectionExplanation} Run ha fact type register <type> --source <source>, then retry this command.`
+          : renderTemplate("failure", "fact-type-unregistered", {}),
+    };
   if (code === "daemon_restarting" && typeof outer.hint === "string") return { code, hint: outer.hint };
   const rawDiagnostic = record(receipt.diagnostic) ? receipt.diagnostic : null,
     // A bare {kind:"failure"} diagnostic is the code-only placeholder `rejected()` always attaches;

--- a/packages/cli/src/cli/guidance-plane.ts
+++ b/packages/cli/src/cli/guidance-plane.ts
@@ -189,7 +189,8 @@ export function humanError(receipt: Record<string, unknown>): { readonly code: s
       code,
       hint:
         typeof receipt.rejectionExplanation === "string"
-          ? `${receipt.rejectionExplanation} Run ha fact type register <type> --source <source>, then retry this command.`
+          ? `${receipt.rejectionExplanation} ` +
+            `Run ha fact type register <type> --source <source>, then retry this command.`
           : renderTemplate("failure", "fact-type-unregistered", {}),
     };
   if (code === "daemon_restarting" && typeof outer.hint === "string") return { code, hint: outer.hint };

--- a/packages/cli/src/cli/thin-command-fact.ts
+++ b/packages/cli/src/cli/thin-command-fact.ts
@@ -92,15 +92,6 @@ export function parseFactRecord(
       "Use --statement <observation> or --text <observation>; --source <source> is also required.",
       json,
     );
-  if (Boolean(supersedes) !== Boolean(rationale))
-    return rejected(
-      "missing_field",
-      supersedes
-        ? "--rationale and --supersedes must be provided together; add --rationale <why>, then rerun the command."
-        : "--rationale and --supersedes must be provided together; " +
-            "add --supersedes <fact-ref>, then rerun the command.",
-      json,
-    );
   return accepted(rootDir, repoId, json, {
     kind: "fact-record",
     ...(positionalTaskId || flaggedTaskId ? { taskId: positionalTaskId ?? flaggedTaskId } : {}),

--- a/packages/cli/test/guidance-plane.test.ts
+++ b/packages/cli/test/guidance-plane.test.ts
@@ -212,6 +212,23 @@ test("fact_type_unregistered guides registering the domain type before retry", (
   );
 });
 
+test("fact_type_unregistered renders the daemon explanation so the legal values reach the operator", () => {
+  assert.deepEqual(
+    renderCliReceipt({
+      ok: false,
+      code: "fact_type_unregistered",
+      rejectionExplanation: "Fact domain type observation is not registered. Registered: verification.",
+      error: { code: "fact_type_unregistered" },
+    }),
+    {
+      stream: "stderr",
+      text:
+        "error code=fact_type_unregistered hint=Fact domain type observation is not registered. " +
+        "Registered: verification. Run ha fact type register <type> --source <source>, then retry this command.",
+    },
+  );
+});
+
 test("receipt registry preserves migrated family goldens", () => {
   assert.deepEqual(renderCliReceipt({ command: "runtime-batch", dispatches: [] }), {
     stream: "stdout",

--- a/packages/cli/test/thin-command-fact-decision.test.ts
+++ b/packages/cli/test/thin-command-fact-decision.test.ts
@@ -1,6 +1,7 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import { daemonProtocolCommands } from "../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { parseThinCommand } from "../src/cli/thin-command.ts";
 import { materializePacketStdin } from "../src/index.ts";
 
@@ -137,9 +138,8 @@ test("Fact CLI exposes record, controlled types, search, and show while keeping 
   ]);
   assert.deepEqual(rationaleOnly, {
     ok: false,
-    code: "missing_field",
-    nextAction:
-      "--rationale and --supersedes must be provided together; add --supersedes <fact-ref>, then rerun the command.",
+    code: "invalid_field",
+    nextAction: "--rationale requires --supersedes.",
     json: false,
   });
   const supersedesOnly = parseThinCommand([
@@ -156,9 +156,8 @@ test("Fact CLI exposes record, controlled types, search, and show while keeping 
   ]);
   assert.deepEqual(supersedesOnly, {
     ok: false,
-    code: "missing_field",
-    nextAction:
-      "--rationale and --supersedes must be provided together; add --rationale <why>, then rerun the command.",
+    code: "invalid_field",
+    nextAction: "--supersedes requires --rationale.",
     json: false,
   });
   const superseding = parseThinCommand([
@@ -203,6 +202,30 @@ test("Fact CLI exposes record, controlled types, search, and show while keeping 
     false,
   );
   assert.equal(parseThinCommand(["fact", "record", "--statement", "x", "--text", "y", "--source", "s"]).ok, false);
+});
+
+test("fact record help declares the supersedes/rationale pairing the rejection enforces", () => {
+  const command = daemonProtocolCommands.find(({ id }) => id === "fact-record");
+  assert.ok(command);
+  for (const name of ["--supersedes", "--rationale"]) {
+    const input = command.inputs.find((candidate) => candidate.name === name);
+    assert.ok(input, name);
+    const partner = name === "--supersedes" ? "--rationale" : "--supersedes";
+    assert.deepEqual(input.requires, [partner], name);
+    assert.match(command.help, new RegExp(`${name} — [^\\n]*requires: ${partner}`, "u"), name);
+    const parsed = parseThinCommand([
+      "fact",
+      "record",
+      "--statement",
+      "Observed",
+      "--source",
+      "test",
+      name,
+      name === "--supersedes" ? "fact/F-ABCDEFGH" : "why",
+    ]);
+    assert.equal(parsed.ok, false, name);
+    if (!parsed.ok) assert.equal(parsed.nextAction, `${name} requires ${partner}.`, name);
+  }
 });
 
 test("Fact search CLI forwards observed-time windows and keyset pagination", () => {

--- a/packages/daemon/src/protocol/daemon-protocol-commands-doc-fact.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-doc-fact.ts
@@ -236,9 +236,15 @@ export const docFactProtocolCommands = Object.freeze([
       cliInput("--memory-tag", "repeated", false, {
         code: "invalid_field",
       }),
-      cliInput("--supersedes", "single", false, {
-        code: "invalid_field",
-      }),
+      cliInput(
+        "--supersedes",
+        "single",
+        false,
+        {
+          code: "invalid_field",
+        },
+        { requires: ["--rationale"] },
+      ),
       cliInput(
         "--rationale",
         "single",
@@ -246,7 +252,7 @@ export const docFactProtocolCommands = Object.freeze([
         {
           code: "invalid_field",
         },
-        { regex: "^[\\s\\S]{1,199}$" },
+        { requires: ["--supersedes"], regex: "^[\\s\\S]{1,199}$" },
       ),
     ],
   }),

--- a/packages/kernel/src/projection/fact-event-projection.ts
+++ b/packages/kernel/src/projection/fact-event-projection.ts
@@ -140,8 +140,15 @@ export function assertFactAdmission(db: DatabaseSync, event: FactEventV1): void 
       );
   }
   for (const domainType of event.payload.domainTypes ?? [])
-    if (!prepareQuery(db, "SELECT 1 FROM fact_domain_type WHERE domain_type = ?").get(domainType))
-      throw new FactProjectionError("fact_type_unregistered", `Fact domain type ${domainType} is not registered.`);
+    if (!prepareQuery(db, "SELECT 1 FROM fact_domain_type WHERE domain_type = ?").get(domainType)) {
+      const registered = listFactDomainTypeRows(db)
+        .map(({ domainType: value }) => value)
+        .join(", ");
+      throw new FactProjectionError(
+        "fact_type_unregistered",
+        `Fact domain type ${domainType} is not registered. Registered: ${registered || "none yet"}.`,
+      );
+    }
   const supersedes = event.payload.supersedes;
   if (!supersedes) return;
   const target = prepareQuery(db, "SELECT ref FROM fact WHERE ref = ?").get(supersedes.factRef) as

--- a/packages/kernel/test/store/fact-admission-liveness.test.ts
+++ b/packages/kernel/test/store/fact-admission-liveness.test.ts
@@ -64,6 +64,39 @@ test("Fact admission names an unregistered domain type instead of a relation fai
   }
 });
 
+test("Fact admission lists the registered domain types when rejecting an unregistered one", () => {
+  const db = new DatabaseSync(":memory:");
+  try {
+    createRelationGraphProjectionTables(db);
+    createFactProjectionTables(db);
+    assert.throws(
+      () => reduceFactEvent(db, fact(1, "F-ABCDEFGH", undefined, ["observation"])),
+      (error: unknown) =>
+        error instanceof FactProjectionError &&
+        error.code === "fact_type_unregistered" &&
+        /Fact domain type observation is not registered\. Registered: none yet\./u.test(
+          (error as FactProjectionError).message,
+        ),
+    );
+    const registration = fact(2, "F-BCDEFGHJ");
+    reduceFactEvent(db, {
+      ...registration,
+      payload: { ...registration.payload, registersDomainType: "verification" },
+    });
+    assert.throws(
+      () => reduceFactEvent(db, fact(3, "F-CDEFGHJK", undefined, ["observation"])),
+      (error: unknown) =>
+        error instanceof FactProjectionError &&
+        error.code === "fact_type_unregistered" &&
+        /Fact domain type observation is not registered\. Registered: verification\./u.test(
+          (error as FactProjectionError).message,
+        ),
+    );
+  } finally {
+    db.close();
+  }
+});
+
 function fact(revision: number, factId: string, supersedesRef?: string, domainTypes?: string[]): FactEventV1 {
   return {
     schema: "fact-event/v1",


### PR DESCRIPTION
# English

## Summary

Two `ha fact record` frictions, both fixed at their source rather than in the CLI. (1) An unregistered `--type` was rejected with `fact_type_unregistered` and a generic hint that named no legal value, so an operator had to guess or read the ledger; the kernel projection now lists the registered domain types in the rejection and the guidance plane surfaces that daemon explanation followed by the exact register command. (2) `--rationale` was advertised as optional but the CLI hand-rejected it unless `--supersedes` was also given (and vice versa); the pairing is now declared as bidirectional `requires` facets on the daemon protocol doc for `fact record`, so the generic facet validation, the generated help, and the JSON contract all state the same rule, and the nine-line hand-written check in `thin-command-fact.ts` is deleted. Closes task_ccc07185c8e9a0edefbab9d5cc and task_e147efcd8c176c23501b155d8e.

## Architectural Justification

Both fixes move a rule to its single owner (kernel projection for the type list, protocol doc facets for the flag pairing) and delete the CLI-local duplicate; no new mechanism.

## What Changed

- `packages/kernel/src/projection/fact-event-projection.ts` (+9/-2): the `fact_type_unregistered` rejection message appends `Registered: <types>` (or `none yet`) from `listFactDomainTypeRows`.
- `packages/cli/src/cli/guidance-plane.ts` (+9/-1): for `fact_type_unregistered`, the hint is the receipt's `rejectionExplanation` plus `Run ha fact type register <type> --source <source>, then retry this command.`; the static template remains the fallback when no explanation is present.
- `packages/daemon/src/protocol/daemon-protocol-commands-doc-fact.ts` (+10/-4): `--supersedes` declares `requires: ["--rationale"]` and `--rationale` declares `requires: ["--supersedes"]`.
- `packages/cli/src/cli/thin-command-fact.ts` (-9): the hand-written `missing_field` pairing check is removed; the facet validation now rejects with `invalid_field` and the generic `--x requires --y.` text.
- Tests: `guidance-plane.test.ts` (+17), `thin-command-fact-decision.test.ts` (+35/-6, two locked rejection cases updated to the facet wording plus one help-line assertion), `fact-admission-liveness.test.ts` (+33).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +28/-16 production; tests +79/-6.

## Per-Write Cost

G1 probe (`node tools/gates/cost-budget.mjs`, same machine; base = canonical main 377a7bd7d, head = this branch 4b7a69e6a). `fact-record` is the operation whose projection changed; the rejection branch it touches only runs for an unregistered type, which the probe never exercises, so all counts are identical before/after (all 14 probed operations compared; the 5 read operations are also identical).

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| decision-reckon | sqlRowsRead | 75 | 75 | 75 | 75 |
| decision-reckon | sha256Calls | 28 | 28 | 28 | 28 |
| decision-reckon | sha256Bytes | 8494 | 8535 | 8494 | 8535 |
| decision-reckon | gitProcesses | 6 | 6 | 6 | 6 |
| decision-reckon | fileReadBytes | 1237 | 1245 | 1237 | 1245 |
| decision-reject | sqlRowsRead | 101 | 101 | 101 | 101 |
| decision-reject | sha256Calls | 40 | 40 | 40 | 40 |
| decision-reject | sha256Bytes | 29259 | 29290 | 29259 | 29290 |
| decision-reject | gitProcesses | 6 | 6 | 6 | 6 |
| decision-reject | fileReadBytes | 7219 | 7227 | 7219 | 7227 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_ccc07185c8e9a0edefbab9d5cc (parent none)
- Branch: `codex/fact-record-flags`
- Public scope: kernel fact projection rejection text, daemon fact-record protocol facets, CLI guidance for `fact_type_unregistered`.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Registering common types by default (e.g. `observation`) is a ledger-policy question left to the task's follow-up; no default types are added here.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `1c70703b1`
- Branch merge-base with `origin/main`: `1c70703b1`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/fact-record-flags`
- Private evidence commit/path: task_ccc07185c8e9a0edefbab9d5cc `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO ground-truth after rebasing onto `origin/main` 1c70703b1: `run-node-tests --file` on the three touched test files passes except the pre-existing macOS-only tmpdir failure in `guidance-plane.test.ts` ("missing workspace packets identify the root used for relative paths", reproduced on main, tracked as task_2b4858be); `run-local-line-density` G36 pass; `check-file-complexity` pass; `gates/canonical-event-compat --check` ok (173 samples); `check-pr-governance` skipped (no protected surface). Worker (round 2, report `artifacts/reports/dispatch_ed9f13774486cbcfe6048fd9.md`): same gates on the pre-rebase head 0aa9aa98c.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; verified the CLI deletion is the only production removal and that the facet wording is the generic validator's, not a new template.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The `requires` facets are enforced client-side by the CLI's generic facet validation before dispatch; a daemon built before this change would not re-check the pairing server-side, which is unreachable in practice because the CLI rejects first. The rejection text now grows with the number of registered types; ledgers with many types get a long line, which is the intended information.

## References

- Task: task_ccc07185c8e9a0edefbab9d5cc

---

# 中文

## 概要

`ha fact record` 的两处摩擦，都在源头修而不是在 CLI 打补丁。（1）未注册的 `--type` 被 `fact_type_unregistered` 拒绝，但提示是泛化模板、不说合法值是什么，操作者只能猜或翻台账；现在 kernel 投影在拒绝信息里列出已注册的 domain type，guidance plane 把 daemon 的这句解释原样呈现并接上准确的注册命令。（2）`--rationale` 标为可选，但 CLI 手写逻辑要求它必须与 `--supersedes` 同时出现（反之亦然）；现在这对约束声明为 daemon 协议文档里 `fact record` 的双向 `requires` facet，通用 facet 校验、生成的 help 与 JSON 契约说同一条规则，`thin-command-fact.ts` 里九行手写检查删除。关闭 task_ccc07185c8e9a0edefbab9d5cc 与 task_e147efcd8c176c23501b155d8e。

## 架构辩护

两处修复都把规则挪回唯一的所有者（类型清单归 kernel 投影，flag 配对归协议文档 facet）并删除 CLI 本地的重复；不引入新机制。

## 改动内容

- `packages/kernel/src/projection/fact-event-projection.ts`（+9/-2）：`fact_type_unregistered` 拒绝信息追加 `Registered: <types>`（无则 `none yet`），来源 `listFactDomainTypeRows`。
- `packages/cli/src/cli/guidance-plane.ts`（+9/-1）：`fact_type_unregistered` 的 hint = 回执的 `rejectionExplanation` + `Run ha fact type register <type> --source <source>, then retry this command.`；没有解释时仍回落到静态模板。
- `packages/daemon/src/protocol/daemon-protocol-commands-doc-fact.ts`（+10/-4）：`--supersedes` 声明 `requires: ["--rationale"]`，`--rationale` 声明 `requires: ["--supersedes"]`。
- `packages/cli/src/cli/thin-command-fact.ts`（-9）：删除手写 `missing_field` 配对检查；facet 校验改以 `invalid_field` 与通用的 `--x requires --y.` 文案拒绝。
- 测试：`guidance-plane.test.ts`（+17）、`thin-command-fact-decision.test.ts`（+35/-6，两条锁定拒绝用例改为 facet 文案，另加一条 help 行断言）、`fact-admission-liveness.test.ts`（+33）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+28/-16 production; tests +79/-6。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_ccc07185c8e9a0edefbab9d5cc（父 none）
- 分支：`codex/fact-record-flags`
- 公开范围：kernel fact 投影的拒绝文案、daemon fact-record 协议 facet、CLI 对 `fact_type_unregistered` 的引导。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：是否默认注册常见类型（如 `observation`）属于台账策略，留给该任务的后续；本 PR 不加默认类型。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`1c70703b1`
- 分支与 `origin/main` 的 merge-base：`1c70703b1`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/fact-record-flags`
- 私有证据路径：task_ccc07185c8e9a0edefbab9d5cc 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO 在 rebase 到 `origin/main` 1c70703b1 后核实：三个触碰测试文件 `run-node-tests --file` 通过，唯一失败是 `guidance-plane.test.ts` 里已存在的 macOS-only tmpdir 用例（main 上可复现，task_2b4858be 跟踪）；`run-local-line-density` G36 pass；`check-file-complexity` pass；`gates/canonical-event-compat --check` ok（173 样本）；`check-pr-governance` 跳过（无受保护面）。worker（第二轮，报告 `artifacts/reports/dispatch_ed9f13774486cbcfe6048fd9.md`）在 rebase 前的 0aa9aa98c 上跑过同一组门。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过唯一的生产删除就是 CLI 那段手写检查，facet 文案来自通用校验器而非新模板。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- `requires` facet 由 CLI 的通用 facet 校验在派发前于客户端执行；此变更之前构建的 daemon 不会在服务端复查该配对——实际不可达，因为 CLI 先拒。拒绝文案随已注册类型数增长，类型很多的台账会得到一行长文本，这正是要传达的信息。

## 参考

- 任务：task_ccc07185c8e9a0edefbab9d5cc

