### PR TITLE
fix(gui): admit paged relation-graph facets in the preload with the daemon's own validator

### DIFF
--- a/packages/gui/src/preload/allowlist.ts
+++ b/packages/gui/src/preload/allowlist.ts
@@ -1,7 +1,8 @@
 import { daemonGuiInvokeFacets, daemonGuiStreamFacets } from "../../../daemon/src/protocol/daemon-protocol.contract.ts";
 import { admitUseCaseProjectionSelector } from "../../../daemon/src/protocol/daemon-protocol-gui-types.ts";
 import { isUtcTimestamp } from "../../../daemon/src/protocol/json-rpc-types.ts";
-import { relationDirections, relationStates } from "../../../kernel/src/index.ts";
+import { validateDaemonQueryPayload } from "../../../daemon/src/protocol/daemon-protocol-rpc-validation.ts";
+import { relationStates } from "../../../kernel/src/index.ts";
 import { containsSecretLikeKey } from "../api/entity-payload-hygiene.ts";
 import { isRuntimeKindId, runtimeKindForId, runtimeKindIds } from "../../../daemon/src/runtime-inventory.ts";
 export const HARNESS_PRELOAD_API = "harness";
@@ -102,19 +103,22 @@ export function assertPreloadPayload(method: string, payload: unknown): true {
     }
     if (emptyRepoMethods.has(method) && Object.keys(payload).some((key) => key !== "repoId"))
       throw new Error(`Preload ${method} fields are not allowed.`);
-    if (queryRepoMethods.has(method as PreloadApiMethod)) {
-      // A relation-graph facet selector is a different read, not a page window over the
-      // wide one: mirror the daemon's closure rule (facet + its own selectors, and never
-      // both a facet and a legacy status/time/page field) so the renderer is rejected here
-      // instead of at the daemon boundary.
+    if (method === "getRelationGraph" && payload.facet !== undefined) {
+      // A facet selector is admitted by the daemon's own query validator, which owns the facet
+      // vocabularies (edges: facet, relationType, state, direction, limit, cursor; facts: facet,
+      // limit, cursor; other facets: facet only) and rejects unknown fields. Restating that list
+      // here is what broke the paged edges read: the renderer paged with limit/cursor and the
+      // hand-copied list still forbade them, so the request never reached the daemon.
+      const { repoId: _repoId, ...selector } = payload;
+      const errors = validateDaemonQueryPayload("repo.triadic.relationGraph", selector);
+      if (errors.length > 0) throw new Error(`Preload ${method} query facets are invalid: ${errors[0]}`);
+    } else if (queryRepoMethods.has(method as PreloadApiMethod)) {
       const fields =
         method === "getAgenda"
           ? ["repoId", "limit", "cursor"]
           : method === "getTasks"
             ? ["repoId", "status", "changedAfterRevision", "updatedAfter", "updatedBefore", "limit", "cursor"]
-            : payload.facet === undefined
-              ? ["repoId", "status", "updatedAfter", "updatedBefore", "limit", "cursor"]
-              : ["repoId", "facet", "relationType", "state", "direction"];
+            : ["repoId", "status", "updatedAfter", "updatedBefore", "limit", "cursor"];
       if (!closed(payload, fields)) throw new Error(`Preload ${method} fields are not allowed.`);
       if (!validQueryPayload(method, payload)) throw new Error(`Preload ${method} query facets are invalid.`);
     }
@@ -356,20 +360,12 @@ function validQueryPayload(method: string, value: Record<string, unknown>): bool
   const after = value.updatedAfter,
     before = value.updatedBefore,
     changedAfterRevision = value.changedAfterRevision,
-    facet = value.facet,
     states =
       method === "getTasks" ? ["planned", "active", "blocked", "in_review", "done", "cancelled"] : relationStates,
     common =
       (value.limit === undefined ||
         (Number.isSafeInteger(value.limit) && Number(value.limit) >= 1 && Number(value.limit) <= 500)) &&
       (value.cursor === undefined || (typeof value.cursor === "string" && value.cursor.length > 0));
-  if (method === "getRelationGraph" && facet !== undefined)
-    return (
-      ["edges", "facts", "coverageRows", "factAnchors", "runtimeEdges"].includes(String(facet)) &&
-      (facet !== "edges" || validRelationEdgeFacetSelectors(value)) &&
-      (facet === "edges" ||
-        (value.relationType === undefined && value.state === undefined && value.direction === undefined))
-    );
   return method === "getAgenda"
     ? common
     : common &&
@@ -382,15 +378,6 @@ function validQueryPayload(method: string, value: Record<string, unknown>): bool
         !(typeof after === "string" && typeof before === "string" && after > before);
 }
 /** Selectors exist only on the edge facet, and `state` there shares the edge-state vocabulary. */
-function validRelationEdgeFacetSelectors(value: Record<string, unknown>): boolean {
-  return (
-    (value.relationType === undefined || typeof value.relationType === "string") &&
-    (value.state === undefined ||
-      (typeof value.state === "string" && relationStates.includes(value.state as (typeof relationStates)[number]))) &&
-    (value.direction === undefined ||
-      relationDirections.includes(String(value.direction) as (typeof relationDirections)[number]))
-  );
-}
 /** `repo.decisions.list` carries one selector: the summary projection the mounted chrome reads. */
 function validDecisionListPayload(value: Record<string, unknown>): boolean {
   if (!closed(value, ["repoId", "projection"])) return false;

--- a/packages/gui/test/preload-allowlist.test.ts
+++ b/packages/gui/test/preload-allowlist.test.ts
@@ -84,6 +84,31 @@ test("preload exposes only the approved API methods", () => {
     }),
     true,
   );
+  // The renderer pages the edges facet (task_249009a7a7978b203cfe7177fd): a page window travels
+  // with the facet exactly as the daemon's own validator admits it, and the daemon's closure still
+  // rejects legacy list fields or a page window on a facet that has none.
+  assert.equal(
+    assertPreloadPayload("getRelationGraph", {
+      repoId: "repo-a",
+      facet: "edges",
+      state: "active",
+      limit: 500,
+      cursor: "eAo",
+    }),
+    true,
+  );
+  assert.throws(
+    () => assertPreloadPayload("getRelationGraph", { repoId: "repo-a", facet: "edges", status: "active" }),
+    /query facets are invalid/u,
+  );
+  assert.throws(
+    () => assertPreloadPayload("getRelationGraph", { repoId: "repo-a", facet: "coverageRows", limit: 5 }),
+    /query facets are invalid/u,
+  );
+  assert.throws(
+    () => assertPreloadPayload("getRelationGraph", { repoId: "repo-a", facet: "edges", limit: 0 }),
+    /query facets are invalid/u,
+  );
   assert.equal(assertPreloadPayload("getTaskDispatches", { repoId: "repo-a", taskId: "task-a" }), true);
   assert.equal(
     assertPreloadPayload("getTaskDispatches", { repoId: "repo-a", taskIds: ["task-a", "task-b"], limit: 2 }),


### PR DESCRIPTION
# English

## Summary

The Electron GUI shows 关系读取失败 (relation read failed) for every relation view since PR #2538: that PR made the renderer page the relation graph's `edges` facet with `limit: 500` plus a `cursor`, but the preload allowlist kept its own hand-copied field list for a facet selector (`repoId, facet, relationType, state, direction`) and rejected the renderer's own payload with `Preload getRelationGraph fields are not allowed` before any IPC left the preload, so the daemon never saw a `repo.triadic.relationGraph` request (zero in today's connection log while the daemon answers the same request in 30 ms over the socket). The preload now admits a facet selector through the daemon's own `validateDaemonQueryPayload`, which already owns the per-facet vocabularies and rejects unknown fields; the duplicated list and the `validRelationEdgeFacetSelectors` helper are deleted. Non-facet relation queries, `getTasks` and `getAgenda` keep their existing preload closure.

## Architectural Justification

One validator owns the facet vocabulary; the preload calls it instead of restating it (the pattern `admitUseCaseProjectionSelector` already uses in the same file). Net production deletion.

## What Changed

- `packages/gui/src/preload/allowlist.ts` (+13/-26): `getRelationGraph` with a `facet` delegates to `validateDaemonQueryPayload("repo.triadic.relationGraph", selector)`; the facet field list, the facet branch of `validQueryPayload`, `validRelationEdgeFacetSelectors` and the now-unused `relationDirections` import are removed.
- `packages/gui/test/preload-allowlist.test.ts` (+25): the paged edges payload (`facet, state, limit, cursor`) is accepted; `facet` with a legacy `status`, a page window on `coverageRows`, and `limit: 0` are rejected with the daemon's reason.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +13/-26 production; tests +25/-0.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_249009a7a7978b203cfe7177fd (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/preload-relation-page`
- Public scope: GUI preload admission of relation-graph facet queries.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: `getTasks`/`getAgenda`/non-facet relation queries keep their preload field lists (a later single-sourcing can follow the same pattern); the daemon validator and renderer paging are unchanged.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes
- Protected surface scope: `packages/gui/src/preload/allowlist.ts` (renderer→main IPC admission). The change narrows nothing and widens only what the daemon already admits: a `getRelationGraph` facet selector is now checked by the daemon's own `validateDaemonQueryPayload`, which rejects unknown fields and validates limit/cursor/state/direction per facet; the hand-copied preload field list that contradicted it is deleted. No new method is exposed, repoId closure, secret-key hygiene and every other method's checks are unchanged.
- Authority: task task_249009a7a7978b203cfe7177fd (GUI relation read regression from PR #2538), parent task_2b8f79fa4412cb726a26f9bfc7
- Machine-check boundary: `packages/gui/test/preload-allowlist.test.ts` 16/16 on this branch, including the new paged-edges admission and three rejection cases; `check-file-complexity`, `run-local-line-density`, prettier and eslint green
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `091d78e7c`
- Branch merge-base with `origin/main`: `091d78e7c`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/preload-relation-page`
- Private evidence commit/path: task_249009a7a7978b203cfe7177fd `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO: reproduced the failure by calling `assertPreloadPayload("getRelationGraph", …)` with the renderer's exact payloads on main (both rejected) and against this branch (both accepted); the same two payloads answer in 30 ms / 8 ms directly over the daemon socket and page through 22 pages / 10,979 edges for the canonical repo. `run-node-tests --file packages/gui/test/preload-allowlist.test.ts` 16/16; `run-local-line-density` G36 pass; `check-file-complexity` pass; prettier clean; eslint clean on both files; `tsc -p packages/gui` reports no errors beyond TS6305 project-reference noise.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; verified the daemon-side closure (`unknownFieldViolation`) covers what the deleted preload list covered, and that the renderer payloads are admitted end to end.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The preload error text for facet queries now carries the daemon's reason (`… query facets are invalid: repo.triadic.relationGraph.payload.limit is invalid`); the existing regex assertions only match the prefix. The Electron GUI must be restarted from a checkout containing this commit for the preload bundle to pick it up.

## References

- Task: task_249009a7a7978b203cfe7177fd

---

# 中文

## 概要

Electron GUI 自 PR #2538 起所有关系视图都显示「关系读取失败」：那次 PR 让渲染层用 `limit: 500` + `cursor` 分页读关系图的 `edges` facet，但 preload 白名单仍保留自己手抄的 facet 字段清单（`repoId, facet, relationType, state, direction`），把渲染层自己发的 payload 以 `Preload getRelationGraph fields are not allowed` 拒在 preload 内、IPC 都没发出，daemon 从未收到 `repo.triadic.relationGraph`（今天的连接日志里为零，而同一请求直连 socket 30 ms 就回）。现在 preload 对 facet 选择器直接调用 daemon 自己的 `validateDaemonQueryPayload`（它已拥有每个 facet 的词表并拒绝未知字段）；重复清单与 `validRelationEdgeFacetSelectors` 删除。非 facet 的关系查询、`getTasks`、`getAgenda` 保持既有的 preload 闭包。

## 架构辩护

一个校验器拥有 facet 词表，preload 调用它而不是复述（同文件里 `admitUseCaseProjectionSelector` 已是这个模式）。生产净删除。

## 改动内容

- `packages/gui/src/preload/allowlist.ts`（+13/-26）：带 `facet` 的 `getRelationGraph` 委托 `validateDaemonQueryPayload("repo.triadic.relationGraph", selector)`；删除 facet 字段清单、`validQueryPayload` 的 facet 分支、`validRelationEdgeFacetSelectors` 与不再使用的 `relationDirections` 导入。
- `packages/gui/test/preload-allowlist.test.ts`（+25）：分页的 edges payload（`facet, state, limit, cursor`）被接受；`facet` 搭配旧的 `status`、对 `coverageRows` 加分页窗口、`limit: 0` 都以 daemon 的理由被拒。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+13/-26 production; tests +25/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_249009a7a7978b203cfe7177fd（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/preload-relation-page`
- 公开范围：GUI preload 对关系图 facet 查询的准入。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：`getTasks`/`getAgenda`/非 facet 关系查询保留各自的 preload 字段清单（之后可按同一模式单源化）；daemon 校验器与渲染层分页不动。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：是
- 受保护面范围：`packages/gui/src/preload/allowlist.ts`（渲染层→主进程 IPC 准入）。本改动不收窄任何东西，只放开 daemon 本就接受的范围：`getRelationGraph` 的 facet 选择器改由 daemon 自己的 `validateDaemonQueryPayload` 校验（拒绝未知字段，按 facet 校验 limit/cursor/state/direction）；与之矛盾的 preload 手抄字段清单删除。不暴露新方法，repoId 闭包、secret 键检查与其它方法的校验不变。
- 授权：task task_249009a7a7978b203cfe7177fd（PR #2538 引入的 GUI 关系读取回归），父任务 task_2b8f79fa4412cb726a26f9bfc7
- 机器检查边界：本分支 `packages/gui/test/preload-allowlist.test.ts` 16/16（含新增的分页 edges 准入与三条拒绝用例）；`check-file-complexity`、`run-local-line-density`、prettier、eslint 全绿
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`091d78e7c`
- 分支与 `origin/main` 的 merge-base：`091d78e7c`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/preload-relation-page`
- 私有证据路径：task_249009a7a7978b203cfe7177fd 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO：用渲染层的原始 payload 调 `assertPreloadPayload("getRelationGraph", …)` 在 main 上复现（两条都被拒），在本分支上两条都通过；同样两条 payload 直连 daemon socket 分别 30 ms / 8 ms 返回，对 canonical 仓能翻完 22 页 / 10,979 条边。`run-node-tests --file packages/gui/test/preload-allowlist.test.ts` 16/16；`run-local-line-density` G36 pass；`check-file-complexity` pass；prettier 干净；两个文件 eslint 干净；`tsc -p packages/gui` 除 TS6305 项目引用噪音外无错误。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；核过 daemon 侧闭包（`unknownFieldViolation`）覆盖了被删 preload 清单的范围，且渲染层 payload 端到端被接受。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- facet 查询的 preload 报错文案现在带 daemon 的原因（`… query facets are invalid: repo.triadic.relationGraph.payload.limit is invalid`），既有正则断言只匹配前缀。Electron GUI 必须从包含本提交的检出重启，preload bundle 才会带上修复。

## 参考

- 任务：task_249009a7a7978b203cfe7177fd

