### PR TITLE
fix(daemon): route task read-set and task review through the shared projection judgment

### DIFF
--- a/packages/daemon/src/repo-cell-task-query.ts
+++ b/packages/daemon/src/repo-cell-task-query.ts
@@ -16,6 +16,7 @@ import {
   type WriteReceiptDraft as WriteReceipt,
 } from "../../kernel/src/index.ts";
 import { readTaskReadSet } from "../../application/src/index.ts";
+import { requireCurrentTaskProjection } from "./projection-readiness.ts";
 import type { RepoCellBinding, RepoTaskAction } from "./repo-cell-types.ts";
 import { requiredPackageDisposition, type TaskQueryReadModel } from "./task-query-read.ts";
 import { resolveTaskRootThreshold, resolveTaskWipLimit } from "./task-wip-settings.ts";
@@ -47,7 +48,6 @@ export interface TaskQueryCell {
   readonly requiredCellText: (value: unknown, name: string) => string;
   readonly wipSnapshotEntries: (activatingTaskId: string) => readonly TaskWipSnapshotEntryV1[];
   readonly legacyReviewLint: typeof import("./repo-cell-review-lint.ts").legacyReviewLint;
-  readonly projectionReady: (value: { readonly status: string }) => boolean;
   readonly now: () => string;
 }
 
@@ -341,13 +341,8 @@ export function listRelations(cell: TaskQueryCell, action: RepoTaskAction, bindi
  */
 export function taskReadSet(cell: TaskQueryCell, action: RepoTaskAction, binding: RepoCellBinding): WriteReceipt {
   const taskId = cell.requiredCellText(action.taskId, "taskId"),
-    current = cell.projection.read(taskId);
-  if (!cell.projectionReady(current) || !current.snapshot.task)
-    throw cell.cellCodedError(
-      "task_not_found",
-      `Run ha task list, choose an existing task id, then retry task read-set.`,
-    );
-  const derived = readTaskReadSet(cell.projection, taskId);
+    current = requireCurrentTaskProjection(cell.projection, taskId, "task read-set"),
+    derived = readTaskReadSet(cell.projection, taskId);
   return cell.readResult(
     cell.operationId(action, binding, cell.input.repoId, current.sourceRevision),
     derived,
@@ -359,12 +354,7 @@ export function taskReadSet(cell: TaskQueryCell, action: RepoTaskAction, binding
 
 export function reviewTask(cell: TaskQueryCell, action: RepoTaskAction, binding: RepoCellBinding): WriteReceipt {
   const taskId = cell.requiredCellText(action.taskId, "taskId"),
-    current = cell.projection.read(taskId);
-  if (!cell.projectionReady(current) || !current.snapshot.task || !current.packagePath)
-    throw cell.cellCodedError(
-      "task_not_found",
-      `Run ha task list, choose an existing task id, then retry task review.`,
-    );
+    current = requireCurrentTaskProjection(cell.projection, taskId, "task review");
   const document = cell.projection.readDocument(`${current.packagePath}/review.md`),
     report = document.document
       ? cell.legacyReviewLint(

--- a/packages/daemon/test/rejection-next-actions.integration.test.ts
+++ b/packages/daemon/test/rejection-next-actions.integration.test.ts
@@ -499,10 +499,12 @@ test("task reads against a task id the projection does not have answer task_not_
     // A short prefix and a full-length id that was never created are the same question:
     // does the canonical projection hold this task?
     for (const taskId of ["task_9bfc3029", "task_00000000000000000000000000"]) {
-      const shown = await cell.run({ kind: "task-show", taskId }, reader);
-      assert.equal(shown.outcome, "op_rejected", JSON.stringify(shown));
-      assert.equal(shown.code, "task_not_found", JSON.stringify(shown));
-      assert.match(String(shown.rejectionExplanation), new RegExp(taskId, "u"));
+      for (const kind of ["task-show", "task-read-set", "task-review"] as const) {
+        const shown = await cell.run({ kind, taskId }, reader);
+        assert.equal(shown.outcome, "op_rejected", `${kind} ${JSON.stringify(shown)}`);
+        assert.equal(shown.code, "task_not_found", `${kind} ${JSON.stringify(shown)}`);
+        assert.match(String(shown.rejectionExplanation), new RegExp(taskId, "u"), kind);
+      }
       const dispatches = await cell.read("repo.task.dispatches", { taskId }, reader).then(
         () => null,
         (error: Error & { code?: string }) => error,

--- a/packages/daemon/test/task-read-set.integration.test.ts
+++ b/packages/daemon/test/task-read-set.integration.test.ts
@@ -163,10 +163,14 @@ test("task read-set derives one ordered projection per cut and never writes back
     assert.equal(isolated.blocked, false);
     assert.equal(isolated.taskRef, "task/task_read_set_isolated");
 
-    // Negative control: an unknown task id fails with the standard read command code.
-    const missing = await readSet("task_read_set_absent");
-    assert.equal(missing.outcome, "op_rejected", JSON.stringify(missing));
-    assert.equal(missing.code, "task_not_found", JSON.stringify(missing));
+    // Negative control: an unknown id and a short prefix of a real id are the same not-found
+    // answer from the shared judgment, naming the id that was asked for.
+    for (const absent of ["task_read_set_absent", "task_read_set_ho"]) {
+      const missing = await readSet(absent);
+      assert.equal(missing.outcome, "op_rejected", JSON.stringify(missing));
+      assert.equal(missing.code, "task_not_found", JSON.stringify(missing));
+      assert.match(String(missing.rejectionExplanation), new RegExp(`${absent} does not exist`, "u"));
+    }
   } finally {
     await cell.close();
     rmSync(rootDir, { recursive: true, force: true });


### PR DESCRIPTION
# English

## Summary

Follow-up to PR #2588 for the same task. The closeout review found that `task read-set` and `task review` still kept their own not-found branch in `repo-cell-task-query.ts`: `!projectionReady || !task` threw `task_not_found` with a generic `Run ha task list …` hint, which also reported a lagging projection cut as not-found. Both faces now call `requireCurrentTaskProjection` (the same judgment the task-gated commands use inside the RepoCell write queue): a lagging cut is `content_not_ready`, a missing task is `task_not_found` naming the requested id, and a task without a projected package is `content_not_ready`. The two hand-written branches and the `projectionReady` member of `TaskQueryCell` are deleted.

## Architectural Justification

One judgment for one requested task id against the applied cut, shared by task show, task dispatches, task read-set, task review and the task-gated writers; net production deletion.

## What Changed

- `packages/daemon/src/repo-cell-task-query.ts` (+4/-14): `taskReadSet` and `reviewTask` resolve the task through `requireCurrentTaskProjection`; the two `task_not_found` throw blocks and the `projectionReady` interface member are removed.
- `packages/daemon/test/task-read-set.integration.test.ts`: the negative control now covers an unknown id and a short prefix of a real id, and asserts the explanation names the id.
- `packages/daemon/test/rejection-next-actions.integration.test.ts`: the not-found case from #2588 runs `task-show`, `task-read-set` and `task-review` for both ids.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +4/-14 production; tests +14/-8.

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_9bfc30291aa26570c662f67c47 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/read-face-shared-judgment`
- Public scope: Daemon read faces `task read-set` and `task review` for an id the projection does not hold.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Write-path faces that still inline `!projectionReady || !task` (`repo-cell-task-maintenance.ts`, `repo-cell-task-command-docs.ts`, `repo-cell-action-dispatch.ts`) are unchanged; they gate mutations, not reads, and are outside this task's contract.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `ac367830d`
- Branch merge-base with `origin/main`: `ac367830d`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/read-face-shared-judgment`
- Private evidence commit/path: task_9bfc30291aa26570c662f67c47 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node tools/run-node-tests.mjs --file packages/daemon/test/task-read-set.integration.test.ts --file packages/daemon/test/rejection-next-actions.integration.test.ts`: tests 13 / pass 13 / fail 0. `run-local-line-density` G36 pass; `check-file-complexity` pass; prettier and eslint clean on the three files; `tsc -p packages/daemon` reports nothing beyond the TS6305 project-reference cascade. No other source or doc references the removed `then retry task read-set` / `then retry task review` wording (only stale `dist/` outputs).

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; wrote the change directly (14-line diff) after the independent closeout review of task_9bfc3029 round 2 named the gap; re-ran the two integration files and the local gates.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A caller that reads `task read-set` while its projection cut lags now gets `content_not_ready` with watermark/sourceRevision instead of `task_not_found`; that is the intended correction (not-found must not race a cut that could still apply the task). The CLI hint text for a missing task changes to the shared `Task <id> does not exist in the canonical event stream.`

## References

- Task: task_9bfc30291aa26570c662f67c47

---

# 中文

## 概要

同一任务 PR #2588 的补丁。closeout 评审发现 `task read-set` 与 `task review` 在 `repo-cell-task-query.ts` 里仍各留一份 not-found 分支：`!projectionReady || !task` 抛 `task_not_found` 并给通用的 `Run ha task list …` 提示，还把投影落后也报成 not-found。两个读面现在改调 `requireCurrentTaskProjection`（RepoCell 写队列内 task-gated 命令用的同一判定）：投影落后为 `content_not_ready`，任务不存在为点名请求 id 的 `task_not_found`，有事件但无投影包为 `content_not_ready`。两段手写分支与 `TaskQueryCell` 的 `projectionReady` 成员删除。

## 架构辩护

对已应用 cut 上一个请求 id 只有一个判定，task show、task dispatches、task read-set、task review 与 task-gated 写方共用；生产净删除。

## 改动内容

- `packages/daemon/src/repo-cell-task-query.ts`（+4/-14）：`taskReadSet`、`reviewTask` 经 `requireCurrentTaskProjection` 解析任务；删除两段 `task_not_found` throw 与 `projectionReady` 接口成员。
- `packages/daemon/test/task-read-set.integration.test.ts`：阴性对照覆盖未知 id 与真实 id 的短前缀，并断言解释点名该 id。
- `packages/daemon/test/rejection-next-actions.integration.test.ts`：#2588 的 not-found 用例对两个 id 各跑 `task-show`、`task-read-set`、`task-review`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+4/-14 production; tests +14/-8。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_9bfc30291aa26570c662f67c47（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/read-face-shared-judgment`
- 公开范围：daemon 读面 `task read-set`、`task review` 对投影中不存在 id 的应答。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：仍内联 `!projectionReady || !task` 的写路面（`repo-cell-task-maintenance.ts`、`repo-cell-task-command-docs.ts`、`repo-cell-action-dispatch.ts`）不动；它们守的是变更不是读取，不在本任务契约内。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`ac367830d`
- 分支与 `origin/main` 的 merge-base：`ac367830d`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/read-face-shared-judgment`
- 私有证据路径：task_9bfc30291aa26570c662f67c47 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- `node tools/run-node-tests.mjs --file packages/daemon/test/task-read-set.integration.test.ts --file packages/daemon/test/rejection-next-actions.integration.test.ts`：tests 13 / pass 13 / fail 0。`run-local-line-density` G36 pass；`check-file-complexity` pass；三个文件 prettier、eslint 干净；`tsc -p packages/daemon` 除 TS6305 项目引用级联外无错。被删的 `then retry task read-set` / `then retry task review` 文案在源码与文档中再无引用（只剩过期 `dist/`）。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；task_9bfc3029 round-2 独立 closeout 评审点名该缺口后，CEO 直接写了这 14 行 diff；重跑两个集成测试文件与本地门。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 投影落后时读 `task read-set` 的调用方现在拿到带 watermark/sourceRevision 的 `content_not_ready` 而不是 `task_not_found`；这是有意的纠正（not-found 不能与尚可能应用该任务的 cut 赛跑）。任务不存在时的 CLI 提示改为共享的 `Task <id> does not exist in the canonical event stream.`

## 参考

- 任务：task_9bfc30291aa26570c662f67c47

