### PR TITLE
perf(kernel): hoist domain static regexes and lookup tables to module level

### DIFF
--- a/packages/kernel/src/domain/agent-squad-schema.ts
+++ b/packages/kernel/src/domain/agent-squad-schema.ts
@@ -191,11 +191,12 @@ export function serializeAgentDeclarationV1(value: unknown): string {
 export function serializeSquadDeclarationV1(value: unknown): string {
   return serialize(SQUAD_DECLARATION_V1_SCHEMA, value, "squad declaration");
 }
+const runtimeTypeIdentifierPattern = new RegExp(ENTITY_ID_PATTERN, "u");
 export function isRuntimeTypeIdentifier(value: string): boolean {
-  return new RegExp(ENTITY_ID_PATTERN, "u").test(value);
+  return runtimeTypeIdentifierPattern.test(value);
 }
 export function entitySlug(value: unknown): value is string {
-  return typeof value === "string" && new RegExp(ENTITY_ID_PATTERN, "u").test(value);
+  return typeof value === "string" && runtimeTypeIdentifierPattern.test(value);
 }
 export function entityNonEmpty(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;

--- a/packages/kernel/src/domain/artifact-entity.ts
+++ b/packages/kernel/src/domain/artifact-entity.ts
@@ -6,7 +6,7 @@ import type {
   EntityKindSchemaVersion,
 } from "../schemas/vertical-definition.ts";
 import { artifactEntityIdPattern } from "./entity-ref.ts";
-import { parseEntityJsonSchema, type EntityDocumentJsonSchema } from "./entity-json-schema.ts";
+import { compiledPattern, parseEntityJsonSchema, type EntityDocumentJsonSchema } from "./entity-json-schema.ts";
 import {
   genericAuthoring,
   genericEntityStore,
@@ -143,7 +143,7 @@ export function mintArtifactEntityId(input: { readonly idPrefix: string; readonl
 export const ARTIFACT_ENTITY_ID_BYTES = 16;
 
 export function isArtifactEntityId(idPrefix: string, value: unknown): value is string {
-  return typeof value === "string" && new RegExp(artifactEntityIdPattern(idPrefix), "u").test(value);
+  return typeof value === "string" && compiledPattern(artifactEntityIdPattern(idPrefix)).test(value);
 }
 
 export function deriveArtifactContentVersion(witness: ArtifactContentWitness): string {

--- a/packages/kernel/src/domain/base-entity.ts
+++ b/packages/kernel/src/domain/base-entity.ts
@@ -3,6 +3,7 @@ import { timestamp } from "./timestamp.ts";
 import { validateActorIdentity, type ActorIdentity } from "./actor-identity.ts";
 import { isRecord, type WriteSource } from "./write-chain.contract.ts";
 import { entityFreshnesses, type EntityFreshness } from "./entity-freshness.ts";
+import { compiledPattern } from "./entity-json-schema.ts";
 
 export const ENTITY_ID_PATTERN = "^[a-z0-9][a-z0-9-]{0,63}$";
 export const entityDispositions = packageDispositions;
@@ -350,7 +351,7 @@ function entityRef<K extends string>(identity: EntityIdentityContract<K>, id: st
 }
 
 function matchesIdentity(identity: EntityIdentityContract, id: string): boolean {
-  return new RegExp(identity.refPattern ?? identity.pattern, "u").test(id);
+  return compiledPattern(identity.refPattern ?? identity.pattern).test(id);
 }
 
 function validWriteSource(value: unknown): value is WriteSource {

--- a/packages/kernel/src/domain/decision-event-validation-shared.ts
+++ b/packages/kernel/src/domain/decision-event-validation-shared.ts
@@ -1,23 +1,20 @@
 import { isNonEmptyString } from "./write-chain.contract.ts";
 
-export function includes<const T extends readonly string[]>(
-  values: T,
-  value: unknown,
-): value is T[number] {
-  return (
-    typeof value === "string" && (values as readonly string[]).includes(value)
-  );
+export function includes<const T extends readonly string[]>(values: T, value: unknown): value is T[number] {
+  return typeof value === "string" && (values as readonly string[]).includes(value);
 }
 
 export function decisionId(value: unknown): value is string {
   return typeof value === "string" && /^dec_[A-Za-z0-9_-]+$/u.test(value);
 }
 
+const optionIdPatterns = Object.freeze({
+  CH: /^CH[A-Za-z0-9_-]+$/u,
+  RJ: /^RJ[A-Za-z0-9_-]+$/u,
+} as const);
+
 export function optionId(value: unknown, prefix: "CH" | "RJ"): value is string {
-  return (
-    typeof value === "string" &&
-    new RegExp(`^${prefix}[A-Za-z0-9_-]+$`, "u").test(value)
-  );
+  return typeof value === "string" && optionIdPatterns[prefix].test(value);
 }
 
 export function claimId(value: unknown): value is string {
@@ -25,9 +22,5 @@ export function claimId(value: unknown): value is string {
 }
 
 export function uniqueFactStrings(value: unknown): value is readonly string[] {
-  return (
-    Array.isArray(value) &&
-    value.every(isNonEmptyString) &&
-    new Set(value).size === value.length
-  );
+  return Array.isArray(value) && value.every(isNonEmptyString) && new Set(value).size === value.length;
 }

--- a/packages/kernel/src/domain/entity-action-explanation.ts
+++ b/packages/kernel/src/domain/entity-action-explanation.ts
@@ -4,6 +4,7 @@ import {
   getEntityKindContract,
   type EntityActionContract,
   type EntityActionInputField,
+  type EntityKindContract,
 } from "./entity-kind-registry.ts";
 import { artifactEntityActionCatalog } from "./artifact-entity-actions.ts";
 import { isEntityActionUnmetCriterion, type EntityActionUnmetCriterionV1 } from "./receipt-domain-registry.ts";
@@ -360,15 +361,25 @@ function actionContract(value: unknown): EntityActionContract | null {
   return explanationCatalog(value.kind)?.actions.find(({ id }) => id === value.id) ?? null;
 }
 
+const entityKindRefPattern = new RegExp(`^${ENTITY_KIND_REF_PATTERN}$`, "u");
+
+// One catalog per declared artifact kind; explanation reads are hot and the catalog is a pure
+// function of the kind, so repeated catalog explanations reuse one compiled value.
+const artifactKindActionCatalogs = new Map<string, NonNullable<EntityKindContract["actionCatalog"]>>();
+
 function explanationCatalog(kind: string) {
   const registered = getEntityKindContract(kind)?.actionCatalog;
   if (registered) return registered;
-  if (!new RegExp(`^${ENTITY_KIND_REF_PATTERN}$`, "u").test(kind)) return null;
-  return artifactEntityActionCatalog(kind, {
+  if (!entityKindRefPattern.test(kind)) return null;
+  const cached = artifactKindActionCatalogs.get(kind);
+  if (cached) return cached;
+  const catalog = artifactEntityActionCatalog(kind, {
     field: "entityId",
     pattern: "^[A-Z][A-Z0-9]{0,15}-[a-f0-9]{16}$",
     refTemplate: `${kind}/{id}`,
   });
+  artifactKindActionCatalogs.set(kind, catalog);
+  return catalog;
 }
 
 function validateCriterion(value: unknown): readonly string[] {

--- a/packages/kernel/src/domain/entity-event.ts
+++ b/packages/kernel/src/domain/entity-event.ts
@@ -13,7 +13,7 @@ import {
   type ArtifactEntityContractSnapshot,
   type ArtifactLocator,
 } from "./artifact-entity.ts";
-import { parseEntityJsonSchema } from "./entity-json-schema.ts";
+import { compiledPattern, parseEntityJsonSchema } from "./entity-json-schema.ts";
 import {
   createEntityOwnedContent,
   entityDirectoryFootprint,
@@ -510,7 +510,7 @@ function validateDeletedPayload(
   }
   if (
     typeof payload.entityId !== "string" ||
-    !new RegExp(contract.id.pattern, "u").test(payload.entityId) ||
+    !compiledPattern(contract.id.pattern).test(payload.entityId) ||
     typeof payload.reason !== "string" ||
     !payload.reason.trim()
   )
@@ -538,7 +538,7 @@ function validateArtifactPayload(payload: Record<string, unknown>, allowUnknownF
     historical = isRecord(snapshot) && !Object.hasOwn(snapshot, "kindVersion"),
     validEntityId = historical
       ? typeof payload.entityId === "string" &&
-        new RegExp(`^${snapshot.idPrefix}-[a-f0-9]{16}$`, "u").test(payload.entityId)
+        compiledPattern(`^${String(snapshot.idPrefix)}-[a-f0-9]{16}$`).test(payload.entityId)
       : isArtifactEntityId(snapshot.idPrefix, payload.entityId);
   try {
     if (canonicalArtifactSourceIdentity(String(payload.sourceIdentity)) !== payload.sourceIdentity)
@@ -592,7 +592,7 @@ function validateUpsertPayload(
   } catch {
     return ["entity event kind is not registered"];
   }
-  if (typeof payload.entityId !== "string" || !new RegExp(contract.id.pattern, "u").test(payload.entityId))
+  if (typeof payload.entityId !== "string" || !compiledPattern(contract.id.pattern).test(payload.entityId))
     return ["entity event kind and identity are invalid"];
   return validateClaim(payload, contract, hasFields, schema, allowUnknownFields);
 }

--- a/packages/kernel/src/domain/entity-json-schema.ts
+++ b/packages/kernel/src/domain/entity-json-schema.ts
@@ -100,6 +100,18 @@ export function explainEntityJsonSchema(schema: EntityDocumentJsonSchema): reado
   }));
 }
 
+// One compiled RegExp per distinct pattern string, bounded by the schemas and kind contracts the
+// process has validated; shared by every identity/pattern check in the domain.
+const compiledPatterns = new Map<string, RegExp>();
+
+export function compiledPattern(pattern: string): RegExp {
+  const cached = compiledPatterns.get(pattern);
+  if (cached) return cached;
+  const compiled = new RegExp(pattern, "u");
+  compiledPatterns.set(pattern, compiled);
+  return compiled;
+}
+
 function validateNode(schema: EntityJsonSchemaNode, value: unknown, path: string, errors: string[]): void {
   if (value === null && schema["x-nullable"] === true) return;
   const errorStart = errors.length;
@@ -135,7 +147,7 @@ function validateNodeValue(schema: EntityJsonSchemaNode, value: unknown, path: s
       errors.push(`${path} must be one of ${schema.enum.join(", ")}.`);
     if (schema.minLength !== undefined && value.trim().length < schema.minLength)
       errors.push(`${path} must be a non-empty string.`);
-    if (schema.pattern !== undefined && !new RegExp(schema.pattern, "u").test(value))
+    if (schema.pattern !== undefined && !compiledPattern(schema.pattern).test(value))
       errors.push(`${path} does not match its declared pattern.`);
     return;
   }

--- a/packages/kernel/src/domain/entity-kind-registry.ts
+++ b/packages/kernel/src/domain/entity-kind-registry.ts
@@ -12,7 +12,7 @@ import {
 import { CONTRACT_VERSION_1_0, type ContractVersion } from "./contract-version.ts";
 import { DEFAULT_POLICY } from "./default-policy.ts";
 import { normalizeRelativeDocumentPath } from "../layout/portable-path.ts";
-import { explainEntityJsonSchema, type EntityDocumentJsonSchema } from "./entity-json-schema.ts";
+import { compiledPattern, explainEntityJsonSchema, type EntityDocumentJsonSchema } from "./entity-json-schema.ts";
 import { decisionSchema, executionSchema, factSchema, reviewSchema, taskSchema } from "./entity-document-schemas.ts";
 import {
   compileDecisionReckonAction,
@@ -906,7 +906,16 @@ export const entityKindContracts = Object.freeze([
 const entityKindContractByKind = new Map<string, EntityKindContract>(
   entityKindContracts.map((contract) => [contract.kind, contract]),
 );
-
+const executableActionsByIngress = new Map<string, EntityActionContract>(),
+  taskActionsByTransition = new Map<string, EntityActionContract>();
+for (const { actionCatalog, kind } of entityKindContracts as readonly EntityKindContract[])
+  for (const action of actionCatalog?.actions ?? []) {
+    if (action.execution?.ingress !== undefined && !executableActionsByIngress.has(action.execution.ingress))
+      executableActionsByIngress.set(action.execution?.ingress, action);
+    if (kind === "task")
+      for (const key of [action.id, `task.${action.id}`, action.execution?.lifecycle?.transitionId])
+        if (key !== undefined && !taskActionsByTransition.has(key)) taskActionsByTransition.set(key, action);
+  }
 export function getEntityKindContract(kind: string): EntityKindContract | undefined {
   return entityKindContractByKind.get(kind);
 }
@@ -916,20 +925,11 @@ export function isRelationEndpointKind(kind: string): kind is EntityKind {
 }
 
 export function getExecutableEntityAction(ingress: string): EntityActionContract | undefined {
-  for (const contract of entityKindContracts) {
-    const action = contract.actionCatalog?.actions.find((candidate) => candidate.execution?.ingress === ingress);
-    if (action) return action;
-  }
-  return undefined;
+  return executableActionsByIngress.get(ingress);
 }
 
 export function getTaskActionForTransition(transitionId: string): EntityActionContract | undefined {
-  return getEntityKindContract("task")?.actionCatalog?.actions.find(
-    (action) =>
-      action.id === transitionId ||
-      `task.${action.id}` === transitionId ||
-      action.execution?.lifecycle?.transitionId === transitionId,
-  );
+  return taskActionsByTransition.get(transitionId);
 }
 
 export function requireEntityKindContract(kind: string): EntityKindContract {
@@ -990,7 +990,7 @@ export function explainEntityKindContract(contract: EntityKindContract): EntityK
 }
 
 export function entityDocumentPath(contract: EntityStoreKindContract, id: string): string {
-  if (!new RegExp(contract.id.pattern, "u").test(id))
+  if (!compiledPattern(contract.id.pattern).test(id))
     throw Object.assign(new Error(`${id} is not a valid ${contract.kind} id.`), { code: "invalid_entity_id" });
   return contract.entityStore.document.pathTemplate.replace("{id}", id);
 }

--- a/packages/kernel/src/domain/entity-ref.ts
+++ b/packages/kernel/src/domain/entity-ref.ts
@@ -29,9 +29,10 @@ const artifactIdPrefixPattern = "[A-Z][A-Z0-9]{0,15}",
 export const ENTITY_KIND_ID_PATTERN = "KND-[0-9a-f]{32}";
 export const ENTITY_KIND_REF_PATTERN = `entity-kind/${ENTITY_KIND_ID_PATTERN}`;
 
+const entityKindIdPattern = new RegExp(`^${ENTITY_KIND_ID_PATTERN}$`, "u");
+
 export function entityKindRef(kindId: string): string {
-  if (!new RegExp(`^${ENTITY_KIND_ID_PATTERN}$`, "u").test(kindId))
-    throw new Error(`${kindId} is not a valid entity kind identity.`);
+  if (!entityKindIdPattern.test(kindId)) throw new Error(`${kindId} is not a valid entity kind identity.`);
   return `entity-kind/${kindId}`;
 }
 
@@ -55,20 +56,53 @@ function artifactRefBodyPattern(capture: boolean): string {
 }
 const artifactRefPattern = new RegExp(`^${artifactRefBodyPattern(true)}$`, "u");
 
+/**
+ * The built-in ref grammar, compiled once on first use: this module sits in an import cycle
+ * (entity-ref → base-entity → write-chain.contract → receipt-domain-registry → entity-ref), so the
+ * table may only be built once `entityTypeContracts` has actually initialized. Afterwards every
+ * parse reuses one table instead of rebuilding a RegExp per authority per call.
+ */
+interface CompiledRefAuthority {
+  readonly authority: EntityKindRefAuthority;
+  readonly parse: RegExp;
+  readonly identity: RegExp;
+}
+let compiledRefGrammar: {
+  readonly byOrder: readonly CompiledRefAuthority[];
+  readonly authorityByKind: ReadonlyMap<string, EntityKindRefAuthority>;
+  readonly identityByKind: ReadonlyMap<string, RegExp>;
+} | null = null;
+
+function refGrammar() {
+  if (compiledRefGrammar === null) {
+    const authorities = entityTypeContracts.map(({ kind, id }) => Object.freeze({ kind, ...id }));
+    const compiled = authorities.map((authority) => ({
+      authority,
+      parse: new RegExp(`^${compileRefBodyPattern(authority, true)}$`, "u"),
+      identity: new RegExp(authority.refPattern ?? authority.pattern, "u"),
+    }));
+    compiledRefGrammar = {
+      byOrder: compiled,
+      authorityByKind: new Map(authorities.map((authority) => [authority.kind, authority])),
+      identityByKind: new Map(compiled.map(({ authority, identity }) => [authority.kind, identity])),
+    };
+  }
+  return compiledRefGrammar;
+}
+
 export function parseEntityRef(value: string): ParsedEntityRef | null {
   const prefix = value.match(entityRefPrefixPattern),
     body = prefix?.groups?.body;
   if (!body) return null;
   const harnessAlias = prefix.groups?.alias;
 
-  for (const contract of refAuthorities()) {
-    const parse = new RegExp(`^${compileRefBodyPattern(contract, true)}$`, "u");
+  for (const { authority, parse } of refGrammar().byOrder) {
     const match = body.match(parse),
       id = match?.groups?.id;
     if (!id) continue;
     return {
       raw: value,
-      kind: contract.kind,
+      kind: authority.kind,
       id,
       ...(match.groups?.anchor ? { anchor: match.groups.anchor } : {}),
       ...(match.groups?.execution ? { ownerExecutionId: match.groups.execution } : {}),
@@ -88,16 +122,16 @@ export function parseEntityRef(value: string): ParsedEntityRef | null {
 }
 
 export function requireEntityKindRefAuthority(kind: string): EntityKindRefAuthority {
-  const authority = refAuthorities().find((candidate) => candidate.kind === kind);
+  const authority = refGrammar().authorityByKind.get(kind);
   if (!authority) throw new Error(`Entity kind ${kind} has no ref authority.`);
   return authority;
 }
 
 export function formatEntityRef(kind: string, id: string): EntityRef {
-  const authority = requireEntityKindRefAuthority(kind);
-  if (!new RegExp(authority.refPattern ?? authority.pattern, "u").test(id))
-    throw new Error(`${id} is not a valid ${kind} ref identity.`);
-  return authority.refTemplate.replace("{id}", id);
+  const identity = refGrammar().identityByKind.get(kind);
+  if (!identity) throw new Error(`Entity kind ${kind} has no ref authority.`);
+  if (!identity.test(id)) throw new Error(`${id} is not a valid ${kind} ref identity.`);
+  return requireEntityKindRefAuthority(kind).refTemplate.replace("{id}", id);
 }
 
 function compileRefBodyPattern(contract: EntityKindRefAuthority, capture: boolean): string {
@@ -105,7 +139,7 @@ function compileRefBodyPattern(contract: EntityKindRefAuthority, capture: boolea
     const token = segment.match(templateTokenPattern)?.groups?.kind;
     if (!token) return escapeRegExp(segment);
     const source: EntityKindRefAuthority | undefined =
-      token === "id" ? contract : refAuthorities().find(({ kind }) => kind === token);
+      token === "id" ? contract : refGrammar().authorityByKind.get(token);
     if (!source) throw new Error(`Entity ref template ${contract.refTemplate} names unknown kind ${token}.`);
     const pattern = unanchored(source.refPattern ?? source.pattern);
     return capture ? `(?<${token}>${pattern})` : `(?:${pattern})`;
@@ -113,10 +147,6 @@ function compileRefBodyPattern(contract: EntityKindRefAuthority, capture: boolea
   const anchorPattern = contract.anchorPattern ? unanchored(contract.anchorPattern) : "",
     anchor = contract.anchorPattern ? `(?:/${capture ? `(?<anchor>${anchorPattern})` : `(?:${anchorPattern})`})?` : "";
   return `${segments.join("/")}${anchor}`;
-}
-
-function refAuthorities(): readonly EntityKindRefAuthority[] {
-  return entityTypeContracts.map(({ kind, id }) => Object.freeze({ kind, ...id }));
 }
 
 function unanchored(pattern: string): string {

--- a/packages/kernel/src/domain/entity-relation.ts
+++ b/packages/kernel/src/domain/entity-relation.ts
@@ -1,4 +1,5 @@
 import { sha256Text } from "../integrity/stable-hash.ts";
+import { compiledPattern } from "./entity-json-schema.ts";
 import { parseEntityRef } from "./entity-ref.ts";
 import type { ParsedEntityRef } from "./entity-ref.ts";
 import { canonicalRelationDirections, type CanonicalRelationDirection } from "./relation-direction.ts";
@@ -66,6 +67,29 @@ export interface GovernedRelationRegistryWitness {
 export function relationStrengthForType(type: RelationType): RelationStrength {
   return type === "relates" ? "weak" : "strong";
 }
+
+function relationTripleKey(sourceKind: string, type: RelationType, targetKind: string): string {
+  return `${sourceKind}\0${type}\0${targetKind}`;
+}
+
+/**
+ * Inverted index over the canonical registry's writable rows, so each triple/record check is one lookup
+ * instead of a scan over every direction. Values are the strength rules of the rows that carry the
+ * triple, in registry order; `undefined` means the row leaves strength unconstrained.
+ */
+const writableRelationStrengths = new Map<string, readonly (RelationStrength | undefined)[]>(
+  (() => {
+    const strengths = new Map<string, (RelationStrength | undefined)[]>();
+    for (const direction of canonicalRelationDirections) {
+      if (direction.registration === "derived") continue;
+      const key = relationTripleKey(direction.sourceKind, direction.type, direction.targetKind);
+      const rules = strengths.get(key) ?? [];
+      rules.push(direction.strength);
+      strengths.set(key, rules);
+    }
+    return [...strengths];
+  })(),
+);
 
 export function normalizeLegacyRelationState(state: unknown): RelationState {
   if (state === "edge_retired") return "retired";
@@ -199,6 +223,8 @@ export function isAllowedRelationKindTriple(
   targetKind: string,
   registry: readonly CanonicalRelationDirection[] = canonicalRelationDirections,
 ): boolean {
+  if (registry === canonicalRelationDirections)
+    return writableRelationStrengths.has(relationTripleKey(sourceKind, type, targetKind));
   // Ratified convention (dec_mr74sbka, 2026-07-05): every edge reads as one sentence,
   // `source <verb> target`, in the physical (host -> target) direction — no cell whose
   // verb reads backwards. The canonical direction registry is the single authority:
@@ -223,6 +249,12 @@ export function isAllowedRelationRecord(
   targetKind: string,
   registry: readonly CanonicalRelationDirection[] = canonicalRelationDirections,
 ): boolean {
+  if (registry === canonicalRelationDirections) {
+    const strengths = writableRelationStrengths.get(relationTripleKey(sourceKind, record.type, targetKind));
+    return (
+      strengths !== undefined && strengths.some((strength) => strength === undefined || strength === record.strength)
+    );
+  }
   return registry.some(
     (direction) =>
       direction.registration !== "derived" &&
@@ -307,7 +339,7 @@ function matchesWitnessedEndpoint(
 ): boolean {
   const [prefix = "", suffix = ""] = endpoint.refTemplate.split("{id}");
   if (!ref.startsWith(prefix) || !ref.endsWith(suffix) || ref.length < prefix.length + suffix.length) return false;
-  return new RegExp(endpoint.idPattern, "u").test(ref.slice(prefix.length, ref.length - suffix.length));
+  return compiledPattern(endpoint.idPattern).test(ref.slice(prefix.length, ref.length - suffix.length));
 }
 
 function validGovernedArtifactEndpoint(

--- a/packages/kernel/src/domain/people-roster.ts
+++ b/packages/kernel/src/domain/people-roster.ts
@@ -1,4 +1,4 @@
-import type { EntityDocumentJsonSchema } from "./entity-json-schema.ts";
+import { compiledPattern, type EntityDocumentJsonSchema } from "./entity-json-schema.ts";
 import { parseDelegatedExecutionToken, type DelegatedExecutionToken } from "./delegated-execution-token.ts";
 import {
   parseRoleBinding,
@@ -604,7 +604,7 @@ export function validatePeopleRoster(
         throw new PeopleRosterContractError(`unknown command class: ${commandClass}`);
   }
   for (const person of people) {
-    if (!new RegExp(personIdPattern, "u").test(person.personId))
+    if (!compiledPattern(personIdPattern).test(person.personId))
       throw new PeopleRosterContractError(`invalid personId: ${person.personId || "<missing>"}`);
     if (personIds.has(person.personId)) throw new PeopleRosterContractError(`duplicate personId: ${person.personId}`);
     personIds.add(person.personId);

--- a/packages/kernel/src/domain/schedule.ts
+++ b/packages/kernel/src/domain/schedule.ts
@@ -7,6 +7,7 @@ import { timestamp } from "./timestamp.ts";
 import { hasContractFields, isNonEmptyString, isRecord } from "./write-chain.contract.ts";
 
 export const scheduleStates = ["armed", "paused"] as const;
+const scheduleIdPattern = new RegExp(ENTITY_ID_PATTERN, "u");
 export const scheduleModes = ["detect", "remediate"] as const;
 export const scheduleMissedReasons = ["scheduler_unavailable", "single_flight"] as const;
 export const scheduleRunOutcomes = ["succeeded", "failed", "unknown", "cancelled"] as const;
@@ -270,7 +271,7 @@ export function validateScheduleDefinitionV1(value: unknown, allowUnknownFields 
     return ["schedule definition fields are invalid"];
   if (
     typeof value.scheduleId !== "string" ||
-    !new RegExp(ENTITY_ID_PATTERN, "u").test(value.scheduleId) ||
+    !scheduleIdPattern.test(value.scheduleId) ||
     !isNonEmptyString(value.name) ||
     !scheduleStates.includes(value.state as ScheduleState) ||
     !scheduleModes.includes(value.mode as ScheduleMode) ||
@@ -357,7 +358,7 @@ function validTarget(value: unknown, allowUnknownFields: boolean): value is Sche
     return (
       hasContractFields(value, ["kind", "squadId"], allowUnknownFields) &&
       typeof value.squadId === "string" &&
-      new RegExp(ENTITY_ID_PATTERN, "u").test(value.squadId)
+      scheduleIdPattern.test(value.squadId)
     );
   const optionalText = ["model", "reasoningEffort"],
     optional = [...optionalText, "fast"],
@@ -367,7 +368,7 @@ function validTarget(value: unknown, allowUnknownFields: boolean): value is Sche
     (allowUnknownFields || Object.keys(value).every((field) => required.includes(field) || optional.includes(field))) &&
     value.kind === "agent" &&
     typeof value.agentId === "string" &&
-    new RegExp(ENTITY_ID_PATTERN, "u").test(value.agentId) &&
+    scheduleIdPattern.test(value.agentId) &&
     isNonEmptyString(value.runtimeInstanceId) &&
     optionalText.every((field) => value[field] === undefined || isNonEmptyString(value[field])) &&
     (value.fast === undefined || typeof value.fast === "boolean")

--- a/packages/kernel/src/domain/vertical-contract.ts
+++ b/packages/kernel/src/domain/vertical-contract.ts
@@ -122,6 +122,9 @@ export function compileVerticalContract(
           Object.freeze({ artifactTypeIdentity: typeIdentity, declaration }),
         ),
       ),
+      // Archiving a kind closes the door to new material, not to the material already inside it:
+      // only `import` loses its execution, so existing instances stay updatable and archivable.
+      compiledActionCatalog = artifactEntityActionCatalog(typeIdentity, identity),
       entityKindContract: EntityKindContract = Object.freeze({
         ...entityTypeContract,
         schema: schemaVersions[schemaVersions.length - 1]!.schema,
@@ -137,18 +140,16 @@ export function compileVerticalContract(
               ]),
             }
           : {}),
-        // Archiving a kind closes the door to new material, not to the material already inside it:
-        // only `import` loses its execution, so existing instances stay updatable and archivable.
         actionCatalog: artifact.retired
           ? Object.freeze({
-              ...artifactEntityActionCatalog(typeIdentity, identity),
+              ...compiledActionCatalog,
               actions: Object.freeze(
-                artifactEntityActionCatalog(typeIdentity, identity).actions.map((action) =>
+                compiledActionCatalog.actions.map((action) =>
                   action.id === "import" ? Object.freeze({ ...action, execution: null }) : action,
                 ),
               ),
             })
-          : artifactEntityActionCatalog(typeIdentity, identity),
+          : compiledActionCatalog,
         entityStore: genericEntityStore(artifact.store.pathTemplate),
         authoring: genericAuthoring,
         sdkExposure: noSdkExposure,

--- a/packages/kernel/src/layout/harness-settings.ts
+++ b/packages/kernel/src/layout/harness-settings.ts
@@ -16,6 +16,15 @@ const horizontal = "[^\\S\\r\\n]*";
 // The value must open with a non-blank, non-`#` character, so `wipLimit: # unset` reads as
 // absent rather than as a one-space string that every caller would then have to re-trim.
 const scalarPatterns = new Map<string, RegExp>();
+const blockPatterns = new Map<string, RegExp>();
+
+function blockSection(block: string): RegExp {
+  const cached = blockPatterns.get(block);
+  if (cached) return cached;
+  const pattern = new RegExp(`^  ${block}:[^\\S\\r\\n]*(?:\\r?\\n)((?:    [^\\r\\n]*(?:\\r?\\n|$))*)`, "mu");
+  blockPatterns.set(block, pattern);
+  return pattern;
+}
 
 function scalar(indent: string, key: string): RegExp {
   const cacheKey = `${indent}\0${key}`,
@@ -33,7 +42,6 @@ export function setting(body: string, key: string): string | undefined {
 
 /** Reads a scalar nested under a named settings block, for example `settings.scaffolds.task` or `settings.tasks.wipLimit`. */
 export function settingBlockValue(body: string, block: string, key: string): string | undefined {
-  const section =
-    new RegExp(`^  ${block}:[^\\S\\r\\n]*(?:\\r?\\n)((?:    [^\\r\\n]*(?:\\r?\\n|$))*)`, "mu").exec(body)?.[1] ?? "";
+  const section = blockSection(block).exec(body)?.[1] ?? "";
   return scalar("    ", key).exec(section)?.[1];
 }

--- a/packages/kernel/src/markdown/flow-frontmatter.ts
+++ b/packages/kernel/src/markdown/flow-frontmatter.ts
@@ -2,11 +2,21 @@ export interface FlowFrontmatterParseOptions {
   readonly tolerateInvalidArrays?: boolean;
 }
 
+const blockKeyPatterns = new Map<string, RegExp>();
+
 export function readBlockScalar(frontmatter: string, blockName: string, key: string): string {
-  return readIndentedBlock(frontmatter, blockName)
-    .find((line) => line.trimStart().startsWith(`${key}:`))
-    ?.replace(new RegExp(`^\\s*${key}:\\s*`, "u"), "")
-    .trim() ?? "[]";
+  const cacheKey = `${blockName}\0${key}`;
+  const cached = blockKeyPatterns.get(cacheKey);
+  // The key stays unescaped, exactly as the inline template built it: callers pass declared
+  // frontmatter keys, and escaping here would silently change what a dotted key matches.
+  const pattern = cached ?? new RegExp(`^\\s*${key}:\\s*`, "u");
+  if (!cached) blockKeyPatterns.set(cacheKey, pattern);
+  return (
+    readIndentedBlock(frontmatter, blockName)
+      .find((line) => line.trimStart().startsWith(`${key}:`))
+      ?.replace(pattern, "")
+      .trim() ?? "[]"
+  );
 }
 
 export function parseStringArray(value: string, options: FlowFrontmatterParseOptions = {}): string[] {
@@ -22,7 +32,7 @@ export function parseStringArray(value: string, options: FlowFrontmatterParseOpt
 export function parseObjectList(
   frontmatter: string,
   key: string,
-  options: FlowFrontmatterParseOptions = {}
+  options: FlowFrontmatterParseOptions = {},
 ): ReadonlyArray<Record<string, unknown>> {
   const items: Record<string, unknown>[] = [];
   let current: Record<string, unknown> | null = null;
@@ -45,7 +55,10 @@ export function parseObjectList(
 }
 
 export function parseFlowObject(value: string, options: FlowFrontmatterParseOptions = {}): Record<string, unknown> {
-  const body = value.trim().replace(/^\{\s*/u, "").replace(/\s*\}$/u, "");
+  const body = value
+    .trim()
+    .replace(/^\{\s*/u, "")
+    .replace(/\s*\}$/u, "");
   const result: Record<string, unknown> = {};
   for (const part of splitFlowFrontmatterTopLevel(body)) {
     const separator = part.indexOf(":");
@@ -59,7 +72,7 @@ export function parseFlowObject(value: string, options: FlowFrontmatterParseOpti
 export function unquote(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) return "";
-  if (!trimmed.startsWith("\"")) return trimmed;
+  if (!trimmed.startsWith('"')) return trimmed;
   try {
     return String(JSON.parse(trimmed));
   } catch {
@@ -102,7 +115,7 @@ function splitFlowFrontmatterTopLevel(value: string): string[] {
   for (let index = 0; index < value.length; index += 1) {
     const char = value[index];
     const previous = value[index - 1];
-    if (char === "\"" && previous !== "\\") inString = !inString;
+    if (char === '"' && previous !== "\\") inString = !inString;
     if (!inString && (char === "{" || char === "[")) depth += 1;
     if (!inString && (char === "}" || char === "]")) depth -= 1;
     if (!inString && depth === 0 && char === ",") {

--- a/packages/kernel/src/markdown/frontmatter.ts
+++ b/packages/kernel/src/markdown/frontmatter.ts
@@ -25,7 +25,13 @@ export function readNestedScalar(block: string, key: string, options: ReadScalar
   return value.trim();
 }
 
+const scalarPatterns = new Map<string, RegExp>();
+
 function matchScalar(body: string, key: string, prefix: string): string | undefined {
   const escaped = key.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-  return body.match(new RegExp(`^${prefix}${escaped}:[ \\t]*(.*)$`, "mu"))?.[1];
+  const cacheKey = `${prefix}\0${escaped}`;
+  const cached = scalarPatterns.get(cacheKey);
+  const pattern = cached ?? new RegExp(`^${prefix}${escaped}:[ \\t]*(.*)$`, "mu");
+  if (!cached) scalarPatterns.set(cacheKey, pattern);
+  return body.match(pattern)?.[1];
 }

--- a/packages/kernel/src/projection/relation-entity-projection.ts
+++ b/packages/kernel/src/projection/relation-entity-projection.ts
@@ -24,6 +24,22 @@ import { relationFreshnessAtCut, type EntityVersionWitness } from "../domain/ent
 
 export const RELATION_PROJECTION_VERSION = "relation-projection/v1" as const;
 
+/**
+ * Which kinds can interpret each event schema, in registry order, so replay visits only the contracts
+ * that declare the schema instead of every kind. Contracts without a canonical projection cannot
+ * produce embedded projections and are absent by construction.
+ */
+const embeddedProjectionContractsBySchema = new Map<string, readonly (typeof entityKindContracts)[number][]>(
+  [...new Set(entityKindContracts.flatMap((contract) => contract.canonicalProjection?.embeddedEvents ?? []))].map(
+    (source) => [
+      source.schema,
+      entityKindContracts.filter((contract) =>
+        contract.canonicalProjection?.embeddedEvents.some((candidate) => candidate.schema === source.schema),
+      ),
+    ],
+  ),
+);
+
 export interface VersionedRelationProjectionRow extends RelationGraphEdgeRow {
   readonly schema: typeof RELATION_PROJECTION_VERSION;
   readonly entity: RelationEntity;
@@ -126,7 +142,11 @@ function derivedRelationRecordsForReplay(
   const records: EntityRelationRecord[] = [];
   if (event.schema === "agent-runtime-event/v1" && event.type === "runtime_session_task_bound")
     records.push(runtimeTaskExecutionRelation(event.payload.runtimeSessionId, event.payload.taskId));
-  for (const contract of entityKindContracts)
+  // Hoisted from interpretEmbeddedEntityProjections: it raised this for every declaring contract
+  // regardless of schema match, so replay keeps rejecting a malformed payload outright.
+  if (typeof event.payload !== "object" || event.payload === null || Array.isArray(event.payload))
+    throw new Error(`${event.schema}/${event.type} payload must be an object`);
+  for (const contract of embeddedProjectionContractsBySchema.get(event.schema) ?? [])
     for (const projection of interpretEmbeddedEntityProjections(contract, event))
       for (const relation of projection.relations) {
         const record = {


### PR DESCRIPTION
# English

## Summary

Fix-plan batch 7 (D-kernel): static tables and constant regexes that the kernel domain rebuilt on every call are hoisted to module level, with zero behaviour change (every error text and code is moved verbatim). `parseEntityRef` compiled one RegExp per ref authority per call (14 on a miss) and `refAuthorities()` rebuilt its table each time; the grammar is now compiled once, lazily because of the entity-ref → base-entity → write-chain → receipt-domain-registry → entity-ref import cycle. `getExecutableEntityAction` / `getTaskActionForTransition` scanned the contract catalogue; they read first-registration-wins inverted maps. The default relation registry gets a triple → strength-rules index shared by `isAllowedRelationKindTriple` and `isAllowedRelationRecord` (explicit registries keep the scan). Relation replay visits only the contracts that declare an event's schema. Fourteen `new RegExp(pattern)` sites in domain/markdown/layout go through one bounded `compiledPattern()` cache or a module constant; frontmatter scalar/block patterns are memoised by stable key (prefix+key / block+key, the `harness-settings` scalarPatterns shape) rather than by document body, so the daemon's cache stays bounded.

## Architectural Justification

Static data is compiled once where it is declared (registry, grammar, schema) and read by lookup; every call site keeps its wording and code. First-registration-wins indexes preserve the previous first-match scan order.

## What Changed

- `packages/kernel/src/domain/entity-ref.ts` (+45/-15): one-time lazy ref grammar (`refGrammar()`), `refAuthorities()` deleted; `entityKindRef`/`formatEntityRef` constant regexes hoisted.
- `packages/kernel/src/domain/entity-kind-registry.ts` (+14/-14): `executableActionsByIngress` and `taskActionsByTransition` maps replace the catalogue scans; `entityDocumentPath` uses `compiledPattern`.
- `packages/kernel/src/domain/entity-relation.ts` (+33/-1): `writableRelationStrengths` index for the default registry; witness endpoint pattern via `compiledPattern`.
- `packages/kernel/src/projection/relation-entity-projection.ts` (+21/-1): `embeddedProjectionContractsBySchema`; the non-object payload guard hoisted to the call site with the same message.
- `packages/kernel/src/domain/entity-json-schema.ts` (+13/-1): exported `compiledPattern()`; consumers `base-entity.ts`, `entity-event.ts`, `artifact-entity.ts`, `people-roster.ts`, `agent-squad-schema.ts`, `schedule.ts`, `decision-event-validation-shared.ts`, `entity-action-explanation.ts` (artifact catalogue memoised by kind), `vertical-contract.ts` (retired catalogue built once).
- `packages/kernel/src/markdown/frontmatter.ts` (+7/-1), `flow-frontmatter.ts` (+21/-8), `packages/kernel/src/layout/harness-settings.ts` (+10/-2): keyed regex memos.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +209/-80 production; tests +0/-0 (existing suites unchanged; the per-call compile/scan counting oracle is filed at the task package `artifacts/measure/fixplan-d-measure.mjs`).

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root (2860a94cf) and in the branch worktree: every operation and metric identical, G38 passes on both. These counters observe SQL rows, hashes, git processes and file bytes; this batch removes per-call `new RegExp` compiles and registry scans, which they do not count. The behaviour witness is the counting oracle in the task package (RegExp constructor / `Array.prototype.find|some` / `Object.freeze` monkeypatched, 2,000 calls per probe): base RED, head GREEN, single-file mutations RED.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_fb1683da75c922af354f9637cc (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/fixplan-d-kernel-static`
- Public scope: Kernel domain / markdown / layout hot paths that compiled or scanned static data per call (fix-plan findings R1-05-F1/F4/F5, R2-05-F3/F4/F9/F10/F12, R2-08rx-F1/F2/F3/F4/F6/F7/F8, R4-validation-F8 regex half).
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: No schema, protocol or error-text change; `schemas/task-closeout-packet.ts` (R2-08rx-F7 premise gone) untouched; write-amplification and serialize/validate findings belong to batch 13 A1 (in flight).

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `2860a94cf`
- Branch merge-base with `origin/main`: `2860a94cf`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/fixplan-d-kernel-static`
- Private evidence commit/path: task_fb1683da75c922af354f9637cc `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO ground-truth on the branch head: 29 kernel test files that import the touched modules: 174/174 (54+70+50 across three runner batches); the filed counting oracle `artifacts/measure/fixplan-d-measure.mjs --assert` is GREEN at head, `check-file-complexity` pass (entity-event 800/800, entity-kind-registry 1012/1012 and people-roster 946/946 sit exactly on their ratchet ceilings with net zero lines in this change), `run-local-line-density` G36 pass, `canonical-event-compat` ok, `check-bypass-write-boundary`, `check-cli-structure`, `check-import-boundaries` pass, `check-pr-governance` skipped (no protected surface), G1 base = head. Worker (GLM, report `artifacts/reports/fixplan-d-kernel-static.md`): 32 directly-importing test files 203/203; fast+contract tiers 1130/1130 after the final rebase; isolated Ubuntu integration for `legacy-entity-declaration-follower`, `migration-import-rosters-multisource`, `task-read-set`, `rejection-next-actions` all exit 0; `tsc -b` for the kernel workspace 0 errors; counting oracle: parseEntityRef 1 → 0 RegExp per call (miss 14 → 0), relation record check 50-row scan → 0, catalogue explain 154 `Object.freeze` → 0, all 28 probes 0.00 per call at head; reverting `entity-ref.ts` or `entity-relation.ts` alone turns the oracle RED again.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; read the five load-bearing diffs (lazy grammar and the import cycle it works around, both inverted maps against the old first-match scans, the default-registry fast path with the explicit-registry scan retained, the hoisted payload guard) and re-ran gates and targeted tests; the oracle script was copied from /tmp into the task package so the numbers can be re-derived.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- `compiledPattern()` is a process-lifetime cache keyed by pattern string; its key space is the schemas, kind contracts, endpoint templates and derived artifact/entity id shapes, all static per build. `relation-entity-projection` now throws on a non-object payload unconditionally where it previously threw once at least one contract declared a canonical projection (always true for the built-in registry); a registry with no canonical projections would throw where it did not before. Three files sit exactly on their complexity ceilings; any further addition there must split by responsibility rather than trim lines. Production grows by 129 net lines: the indexes and their invariant comments replace per-call work, not code.

## References

- Task: task_fb1683da75c922af354f9637cc

---

# 中文

## 概要

fix-plan 批 7（D-kernel）：kernel domain 每次调用都重建的静态表与常量正则上提到模块级，零行为变化（所有错误文案与 code 逐字搬移）。`parseEntityRef` 每次调用按 ref authority 各编一个 RegExp（未命中 14 个）且 `refAuthorities()` 每次重建表；语法表现在只编译一次，因 entity-ref → base-entity → write-chain → receipt-domain-registry → entity-ref 的 import 环而惰性构建。`getExecutableEntityAction` / `getTaskActionForTransition` 原来扫契约目录，改读首注册胜出的倒排 Map。默认关系注册表建 triple → strength 规则索引，`isAllowedRelationKindTriple` 与 `isAllowedRelationRecord` 共用（显式传入的 registry 仍走扫描）。关系 replay 只访问声明了该事件 schema 的契约。domain/markdown/layout 里 14 处 `new RegExp(pattern)` 改走一个有界的 `compiledPattern()` 缓存或模块常量；frontmatter 标量/块正则按稳定键（prefix+key / block+key，即 `harness-settings` scalarPatterns 的形状）memo 而不是按文档正文，daemon 里的缓存保持有界。

## 架构辩护

静态数据在声明处（注册表、语法、schema）编译一次、按查找读取；每个调用点保留原文案与 code。首注册胜出的索引保持原先 first-match 扫描顺序。

## 改动内容

- `packages/kernel/src/domain/entity-ref.ts`（+45/-15）：一次性惰性 ref 语法表 `refGrammar()`，删除 `refAuthorities()`；`entityKindRef`/`formatEntityRef` 常量正则上提。
- `packages/kernel/src/domain/entity-kind-registry.ts`（+14/-14）：`executableActionsByIngress`、`taskActionsByTransition` 两个 Map 取代目录扫描；`entityDocumentPath` 用 `compiledPattern`。
- `packages/kernel/src/domain/entity-relation.ts`（+33/-1）：默认注册表的 `writableRelationStrengths` 索引；witness 端点正则走 `compiledPattern`。
- `packages/kernel/src/projection/relation-entity-projection.ts`（+21/-1）：`embeddedProjectionContractsBySchema`；非对象 payload 守卫按原文案上提到调用点。
- `packages/kernel/src/domain/entity-json-schema.ts`（+13/-1）：导出 `compiledPattern()`；使用方 `base-entity.ts`、`entity-event.ts`、`artifact-entity.ts`、`people-roster.ts`、`agent-squad-schema.ts`、`schedule.ts`、`decision-event-validation-shared.ts`、`entity-action-explanation.ts`（artifact 目录按 kind memo）、`vertical-contract.ts`（retired 目录只建一次）。
- `packages/kernel/src/markdown/frontmatter.ts`（+7/-1）、`flow-frontmatter.ts`（+21/-8）、`packages/kernel/src/layout/harness-settings.ts`（+10/-2）：按键 memo 的正则。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+209/-80 production; tests +0/-0 (existing suites unchanged; the per-call compile/scan counting oracle is filed at the task package `artifacts/measure/fixplan-d-measure.mjs`)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_fb1683da75c922af354f9637cc（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/fixplan-d-kernel-static`
- 公开范围：kernel domain / markdown / layout 里每次调用都编译或扫描静态数据的热路径（fix-plan finding R1-05-F1/F4/F5、R2-05-F3/F4/F9/F10/F12、R2-08rx-F1/F2/F3/F4/F6/F7/F8、R4-validation-F8 正则半边）。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：无 schema、协议、错误文案变化；`schemas/task-closeout-packet.ts`（R2-08rx-F7 前提已消失）不动；写放大与 serialize/validate 类 finding 属批 13 A1（在飞）。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`2860a94cf`
- 分支与 `origin/main` 的 merge-base：`2860a94cf`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/fixplan-d-kernel-static`
- 私有证据路径：task_fb1683da75c922af354f9637cc 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO 在分支 head 核实：导入触碰模块的 29 个 kernel 测试文件 174/174（三批 54+70+50）；归档的计数 oracle `artifacts/measure/fixplan-d-measure.mjs --assert` 在 head 上 GREEN、`check-file-complexity` pass（entity-event 800/800、entity-kind-registry 1012/1012、people-roster 946/946 恰在棘轮上限，本变更在这三个文件净零行）、`run-local-line-density` G36 pass、`canonical-event-compat` ok、`check-bypass-write-boundary`、`check-cli-structure`、`check-import-boundaries` 通过、`check-pr-governance` 跳过（无受保护面）、G1 base = head。worker（GLM，报告 `artifacts/reports/fixplan-d-kernel-static.md`）：32 个直接导入的测试文件 203/203；最终 rebase 后 fast+contract 1130/1130；Ubuntu 隔离集成 `legacy-entity-declaration-follower`、`migration-import-rosters-multisource`、`task-read-set`、`rejection-next-actions` 全部 exit 0；kernel workspace `tsc -b` 0 错误；计数 oracle：parseEntityRef 每调用 1 → 0 次 RegExp（未命中 14 → 0），关系记录检查 50 行扫描 → 0，目录解释 154 次 `Object.freeze` → 0，head 上 28 个探针全部 0.00/调用；单独还原 `entity-ref.ts` 或 `entity-relation.ts` 都让 oracle 变红。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；通读五处承重 diff（惰性语法表与它绕开的 import 环、两个倒排 Map 对照旧的 first-match 扫描、默认注册表快路径并保留显式注册表扫描、上提的 payload 守卫），重跑门与定向测试；oracle 脚本已从 /tmp 拷入任务包以便复算。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- `compiledPattern()` 是进程生命周期的缓存、键为 pattern 字符串；键空间是 schema、kind 契约、端点模板与派生的 artifact/entity id 形状，每个构建都是静态的。`relation-entity-projection` 现在对非对象 payload 无条件抛错，原来是「至少一个契约声明了 canonical projection 时抛」（内置注册表恒成立）；一个没有任何 canonical projection 的注册表会在原本不抛的地方抛。三个文件恰在复杂度上限上，之后再加行必须按职责拆分而不是削行。生产净增 129 行：索引及其不变量注释替代的是每次调用的工作，不是代码。

## 参考

- 任务：task_fb1683da75c922af354f9637cc

