### PR TITLE
fix: state the workspace-root path rule in file-flag help and rejections

### DIFF
--- a/packages/cli/test/guidance-plane.test.ts
+++ b/packages/cli/test/guidance-plane.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { readWorkspaceText } from "../../daemon/src/workspace-text-port.ts";
 import { diagnosticForError, taskCreateGuidance } from "../../daemon/src/receipt-guidance.ts";
+import { workspacePathResolutionRule } from "../../preset/src/preset-command-contract.ts";
 import { humanError, renderReceiptGuidance } from "../src/cli/guidance-plane.ts";
 import { renderCliReceipt } from "../src/cli/receipt-render-registry.ts";
 
@@ -21,7 +22,7 @@ test("missing workspace packets identify the root used for relative paths", () =
       (error: Error) => {
         const hint = humanError({ code: "invalid_command", rejectionExplanation: error.message }).hint;
         assert.ok(hint.includes(root), hint);
-        assert.match(hint, /relative paths are resolved from this root/u);
+        assert.ok(hint.includes(workspacePathResolutionRule), hint);
         return true;
       },
     );

--- a/packages/cli/test/task-action-derivation.test.ts
+++ b/packages/cli/test/task-action-derivation.test.ts
@@ -8,6 +8,7 @@ import {
   reviewJsonFields,
 } from "../../daemon/src/protocol/daemon-protocol-commands-task.ts";
 import { validateDaemonRpcCall } from "../../daemon/src/protocol/daemon-protocol-rpc-validation.ts";
+import { workspacePathFormat } from "../../preset/src/preset-command-contract.ts";
 import { parseThinCommand } from "../src/cli/thin-command.ts";
 
 test("daemon lifecycle command inputs and thin CLI parameters are projections of Task Actions", () => {
@@ -37,6 +38,7 @@ test("daemon lifecycle command inputs and thin CLI parameters are projections of
                 required: field.required,
                 ...(field.enum ? { enum: field.enum } : {}),
                 ...(field.regex ? { regex: field.regex } : {}),
+                ...(field.field === "fromFile" ? { format: workspacePathFormat } : {}),
                 ...(field.cli.jsonSchema
                   ? {
                       jsonFields: field.cli.jsonSchema.fields

--- a/packages/cli/test/thin-command-contract-parity.test.ts
+++ b/packages/cli/test/thin-command-contract-parity.test.ts
@@ -8,6 +8,7 @@ import {
   validateDaemonRpcCall,
 } from "../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { unknownFieldViolation } from "../../daemon/src/protocol/json-rpc-types.ts";
+import { workspacePathFormat } from "../../preset/src/preset-command-contract.ts";
 import { deriveThinCliInputs, parseThinCommand } from "../src/cli/thin-command.ts";
 
 const frozenMutations = Object.freeze([
@@ -119,6 +120,7 @@ test("all public commands expose the canonical structured input facet", () => {
     assert.deepEqual(jsonInput.jsonFields, fromFile.jsonFields, `${id}: JSON required fields match`);
     assert.deepEqual(jsonInput.jsonAllowedFields, fromFile.jsonAllowedFields, `${id}: JSON allowed fields match`);
     assert.equal(jsonInput.format, "<json|@->", `${id}: stdin format`);
+    assert.equal(fromFile.format, workspacePathFormat, `${id}: workspace path rule`);
     assert.equal(fromFile.conflictsWith?.includes("--json-input"), true, `${id}: file conflict`);
     assert.equal(jsonInput.conflictsWith?.includes("--from-file"), true, `${id}: inline conflict`);
   }

--- a/packages/cli/test/thin-command-fact-decision.test.ts
+++ b/packages/cli/test/thin-command-fact-decision.test.ts
@@ -1,7 +1,12 @@
 // harness-test-tier: fast
 import assert from "node:assert/strict";
 import test from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { daemonProtocolCommands } from "../../daemon/src/protocol/daemon-protocol.contract.ts";
+import { readWorkspaceText } from "../../daemon/src/workspace-text-port.ts";
+import { workspacePathFormat, workspacePathResolutionRule } from "../../preset/src/preset-command-contract.ts";
 import { parseThinCommand } from "../src/cli/thin-command.ts";
 import { materializePacketStdin } from "../src/index.ts";
 
@@ -535,6 +540,36 @@ test("Decision F06 and distill leaf commands preserve their complete structured 
   assert.equal(parseThinCommand(["decision", "validate", "dec_1", "--all"]).ok, false);
   assert.equal(parseThinCommand(["decision", "transition", "retired", "dec_1", "--standing-policy"]).ok, false);
   assert.equal(parseThinCommand(["decision", "amend", "dec_1"]).ok, false);
+});
+
+test("Decision file-flag help and the workspace read rejection state one shared path rule", () => {
+  const fileFlagHelpLine = (commandId: string, flag: string) =>
+    daemonProtocolCommands
+      .find((command) => command.id === commandId)
+      ?.help.split("\n")
+      .find((line) => line.trim().startsWith(`${flag} —`));
+  for (const [commandId, flag] of [
+    ["decision-propose", "--from-file"],
+    ["decision-propose", "--body-file"],
+    ["decision-amend", "--body-file"],
+  ] as const) {
+    const line = fileFlagHelpLine(commandId, flag);
+    assert.ok(line, `${commandId}: ${flag} help line`);
+    assert.ok(line?.includes(`format: ${workspacePathFormat}`), line);
+  }
+  const root = mkdtempSync(path.join(tmpdir(), "ha-path-rule-"));
+  try {
+    assert.throws(
+      () => readWorkspaceText(root, "missing-relative-probe.json", "fromFile"),
+      (error: Error) => {
+        assert.ok(error.message.includes("fromFile"), error.message);
+        assert.ok(error.message.includes(workspacePathResolutionRule), error.message);
+        return true;
+      },
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("Decision human consent defaults absent consent-at and consent-channel at the CLI plane", () => {

--- a/packages/daemon/src/protocol/daemon-protocol-commands-decision-lifecycle.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-decision-lifecycle.ts
@@ -6,6 +6,7 @@ import {
   defineLedgerWriteCommand,
   defineLocalArbiterCommand,
   defineRepoReadCommand,
+  workspacePathFormat,
 } from "../../../preset/src/preset-command-contract.ts";
 
 export const decisionLifecycleProtocolCommands = Object.freeze([
@@ -74,6 +75,7 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
           jsonFields: decisionProposalRequiredJsonFields,
           jsonAllowedFields: decisionProposalJsonFields,
           jsonDefaultFields: decisionProposalDefaultJsonFields,
+          format: workspacePathFormat,
           conflictsWith: ["--json-input"],
         },
       ),
@@ -113,6 +115,7 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
         },
         {
           requiresAny: ["--from-file", "--json-input"],
+          format: workspacePathFormat,
           conflictsWith: ["--body"],
         },
       ),
@@ -313,9 +316,15 @@ export const decisionLifecycleProtocolCommands = Object.freeze([
       cliInput("--body", "single", false, {
         code: "invalid_field",
       }),
-      cliInput("--body-file", "single", false, {
-        code: "invalid_field",
-      }),
+      cliInput(
+        "--body-file",
+        "single",
+        false,
+        {
+          code: "invalid_field",
+        },
+        { format: workspacePathFormat },
+      ),
       cliInput("--dry-run", "boolean", false, {
         code: "invalid_field",
       }),

--- a/packages/daemon/src/protocol/daemon-protocol-commands-people.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-people.ts
@@ -1,4 +1,4 @@
-import { cliInput, defineCliCommand } from "../../../preset/src/preset-command-contract.ts";
+import { cliInput, defineCliCommand, workspacePathFormat } from "../../../preset/src/preset-command-contract.ts";
 import { credentialKindWords, peopleCommandClassWords } from "./daemon-protocol-vocabulary.ts";
 
 export const peopleAddJsonFields = Object.freeze(["personId", "displayName", "role", "commandClass"] as const),
@@ -41,7 +41,12 @@ const peopleWriteTopology = {
       "single",
       false,
       { code: "invalid_field" },
-      { jsonFields: requiredFields, jsonAllowedFields: allowedFields, conflictsWith: ["--json-input"] },
+      {
+        jsonFields: requiredFields,
+        jsonAllowedFields: allowedFields,
+        format: workspacePathFormat,
+        conflictsWith: ["--json-input"],
+      },
     ),
     cliInput(
       "--json-input",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-runtime-fleet.ts
@@ -5,6 +5,7 @@ import {
   defineHostAdminCommand,
   defineRepoReadCommand,
   defineRuntimeLocalWriteCommand,
+  workspacePathFormat,
 } from "../../../preset/src/preset-command-contract.ts";
 
 export const runtimeFleetProtocolCommands = Object.freeze([
@@ -273,7 +274,12 @@ const schedulePacketInputs = (requiredFields: readonly string[], allowedFields: 
     "single",
     false,
     { code: "invalid_field" },
-    { jsonFields: requiredFields, jsonAllowedFields: allowedFields, conflictsWith: ["--json-input"] },
+    {
+      jsonFields: requiredFields,
+      jsonAllowedFields: allowedFields,
+      format: workspacePathFormat,
+      conflictsWith: ["--json-input"],
+    },
   ),
   cliInput(
     "--json-input",

--- a/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands-task.ts
@@ -8,6 +8,7 @@ import {
   generatedTaskActionProtocolDeclarations,
   generatedTaskCreateResultFields,
   generatedWriteReceiptFields,
+  workspacePathFormat,
   type GeneratedTaskActionProtocolDeclaration,
 } from "../../../preset/src/preset-command-contract.ts";
 export { generatedTaskActionProtocolDeclarations, generatedTaskCreateResultFields, generatedWriteReceiptFields };
@@ -37,6 +38,9 @@ function taskActionCliInputs(action: GeneratedTaskActionProtocolDeclaration) {
               }),
               ...(field.enum ? { enum: field.enum } : {}),
               ...(field.regex ? { regex: field.regex } : {}),
+              // The kernel contract carries the packet shape; the workspace-root path rule belongs
+              // to the daemon read layer, so it is added here where the CLI facet is assembled.
+              ...(field.field === "fromFile" ? { format: workspacePathFormat } : {}),
             }),
           ]
         : [],

--- a/packages/daemon/src/workspace-text-port.ts
+++ b/packages/daemon/src/workspace-text-port.ts
@@ -1,5 +1,6 @@
 import { readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
+import { workspacePathResolutionRule } from "../../preset/src/preset-command-contract.ts";
 
 /** Physical workspace text reads stay in the daemon adapter layer. */
 export function readWorkspaceText(rootDir: string, requested: string, field: string): string {
@@ -15,8 +16,7 @@ export function readWorkspaceText(rootDir: string, requested: string, field: str
   } catch (error) {
     if (isBoundaryError(error)) throw error;
     throw portError(
-      `${field} must name a readable UTF-8 file inside workspace root ${rootDir}; ` +
-        "relative paths are resolved from this root.",
+      `${field} must name a readable UTF-8 file inside workspace root ${rootDir}; ${workspacePathResolutionRule}.`,
     );
   }
 }

--- a/packages/preset/src/preset-command-contract.ts
+++ b/packages/preset/src/preset-command-contract.ts
@@ -57,6 +57,12 @@ export function cliInput<const Extra extends Readonly<Record<string, unknown>> =
   >;
 }
 
+// The daemon's workspace file reads (readWorkspaceText) and every --from-file/--body-file help
+// facet must state this one rule; interpolating the constant keeps help and the runtime rejection
+// on the same source instead of two hand-copied sentences.
+export const workspacePathResolutionRule = "relative paths resolve from the workspace root, not the current directory";
+export const workspacePathFormat = `<path; ${workspacePathResolutionRule}>`;
+
 export function regexLength(regex: string | undefined): readonly [number, number] | undefined {
   const match = regex?.match(
     /^\^(?:\[(?:\\.|[^\]\\\r\n])*\]|\\(?:[dDsSwW]|[pP]\{[^}\r\n]+\})|\.)(?:\{(\d+)(?:,(\d+))?\})\$$/u,
@@ -219,6 +225,7 @@ const taskCreateCliInputs = Object.freeze(
         ...(field.enum ? { enum: field.enum } : {}),
         ...(field.regex ? { regex: field.regex } : {}),
         ...cli,
+        ...(cli.name === "--from-file" ? { format: workspacePathFormat } : {}),
       }),
     ];
   }),


### PR DESCRIPTION
# English

## Summary

`ha decision propose --from-file tasks/<t>/x.json` run from inside `harness/` was rejected, and the operator could not learn the rule from `--help`: the daemon resolves relative file paths from the workspace root, not the current directory, but only the runtime rejection said so and the help for `--from-file`/`--body-file` listed JSON fields only. The rule is now one exported constant in the preset command contract (`workspacePathResolutionRule`), interpolated into the daemon's `readWorkspaceText` rejection and into a `format` facet on every daemon-read file flag (decision propose/amend, people and schedule packet helpers, runtime fleet, task `fromFile` inputs), so `--help` and the rejection are the same sentence from the same source. Goal 3 audit: there is no duplicated path guard to delete — the CLI passes the string through and `readWorkspaceText` is the only read/boundary layer.

## Architectural Justification

One constant owns the rule; help and rejection both interpolate it. No second guard, no wrapper.

## What Changed

- `packages/preset/src/preset-command-contract.ts` (+7): exports `workspacePathResolutionRule` and the derived `workspacePathFormat` (`<path; …>`).
- `packages/daemon/src/workspace-text-port.ts` (+2/-2): the rejection text interpolates the constant instead of a hand-copied sentence.
- `packages/daemon/src/protocol/daemon-protocol-commands-decision-lifecycle.ts` (+13/-2), `-people.ts` (+7/-2), `-runtime-fleet.ts` (+7/-1), `-task.ts` (+4): `format: workspacePathFormat` on `--from-file`/`--body-file` and generated `fromFile` inputs.
- Tests: `thin-command-fact-decision.test.ts` (+35) locks the help line and the rejection text against the constant; `guidance-plane.test.ts`, `task-action-derivation.test.ts`, `thin-command-contract-parity.test.ts` (+7/-1) updated for the new facet.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +39/-8 production; tests +42/-1.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_d6cfb48c613148fe74f40c0294 (parent none)
- Branch: `codex/decision-from-file-help`
- Public scope: help/rejection wording for workspace file flags across daemon protocol docs and the preset command contract.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Changing where relative paths resolve (cwd vs workspace root) is not touched; the outside-root rejection keeps naming field, root and example without the rule sentence (a different failure).

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `30507c100`
- Branch merge-base with `origin/main`: `30507c100`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/decision-from-file-help`
- Private evidence commit/path: task_d6cfb48c613148fe74f40c0294 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO ground-truth on the rebased head 9cc816448 (base origin/main 30507c100): `run-node-tests --file` on the four touched CLI test files reports tests 27 / pass 26 / fail 1, the one failure being the pre-existing macOS-only tmpdir case in `guidance-plane.test.ts` (task_2b4858be); `run-local-line-density` G36 pass; `check-file-complexity` pass; `check-pr-governance` skipped (no protected surface); `git grep` shows the rule sentence defined once. Worker (report `artifacts/reports/decision-from-file-help.md`): red-first on the three new/extended tests, `npm test -- --tier fast --tier contract` 1128 pass / 0 fail, eight consumer integration files dispatched through `dispatch-isolated-test.mjs` all exit 0.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; verified the constant is defined once and every occurrence of the rule sentence is an interpolation of it.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Help output for the affected flags grows by one clause; any golden-file snapshot of `--help` outside the updated tests would need refreshing (none found by grep).

## References

- Task: task_d6cfb48c613148fe74f40c0294

---

# 中文

## 概要

在 `harness/` 目录下跑 `ha decision propose --from-file tasks/<t>/x.json` 被拒，而操作者从 `--help` 学不到规则：daemon 以 workspace root（不是当前目录）解析相对文件路径，但只有运行时拒绝文案这么说，`--from-file`/`--body-file` 的 help 只列 JSON 字段。现在该规则是 preset command contract 里唯一导出的常量 `workspacePathResolutionRule`，同时插入 daemon `readWorkspaceText` 的拒绝文案和每个 daemon 读取的文件 flag 的 `format` facet（decision propose/amend、people 与 schedule packet 辅助命令、runtime fleet、task 的 `fromFile` 输入），help 与拒绝是同一来源的同一句话。Goal 3 审计：没有可删的重复路径守卫——CLI 原样透传字符串，`readWorkspaceText` 是唯一的读取/边界层。

## 架构辩护

一个常量拥有规则，help 与拒绝都插值它；无第二层守卫、无包装。

## 改动内容

- `packages/preset/src/preset-command-contract.ts`（+7）：导出 `workspacePathResolutionRule` 与派生的 `workspacePathFormat`（`<path; …>`）。
- `packages/daemon/src/workspace-text-port.ts`（+2/-2）：拒绝文案插值该常量，替换手抄句子。
- `daemon-protocol-commands-decision-lifecycle.ts`（+13/-2）、`-people.ts`（+7/-2）、`-runtime-fleet.ts`（+7/-1）、`-task.ts`（+4）：给 `--from-file`/`--body-file` 与生成的 `fromFile` 输入加 `format: workspacePathFormat`。
- 测试：`thin-command-fact-decision.test.ts`（+35）锁定 help 行与拒绝文案均来自该常量；`guidance-plane.test.ts`、`task-action-derivation.test.ts`、`thin-command-contract-parity.test.ts`（+7/-1）随新 facet 更新。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+39/-8 production; tests +42/-1。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_d6cfb48c613148fe74f40c0294（父 none）
- 分支：`codex/decision-from-file-help`
- 公开范围：daemon 协议文档与 preset command contract 中 workspace 文件 flag 的 help/拒绝文案。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：不改相对路径的解析基准（cwd 还是 workspace root）；越界（outside-root）拒绝仍只点名字段、根与示例，不带规则句（那是另一种失败）。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`30507c100`
- 分支与 `origin/main` 的 merge-base：`30507c100`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/decision-from-file-help`
- 私有证据路径：task_d6cfb48c613148fe74f40c0294 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO 在 rebase 后 head 9cc816448（base origin/main 30507c100）核实：四个触碰的 CLI 测试文件 `run-node-tests --file` 报 tests 27 / pass 26 / fail 1，唯一失败是 `guidance-plane.test.ts` 里已存在的 macOS-only tmpdir 用例（task_2b4858be）；`run-local-line-density` G36 pass；`check-file-complexity` pass；`check-pr-governance` 跳过（无受保护面）；`git grep` 显示规则句只定义一次。worker（报告 `artifacts/reports/decision-from-file-help.md`）：三个新增/扩展测试先红后绿，`npm test -- --tier fast --tier contract` 1128 pass / 0 fail，八个消费方 integration 文件经 `dispatch-isolated-test.mjs` 派测全部 exit 0。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过常量只定义一次，规则句的每次出现都是对它的插值。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 受影响 flag 的 help 多一个从句；若有更新测试之外的 `--help` 快照需要刷新（grep 未发现）。

## 参考

- 任务：task_d6cfb48c613148fe74f40c0294

