### PR TITLE
fix: answer task_not_found for task reads on ids the projection does not hold

### DIFF
--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -24,6 +24,7 @@ import type {
 } from "./protocol/daemon-protocol.contract.ts";
 import type { AgentRuntimeAttemptChainDto } from "./agent-runtime-contract.ts";
 import { runtimePidIsAlive } from "./runtime-spawn-process.ts";
+import { projectedTaskNotFound } from "./projection-readiness.ts";
 
 type DispatchLiveIndexRow = ReturnType<typeof readDispatchLiveIndex>["entries"][number];
 
@@ -65,8 +66,14 @@ export function readTaskDispatches(
         : { taskIds: [singleTaskId] },
     batch = input.projection.readTaskRuntimeBatch(query),
     tasks = new Map(batch.rows.map((row) => [row.taskId, row]));
+  if (singleTaskId !== undefined) {
+    const notFound = projectedTaskNotFound(input.projection.read(singleTaskId), singleTaskId);
+    if (notFound !== null) throw notFound;
+  }
   if (singleTaskId !== undefined && !batch.rows[0]?.packagePath)
-    throw new Error(`Task ${singleTaskId} has no projected package path.`);
+    throw Object.assign(new Error(`Task ${singleTaskId} has no projected package path.`), {
+      code: "task_not_found",
+    });
   const sessions = new Map(
     batch.rows.flatMap((task) => task.sessions.map((session) => [session.runtimeSessionId, session] as const)),
   );

--- a/packages/daemon/src/projection-readiness.ts
+++ b/packages/daemon/src/projection-readiness.ts
@@ -23,6 +23,23 @@ export function requireCurrentTaskProjection(
   return read;
 }
 
+// Serving read faces (task show, task dispatches) resolve one requested id against the applied
+// cut: a current projection without that task is a not-found answer naming the id, never an
+// empty success. A lagging cut stays the caller's pending case — not-found must not race a
+// projection that could still apply the task. Callers throw it or settle it into a receipt
+// per their channel; the judgment and its wording live only here.
+export function projectedTaskNotFound(
+  read: Pick<ReturnType<TaskProjection["read"]>, "watermark" | "sourceRevision" | "snapshot">,
+  taskId: string,
+): (Error & { readonly code: "task_not_found" }) | null {
+  if (read.watermark < read.sourceRevision) return null;
+  return read.snapshot.task
+    ? null
+    : Object.assign(new Error(`Task ${taskId} does not exist in the canonical event stream.`), {
+        code: "task_not_found",
+      } as const);
+}
+
 function projectionNotReady(
   label: string,
   cut: { readonly watermark: number; readonly sourceRevision: number },

--- a/packages/daemon/src/repo-cell-completion.ts
+++ b/packages/daemon/src/repo-cell-completion.ts
@@ -16,6 +16,8 @@ import type { RepoCellBinding, Snapshot } from "./repo-cell-types.ts";
 import { resolveTaskRootThreshold } from "./task-wip-settings.ts";
 import type { RepoCellActionContext } from "./repo-cell-action-context.ts";
 import { renderEvidencePayload } from "./repo-cell-evidence.ts";
+import { failed } from "./repo-cell-settlement.ts";
+import { projectedTaskNotFound } from "./projection-readiness.ts";
 
 export function publishCiWitness(
   cell: RepoCellActionContext,
@@ -130,7 +132,12 @@ export function taskShowFromProjection(
   const read = projection.read(taskId),
     progress = projection.readProgress(taskId),
     rootSetting = resolveTaskRootThreshold(rootDir),
-    task = read.snapshot.task,
+    notFound = projectedTaskNotFound(read, taskId);
+  // task-show answers with receipts on every path — the fleet lease probe reads outcome/code
+  // off the receipt — so settle the shared judgment instead of throwing past the attached
+  // fast path, which has no write-queue settlement.
+  if (notFound !== null) return failed(`read:${taskId}`, notFound);
+  const task = read.snapshot.task,
     rootAssessment = task
       ? deriveTaskRoot(
           {

--- a/packages/daemon/test/dispatch-read.test.ts
+++ b/packages/daemon/test/dispatch-read.test.ts
@@ -39,6 +39,7 @@ function session(
 
 function projectionFor(current: RuntimeSession): TaskProjection {
   return {
+    read: () => ({ watermark: 1, sourceRevision: 1, snapshot: { task: { taskId } } }),
     readTaskRuntimeBatch: () => ({
       status: "ready",
       taskIds: [taskId],
@@ -81,6 +82,63 @@ test("a dispatch whose session has exited reports unknown, not running", () => {
   assert.equal(statusFor(session("exited", null)), "unknown");
   assert.equal(statusFor(session("unknown", null)), "unknown");
   assert.equal(statusFor(session("stale", null)), "unknown");
+});
+
+// A read that resolves one taskId answers from the projection: an id the projection does not
+// hold is a not-found answer naming that id, never a bare untyped throw that callers must
+// guess at (bootstrap_failed downstream).
+test("a single-task query for an id the projection does not have answers task_not_found naming the id", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-read-not-found-"));
+  try {
+    const projection = {
+      read: () => ({ watermark: 1, sourceRevision: 1, snapshot: { task: null } }),
+      readTaskRuntimeBatch: () => ({
+        status: "ready",
+        taskIds: [taskId],
+        rows: [],
+        watermark: 1,
+        sourceRevision: 1,
+      }),
+      readReplicaBasis: () => {
+        throw new Error("dispatch reads must not enumerate the replica document basis");
+      },
+      readDocument: () => ({ document: null }),
+    } as unknown as TaskProjection;
+    assert.throws(
+      () => readTaskDispatches({ rootDir, projection, taskId: "task_9bfc3029" }),
+      (error: Error & { code?: string }) =>
+        error.code === "task_not_found" &&
+        /Task task_9bfc3029 does not exist in the canonical event stream\./u.test(error.message),
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("a single-task query for a task without a projected package answers task_not_found naming the id", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-read-no-package-"));
+  try {
+    const projection = {
+      read: () => ({ watermark: 1, sourceRevision: 1, snapshot: { task: { taskId, title: "Packless" } } }),
+      readTaskRuntimeBatch: () => ({
+        status: "ready",
+        taskIds: [taskId],
+        rows: [{ taskId, packagePath: null, sessions: [] }],
+        watermark: 1,
+        sourceRevision: 1,
+      }),
+      readReplicaBasis: () => {
+        throw new Error("dispatch reads must not enumerate the replica document basis");
+      },
+      readDocument: () => ({ document: null }),
+    } as unknown as TaskProjection;
+    assert.throws(
+      () => readTaskDispatches({ rootDir, projection, taskId }),
+      (error: Error & { code?: string }) => error.code === "task_not_found" && error.message.includes(taskId),
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
 });
 
 test("a daemon restart loss is a terminal lost dispatch", () => {
@@ -212,6 +270,7 @@ test("an unbound detached dispatch is read from the live index", () => {
     });
     appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: 12345 });
     const projection = {
+      read: () => ({ watermark: 1, sourceRevision: 1, snapshot: { task: { taskId } } }),
       readTaskRuntimeBatch: () => ({
         status: "ready",
         taskIds: [taskId],
@@ -293,6 +352,7 @@ test("live and archived rows carry the parent runtime session edge only when pre
       resultRef: "artifact:runtime-result/sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     };
     const projection = {
+      read: () => ({ watermark: 1, sourceRevision: 1, snapshot: { task: { taskId } } }),
       readTaskRuntimeBatch: () => ({
         status: "ready",
         taskIds: [taskId],
@@ -346,6 +406,7 @@ test("archived dispatch rows expose terminal result and task artifact references
       resultRef: "artifact:runtime-result/sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     };
     const projection = {
+      read: () => ({ watermark: 1, sourceRevision: 1, snapshot: { task: { taskId } } }),
       readTaskRuntimeBatch: () => ({
         status: "ready",
         taskIds: [taskId],

--- a/packages/daemon/test/rejection-next-actions.integration.test.ts
+++ b/packages/daemon/test/rejection-next-actions.integration.test.ts
@@ -489,6 +489,33 @@ test("review-execution against a nonexistent task names the missing task", async
   }
 });
 
+test("task reads against a task id the projection does not have answer task_not_found naming the requested id", async () => {
+  const rootDir = workspace("task-read-not-found"),
+    repoId = workspaceId("task-read-not-found"),
+    reader = binding("task-read-not-found");
+  let cell: Awaited<ReturnType<typeof openRepoCell>> | undefined;
+  try {
+    cell = await openRepoCell({ repoId, rootDir: canonicalRoot(rootDir), ownerId: "task-read-not-found" });
+    // A short prefix and a full-length id that was never created are the same question:
+    // does the canonical projection hold this task?
+    for (const taskId of ["task_9bfc3029", "task_00000000000000000000000000"]) {
+      const shown = await cell.run({ kind: "task-show", taskId }, reader);
+      assert.equal(shown.outcome, "op_rejected", JSON.stringify(shown));
+      assert.equal(shown.code, "task_not_found", JSON.stringify(shown));
+      assert.match(String(shown.rejectionExplanation), new RegExp(taskId, "u"));
+      const dispatches = await cell.read("repo.task.dispatches", { taskId }, reader).then(
+        () => null,
+        (error: Error & { code?: string }) => error,
+      );
+      assert.equal(dispatches?.code, "task_not_found", String(dispatches));
+      assert.match(String(dispatches?.message), new RegExp(taskId, "u"));
+    }
+  } finally {
+    await cell?.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function binding(executorId: string) {
   return {
     actor: { principal: { personId: "person-owner" }, executor: { kind: "agent" as const, id: executorId } },

--- a/packages/daemon/test/squad-coordinator-recovery.test.ts
+++ b/packages/daemon/test/squad-coordinator-recovery.test.ts
@@ -199,11 +199,7 @@ function makeRecoveryFixture(
         sessions.find((session) => session.runtimeSessionId === runtimeSessionId) ?? null,
     } as unknown as TaskProjection,
     store = {
-      read: () => ({
-        schema: "canonical-event-stream/v1",
-        revision: 0,
-        events: [],
-      }),
+      read: () => ({ schema: "canonical-event-stream/v1", revision: 0, events: [] }),
       readContentBlob: (sha256: string) => resultBodies.get(sha256) ?? null,
     } as CanonicalEventStore;
   return {

--- a/packages/daemon/test/squad-coordinator-recovery.test.ts
+++ b/packages/daemon/test/squad-coordinator-recovery.test.ts
@@ -156,6 +156,7 @@ function makeRecoveryFixture(
   });
 
   const projection = {
+      read: (taskId: string) => ({ watermark: 1, sourceRevision: 1, snapshot: { task: { taskId } } }),
       readTaskStatuses: () => ({ status: "ready", rows: [], watermark: 1, sourceRevision: 1 }),
       readTaskRuntimeBatch: (query: { readonly taskIds: readonly string[] }) => ({
         status: "ready",

--- a/packages/daemon/test/squad-run-detail-read.test.ts
+++ b/packages/daemon/test/squad-run-detail-read.test.ts
@@ -101,6 +101,7 @@ function leaderArchive(): Record<string, unknown> {
 function projectionWith(archives: ReadonlyMap<string, Record<string, unknown>>): TaskProjection {
   const rows: { squadRunId: string; revision: number; state: unknown }[] = [];
   return {
+    read: (taskId: string) => ({ watermark: 1, sourceRevision: 1, snapshot: { task: { taskId } } }),
     readTaskStatuses: () => ({ status: "ready", rows: [], watermark: 1, sourceRevision: 1 }),
     readTaskRuntimeBatch: (query: { readonly taskIds: readonly string[] }) => ({
       status: "ready" as const,

--- a/packages/daemon/test/squad-run-list-window.test.ts
+++ b/packages/daemon/test/squad-run-list-window.test.ts
@@ -145,6 +145,7 @@ function projectionWith(
   const rows: { squadRunId: string; revision: number; state: unknown }[] = [],
     batchCalls: (readonly string[])[] = [];
   return {
+    read: () => ({ watermark: 1, sourceRevision: 1, snapshot: { task: { taskId: "squad-window-witness" } } }),
     readTaskStatuses: () => ({ status: "ready", rows: [], watermark: 1, sourceRevision: 1 }),
     readTaskRuntimeBatch: (query: { readonly taskIds: readonly string[] }) => {
       batchCalls.push(query.taskIds);


### PR DESCRIPTION
# English

## Summary

`ha task show <id>` for an id the projection does not hold (a short prefix, a typo, a task from another repo) answered `ok` with `task=null revision=0` and a completionNext that told the operator to rebuild the canonical projection, and `ha task dispatches <same id>` answered a bare `bootstrap_failed`. Both are wrong answers to the same question. The judgment now lives once, in `projectedTaskNotFound()` in `projection-readiness.ts`: when the projection cut has caught up with the source revision and still has no task for the id, the answer is `task_not_found` naming the id; when the cut lags, the caller keeps its pending case so not-found never races a projection that could still apply the task. `taskShowFromProjection` settles it into a failed receipt (the fleet lease probe reads outcome/code off task-show receipts), and `dispatch-read` throws it so the RPC layer maps it instead of falling through to the bootstrap fallback; the package-path miss there now also carries the `task_not_found` code.

## Architectural Justification

One judgment function owns the not-found decision and its wording; each read face only chooses how to deliver it (receipt vs throw) per its channel. No new error code, no CLI-side guessing.

## What Changed

- `packages/daemon/src/projection-readiness.ts` (+17): `projectedTaskNotFound(read, taskId)` — the single not-found judgment and wording.
- `packages/daemon/src/repo-cell-completion.ts` (+7/-1): `taskShowFromProjection` settles the judgment into a `failed` receipt instead of returning an applied receipt with `task: null`.
- `packages/daemon/src/dispatch-read.ts` (+8/-1): single-task dispatch reads apply the judgment before reading, and the package-path miss carries `code: "task_not_found"`.
- Tests: `dispatch-read.test.ts` (+61) and `rejection-next-actions.integration.test.ts` (+27) lock task-show and task-dispatches on a short prefix and on a full-length unknown id (red before the fix, reproducing the `task=null` + rebuild suggestion); `squad-run-list-window.test.ts` (+1) supplies the field the shared read shape now needs.
- `squad-coordinator-recovery.test.ts` (+1), `squad-run-detail-read.test.ts` (+1): the projection stubs gain the `read` face the shared judgment consults (first CI run of this PR failed in `fast-contract` with `input.projection.read is not a function` from `squad-coordinator.ts` → `readTaskDispatches`; the stubs were partial, production `TaskProjection` already has `read`).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +33/-2 production; tests +91/-0.

## Per-Write Cost

G1 probe (`node tools/gates/cost-budget.mjs`, same machine; base = canonical main 30507c100, head = this branch 74be892ee before rebase). `task-show` is the read face whose not-found branch changed; the probe only reads tasks that exist, so the new branch is never taken and all counts are identical before/after (all 14 probed operations compared; `agenda` is omitted from the table only because the lint's operation-name pattern requires a hyphen, its counts are likewise identical).

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |
| runtime-overview | sqlRowsRead | 150 | 1446 | 150 | 1446 |
| runtime-overview | sha256Calls | 0 | 0 | 0 | 0 |
| runtime-overview | sha256Bytes | 0 | 0 | 0 | 0 |
| runtime-overview | gitProcesses | 0 | 0 | 0 | 0 |
| runtime-overview | fileReadBytes | 0 | 0 | 0 | 0 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_9bfc30291aa26570c662f67c47 (parent none)
- Branch: `codex/task-not-found-read`
- Public scope: daemon task read faces (task show, task dispatches) for ids the projection does not hold.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: The task-id shape itself is not validated anywhere new (short prefixes are rejected because the projection has no such task, not by a regex); the ULID-only `taskIdPattern` in kernel layout belongs to task_b6254d4b / task_f7cc215a.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `d334263e6`
- Branch merge-base with `origin/main`: `d334263e6`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/task-not-found-read`
- Private evidence commit/path: task_9bfc30291aa26570c662f67c47 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO ground-truth on head c1ff6a0f4 (after the stub fix): `run-node-tests --file` on `dispatch-read.test.ts`, `rejection-next-actions.integration.test.ts`, `squad-run-list-window.test.ts` reports tests 36 / pass 36 / fail 0; `run-local-line-density` G36 pass; `check-file-complexity` pass; `check-pr-governance` skipped (no protected surface). Worker (report `artifacts/reports/task-not-found-read.md`): red-first on the three new cases, mutation (judgment removed) red in both tiers, `npm test -- --tier fast --tier contract` 1128/1128 after rebase and after commit. The worker also ran the whole integration tier once and saw one unrelated red in `packages/kernel/test/store/daemon-registry.test.ts`; the CEO re-ran that file on main 30507c100 and it passes 15/15, so it was a load artifact of the full-tier run, not a main defect. After the fix the six files that stub the projection (`agent-runtime-session-groups.contract`, `artifacts-gui.contract`, `squad-run-detail-read`, `squad-coordinator-recovery`, `squad-run-list-window`, `dispatch-read`) run with fail 0.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; verified there is exactly one not-found definition and that the fleet lease probe's `code === "task_not_found"` path now has a real producer.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The lagging-cut case (watermark below source revision) is left pending by design and is exercised only through the existing pending-path tests, not by a new dedicated case; a real daemon end-to-end CLI render of the new receipt was not hand-run (the receipt shape is locked by the integration test).

## References

- Task: task_9bfc30291aa26570c662f67c47

---

# 中文

## 概要

`ha task show <id>` 对投影里不存在的 id（短前缀、手误、别的仓的 task）回 `ok` + `task=null revision=0`，completionNext 还让操作者去重建 canonical 投影；`ha task dispatches <同一 id>` 回裸 `bootstrap_failed`。同一个问题两种错答。现在判定只在一处：`projection-readiness.ts` 的 `projectedTaskNotFound()`——投影 cut 已追上 source revision 仍无该 task 时，答案是点名 id 的 `task_not_found`；cut 落后时调用方保持 pending，不让 not-found 与可能仍会应用该 task 的投影赛跑。`taskShowFromProjection` 把它结算成 failed receipt（fleet 的 lease 探测从 task-show receipt 读 outcome/code），`dispatch-read` 抛出让 RPC 层映射而不再落到 bootstrap 兜底；那里的 package-path 缺失现在也带 `task_not_found` 码。

## 架构辩护

一个判定函数拥有 not-found 的决定与文案；各读面只按自己的通道选择投递方式（receipt 或 throw）。不新增错误码，不在 CLI 侧猜。

## 改动内容

- `packages/daemon/src/projection-readiness.ts`（+17）：`projectedTaskNotFound(read, taskId)`，唯一的 not-found 判定与文案。
- `packages/daemon/src/repo-cell-completion.ts`（+7/-1）：`taskShowFromProjection` 把判定结算成 `failed` receipt，不再返回带 `task: null` 的 applied receipt。
- `packages/daemon/src/dispatch-read.ts`（+8/-1）：单 task 的 dispatch 读在读取前先过判定；package-path 缺失带 `code: "task_not_found"`。
- 测试：`dispatch-read.test.ts`（+61）、`rejection-next-actions.integration.test.ts`（+27）锁定 task show / task dispatches 对短前缀与全长未知 id 的回答（修前红，精确复现 `task=null` + rebuild 建议）；`squad-run-list-window.test.ts`（+1）补共享读形状新需要的字段。
- `squad-coordinator-recovery.test.ts`（+1）、`squad-run-detail-read.test.ts`（+1）：projection stub 补上共享判定要读的 `read` 面（本 PR 第一次 CI 在 `fast-contract` 红：`squad-coordinator.ts` → `readTaskDispatches` 报 `input.projection.read is not a function`；stub 是部分实现，生产 `TaskProjection` 本就有 `read`）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+33/-2 production; tests +91/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_9bfc30291aa26570c662f67c47（父 none）
- 分支：`codex/task-not-found-read`
- 公开范围：daemon 任务读面（task show、task dispatches）对投影不持有的 id 的回答。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：不在任何新地方校验 task id 形状（短前缀被拒是因为投影没有该 task，不是正则）；kernel layout 里只认 ULID 的 `taskIdPattern` 属 task_b6254d4b / task_f7cc215a。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`d334263e6`
- 分支与 `origin/main` 的 merge-base：`d334263e6`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/task-not-found-read`
- 私有证据路径：task_9bfc30291aa26570c662f67c47 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO 在 head c1ff6a0f4（stub 修复后）核实：`run-node-tests --file` 跑 `dispatch-read.test.ts`、`rejection-next-actions.integration.test.ts`、`squad-run-list-window.test.ts` 报 tests 36 / pass 36 / fail 0；`run-local-line-density` G36 pass；`check-file-complexity` pass；`check-pr-governance` 跳过（无受保护面）。worker（报告 `artifacts/reports/task-not-found-read.md`）：三条新用例先红后绿，变异（删掉判定）两个 tier 都红，`npm test -- --tier fast --tier contract` rebase 后与 commit 后各 1128/1128。worker 还整跑了一次 integration tier，看到 `packages/kernel/test/store/daemon-registry.test.ts` 一条无关红；CEO 在 main 30507c100 单跑该文件 15/15 通过，是整层并跑的负载伪影，不是 main 缺陷。 修复后六个 stub 该投影的文件（`agent-runtime-session-groups.contract`、`artifacts-gui.contract`、`squad-run-detail-read`、`squad-coordinator-recovery`、`squad-run-list-window`、`dispatch-read`）跑 fail 0。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过 not-found 定义只有一处，且 fleet lease 探测的 `code === "task_not_found"` 路径现在有了真实生产者。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- cut 落后（watermark 低于 source revision）的分支按设计保持 pending，只由既有 pending 路径测试覆盖，没有新增专门用例；没有手起真 daemon 端到端看 CLI 对新 receipt 的渲染（receipt 形状已由 integration 测试锁定）。

## 参考

- 任务：task_9bfc30291aa26570c662f67c47

