### PR TITLE
perf(daemon): hoist per-request writer buffers, rotation checks and cache keys; cap inbound JSON line frames

### DIFF
--- a/packages/daemon/src/lifecycle-log.ts
+++ b/packages/daemon/src/lifecycle-log.ts
@@ -97,16 +97,18 @@ export function openDaemonLifecycleLog(input: {
     keptFiles = input.keptFiles ?? defaultKeptFiles,
     now = input.now ?? (() => new Date()),
     pid = input.pid ?? process.pid;
-  let prepared = false,
+  let preparedDirectory = false,
     reportedFailure = false;
   return {
     record: (entry) => {
       try {
-        if (!prepared) {
+        if (!preparedDirectory) {
           mkdirSync(path.dirname(logPath), { recursive: true });
-          rotateLifecycleLog(logPath, maxBytes, keptFiles);
-          prepared = true;
+          preparedDirectory = true;
         }
+        // One recorder serves the daemon's whole life, so the size cap is rechecked before every
+        // append: rotateLifecycleLog early-returns on a single statSync when the file is under it.
+        rotateLifecycleLog(logPath, maxBytes, keptFiles);
         appendFileSync(
           logPath,
           `${JSON.stringify({ schema: DAEMON_LIFECYCLE_LOG_SCHEMA.id, at: now().toISOString(), daemonId: input.daemonId, pid, ...entry } satisfies DaemonLifecycleRecord)}\n`,

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -654,7 +654,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
       const source = makeGitReadinessSource(),
         projectHead = source.run(context.rootDir, ["rev-parse", "HEAD"]),
         commitSha = projectHead.ok ? projectHead.stdout : "",
-        cacheKey = `${commitSha}\n${JSON.stringify(read.decisions)}`;
+        cacheKey = `${commitSha}\n${context.store.readHead()?.revision ?? 0}`;
       if (readinessCache?.key !== cacheKey)
         readinessCache = {
           key: cacheKey,

--- a/packages/daemon/src/repo-writer-worker.ts
+++ b/packages/daemon/src/repo-writer-worker.ts
@@ -32,6 +32,13 @@ const bootstrap = workerData as RepoWriterBootstrapV1;
 if (!isMainThread) void startRepoWriterWorker();
 
 async function startRepoWriterWorker(): Promise<void> {
+  // One buffer pair serves the worker's whole life: syncCapability blocks the thread in Atomics.wait
+  // until the supervisor answers, so rounds never overlap and the supervisor overwrites the shared
+  // bytes in place. The state cell is re-armed before each post so the next round waits for a fresh
+  // answer instead of reading the previous round's completion. Declared before the open so the hoisted
+  // syncCapability can be called from open-time capabilities (killpoint, fleetRoster) without a TDZ.
+  let syncState: SharedArrayBuffer | null = null,
+    syncBytes: SharedArrayBuffer | null = null;
   if (
     bootstrap?.schema !== "harness-repo-writer-bootstrap/v1" ||
     bootstrap.protocolVersion !== REPO_WRITER_PROTOCOL_VERSION ||
@@ -238,12 +245,6 @@ async function startRepoWriterWorker(): Promise<void> {
     }
   }
 
-  // One buffer pair serves the worker's whole life: syncCapability blocks the thread in Atomics.wait
-  // until the supervisor answers, so rounds never overlap and the supervisor overwrites the shared
-  // bytes in place. The state cell is re-armed before each post so the next round waits for a fresh
-  // answer instead of reading the previous round's completion.
-  let syncState: SharedArrayBuffer | null = null,
-    syncBytes: SharedArrayBuffer | null = null;
   function syncCapability<T>(capability: RepoWriterCapabilityCallV1["capability"], payload: unknown): T {
     syncState ??= new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
     syncBytes ??= new SharedArrayBuffer(1024 * 1024);

--- a/packages/daemon/src/repo-writer-worker.ts
+++ b/packages/daemon/src/repo-writer-worker.ts
@@ -238,21 +238,31 @@ async function startRepoWriterWorker(): Promise<void> {
     }
   }
 
+  // One buffer pair serves the worker's whole life: syncCapability blocks the thread in Atomics.wait
+  // until the supervisor answers, so rounds never overlap and the supervisor overwrites the shared
+  // bytes in place. The state cell is re-armed before each post so the next round waits for a fresh
+  // answer instead of reading the previous round's completion.
+  let syncState: SharedArrayBuffer | null = null,
+    syncBytes: SharedArrayBuffer | null = null;
   function syncCapability<T>(capability: RepoWriterCapabilityCallV1["capability"], payload: unknown): T {
-    const state = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2),
-      bytes = new SharedArrayBuffer(1024 * 1024),
-      view = new Int32Array(state),
+    syncState ??= new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
+    syncBytes ??= new SharedArrayBuffer(1024 * 1024);
+    const view = new Int32Array(syncState),
       call: RepoWriterCapabilityCallV1 = {
         schema: "harness-repo-writer-capability-call/v1",
         callId: randomUUID(),
         capability,
         payload,
-        sync: { state, bytes },
+        sync: { state: syncState, bytes: syncBytes },
       };
+    Atomics.store(view, 0, 0);
+    Atomics.store(view, 1, 0);
     parentPort!.postMessage(call);
     while (Atomics.load(view, 0) === 0) Atomics.wait(view, 0, 0);
     const length = Atomics.load(view, 1),
-      decoded = JSON.parse(new TextDecoder().decode(new Uint8Array(bytes, 0, length))) as RepoWriterCapabilityResultV1;
+      decoded = JSON.parse(
+        new TextDecoder().decode(new Uint8Array(syncBytes, 0, length)),
+      ) as RepoWriterCapabilityResultV1;
     if (decoded.outcome === "error") throw deserializeWriterError(decoded.error!);
     return decoded.value as T;
   }
@@ -320,10 +330,10 @@ function reviveBinding(
   descriptor: SerializableRepoCellBindingV1["writerEpochFence"] | null,
 ): RepoCellBinding | undefined {
   if (!binding) return undefined;
-  if (descriptor !== (binding.writerEpochFence ?? null)) {
-    if (JSON.stringify(descriptor) !== JSON.stringify(binding.writerEpochFence ?? null))
-      throw new Error("writer epoch descriptor changed in transit");
-  }
+  // Structured clone hands the worker two distinct objects for the same fence, so equality is decided
+  // field by field; a stringify comparison would reserialize both descriptors on every request.
+  if (!sameWriterEpochFence(descriptor ?? null, binding.writerEpochFence ?? null))
+    throw new Error("writer epoch descriptor changed in transit");
   return {
     ...binding,
     ...(descriptor
@@ -334,6 +344,22 @@ function reviveBinding(
 
 function assertWriterEpoch(descriptor: SerializableRepoCellBindingV1["writerEpochFence"] | null): void {
   if (descriptor) assertWriterEpochFenceDescriptor(descriptor);
+}
+
+function sameWriterEpochFence(
+  left: NonNullable<SerializableRepoCellBindingV1["writerEpochFence"]> | null,
+  right: NonNullable<SerializableRepoCellBindingV1["writerEpochFence"]> | null,
+): boolean {
+  return (
+    left === right ||
+    (left !== null &&
+      right !== null &&
+      left.schema === right.schema &&
+      left.stateRoot === right.stateRoot &&
+      left.repoId === right.repoId &&
+      left.epoch === right.epoch &&
+      left.holderId === right.holderId)
+  );
 }
 
 function postReceipt(requestId: string, value?: unknown, error?: unknown): void {

--- a/packages/daemon/src/transport/frame-codec.ts
+++ b/packages/daemon/src/transport/frame-codec.ts
@@ -1,5 +1,10 @@
 import type { JsonRpcRequest } from "../protocol/json-rpc-types.ts";
 
+// The largest payload this transport legitimately carries in one frame is the entity content read's
+// 2 MiB UTF-8 ceiling (entity-content-read.ts); the cap doubles that to cover the JSON envelope and
+// string escaping. A frame that cannot terminate below the cap is a peer defect, not a payload.
+export const JSON_LINE_FRAME_MAX_BYTES = 4 * 1024 * 1024;
+
 export interface JsonLineFrameBatch {
   readonly frames: ReadonlyArray<unknown>;
   readonly error?: Error;
@@ -15,6 +20,13 @@ export function createJsonLineFrameReader(): JsonLineFrameReader {
   return {
     push: (chunk) => {
       buffered += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      if (Buffer.byteLength(buffered) > JSON_LINE_FRAME_MAX_BYTES) {
+        // Drop the unterminated line and hand the caller an error it can fail the connection with;
+        // buffering a newline-less writer forever would grow without bound.
+        const error = new Error(`JSON-RPC frame exceeds ${JSON_LINE_FRAME_MAX_BYTES} bytes`);
+        buffered = "";
+        return { frames: [], error };
+      }
       const lines = buffered.split("\n");
       buffered = lines.pop() ?? "";
       return parseLines(lines);
@@ -27,7 +39,7 @@ export function createJsonLineFrameReader(): JsonLineFrameReader {
       const pending = buffered;
       buffered = "";
       return parseLines([pending]);
-    }
+    },
   };
 }
 
@@ -50,7 +62,7 @@ function parseLines(lines: ReadonlyArray<string>): JsonLineFrameBatch {
     } catch (error) {
       return {
         frames,
-        error: error instanceof Error ? error : new Error(String(error))
+        error: error instanceof Error ? error : new Error(String(error)),
       };
     }
   }
@@ -58,9 +70,11 @@ function parseLines(lines: ReadonlyArray<string>): JsonLineFrameBatch {
 }
 
 function isSingleJsonRpcRequestLike(value: unknown): value is JsonRpcRequest {
-  return value !== null
-    && typeof value === "object"
-    && !Array.isArray(value)
-    && (value as { readonly jsonrpc?: unknown }).jsonrpc === "2.0"
-    && typeof (value as { readonly method?: unknown }).method === "string";
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as { readonly jsonrpc?: unknown }).jsonrpc === "2.0" &&
+    typeof (value as { readonly method?: unknown }).method === "string"
+  );
 }

--- a/packages/daemon/test/decision-surface.test.ts
+++ b/packages/daemon/test/decision-surface.test.ts
@@ -504,6 +504,58 @@ test("Evidence relations reject non-claim sources before writing and identify th
   }
 });
 
+test("the decisions readiness cache key never reserializes the decision rows", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-decision-readiness-cache-"));
+  initRepo(rootDir);
+  const cell = await openRepoCell({
+    repoId: workspaceId("decision-readiness-cache"),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: "decision-readiness-cache-test",
+    now: monotonicClock(),
+  });
+  try {
+    assert.equal((await cell.run(proposal("Readiness cache"), proposer)).outcome, "applied");
+    const first = await cell.read("repo.decisions.list");
+    assert.equal(first.decisions.length, 1);
+    assert.ok(first.decisions[0]?.readiness, "the full projection carries the git readiness rows");
+
+    // A repeated identical read must hit the readiness cache without rebuilding the key from every
+    // decision row: a long-lived daemon serves this read per GUI poll, so the key has to be O(1).
+    const reserialized: number[] = [],
+      stringify = JSON.stringify;
+    JSON.stringify = ((value: unknown, ...rest: unknown[]) => {
+      if (
+        Array.isArray(value) &&
+        value.length === 1 &&
+        typeof (value[0] as { readonly decisionId?: unknown } | undefined)?.decisionId === "string"
+      )
+        reserialized.push(value.length);
+      return stringify(value, ...(rest as Parameters<typeof stringify>));
+    }) as typeof JSON.stringify;
+    let cached: typeof first;
+    try {
+      cached = await cell.read("repo.decisions.list");
+    } finally {
+      JSON.stringify = stringify;
+    }
+    assert.deepEqual(reserialized, []);
+    assert.deepEqual(
+      cached.decisions.map(({ decisionId }) => decisionId),
+      first.decisions.map(({ decisionId }) => decisionId),
+    );
+
+    // A later write bumps the ledger revision, and the cache key must follow it: the next read sees
+    // the new decision's readiness instead of the rows cached before the write.
+    assert.equal((await cell.run(proposal("Readiness cache second"), proposer)).outcome, "applied");
+    const updated = await cell.read("repo.decisions.list");
+    assert.equal(updated.decisions.length, 2);
+    assert.ok(updated.decisions.every(({ readiness }) => readiness));
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function proposal(title: string) {
   return {
     kind: "decision-propose",

--- a/packages/daemon/test/fixtures/writer-sab-allocation-probe.mjs
+++ b/packages/daemon/test/fixtures/writer-sab-allocation-probe.mjs
@@ -1,0 +1,10 @@
+// Worker preload: report every SharedArrayBuffer allocation to the parent thread.
+import { parentPort } from "node:worker_threads";
+
+const shared = globalThis.SharedArrayBuffer;
+globalThis.SharedArrayBuffer = class extends shared {
+  constructor(byteLength) {
+    super(byteLength);
+    parentPort?.postMessage({ schema: "writer-sab-allocation-probe/v1", byteLength });
+  }
+};

--- a/packages/daemon/test/frame-codec.contract.test.ts
+++ b/packages/daemon/test/frame-codec.contract.test.ts
@@ -1,0 +1,44 @@
+// harness-test-tier: contract
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createJsonLineFrameReader,
+  encodeJsonLineFrame,
+  JSON_LINE_FRAME_MAX_BYTES,
+} from "../src/transport/frame-codec.ts";
+
+const request = { jsonrpc: "2.0" as const, method: "ping", params: {} };
+
+test("an unterminated frame larger than the transport cap fails the read instead of buffering unboundedly", () => {
+  const reader = createJsonLineFrameReader();
+  const chunk = "x".repeat(64 * 1024);
+  let batch = { frames: [] as unknown[], error: undefined as Error | undefined };
+  for (let index = 0; index * chunk.length <= JSON_LINE_FRAME_MAX_BYTES; index += 1) batch = reader.push(chunk);
+
+  assert.ok(batch.error, "an over-cap buffer must surface an error, not keep growing");
+  assert.match(batch.error.message, /exceeds/u);
+  assert.deepEqual(batch.frames, []);
+  // The over-cap line is discarded, so a later well-formed frame still parses on the same reader.
+  const next = reader.push(`${JSON.stringify(request)}\n`);
+  assert.deepEqual(next.frames, [request]);
+});
+
+test("a frame just under the cap still parses across many chunks", () => {
+  const reader = createJsonLineFrameReader();
+  // A cap that rejected legitimate frames would break the largest payload the surface accepts today:
+  // the entity content read hands back up to 2 MiB of UTF-8 inside one JSON string.
+  const line = JSON.stringify({ ...request, params: { body: "y".repeat(2 * 1024 * 1024) } }),
+    whole = `${line}\n`,
+    chunkSize = 64 * 1024;
+  assert.ok(Buffer.byteLength(whole) < JSON_LINE_FRAME_MAX_BYTES, "fixture must stay under the cap");
+  let frames: readonly unknown[] = [];
+  for (let offset = 0; offset < whole.length; offset += chunkSize)
+    frames = reader.push(whole.slice(offset, offset + chunkSize)).frames;
+  assert.equal(frames.length, 1);
+});
+
+test("encode frames stay newline-terminated JSON lines", () => {
+  const encoded = encodeJsonLineFrame(request);
+  assert.ok(encoded.endsWith("\n"));
+  assert.deepEqual(JSON.parse(encoded), request);
+});

--- a/packages/daemon/test/lifecycle-log.test.ts
+++ b/packages/daemon/test/lifecycle-log.test.ts
@@ -1,0 +1,36 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, readdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { daemonLifecycleLogPath, openDaemonLifecycleLog, readDaemonLifecycleRecords } from "../src/lifecycle-log.ts";
+
+// The daemon holds one recorder for its whole life (runtime.ts), so a recorder that only rotates on
+// its first record never checks the size again: the retention policy is dead for a long-lived daemon.
+test("one long-lived recorder rechecks the size cap before every append", () => {
+  const userRoot = mkdtempSync(path.join(os.tmpdir(), "harness-lifecycle-log-")),
+    daemonId = "long-lived",
+    logDir = path.dirname(daemonLifecycleLogPath(userRoot, daemonId)),
+    log = openDaemonLifecycleLog({
+      userRoot,
+      daemonId,
+      maxBytes: 600,
+      keptFiles: 2,
+      now: () => new Date("2026-09-13T00:00:00.000Z"),
+    });
+  for (let index = 0; index < 200; index += 1)
+    log.record({ event: "runtime_spawn", runtimeSessionId: `session-${index}` });
+
+  // Rotation must have happened repeatedly on this single recorder, and keptFiles caps the generations.
+  assert.deepEqual(readdirSync(logDir).sort(), [
+    "daemon-long-lived-lifecycle.jsonl",
+    "daemon-long-lived-lifecycle.jsonl.1",
+    "daemon-long-lived-lifecycle.jsonl.2",
+  ]);
+  // The live file is back under the cap and the newest record survived.
+  assert.ok(readFileSync(path.join(logDir, "daemon-long-lived-lifecycle.jsonl"), "utf8").length < 600 + 1024);
+  const records = readDaemonLifecycleRecords(userRoot, daemonId);
+  assert.equal(records.at(-1)?.runtimeSessionId, "session-199");
+  assert.ok(records.length > 1, "kept generations still hold readable history");
+});

--- a/packages/daemon/test/writer-sync-capability-cost.integration.test.ts
+++ b/packages/daemon/test/writer-sync-capability-cost.integration.test.ts
@@ -1,0 +1,98 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { Worker } from "node:worker_threads";
+import { canonicalRoot, workspaceId } from "../src/protocol/daemon-protocol.contract.ts";
+import { openPersistentWriterEpoch } from "../src/writer-epoch.ts";
+import { openWriterSupervisor } from "../src/writer-supervisor.ts";
+import { openBootstrappedRepoCell } from "./repo-settings.fixture.ts";
+import { actor, initRepo } from "./task-surface.fixtures.ts";
+
+const sabProbe = new URL("./fixtures/writer-sab-allocation-probe.mjs", import.meta.url).href;
+
+test("sync capability round trips reuse one shared buffer pair for the writer's whole life", async () => {
+  const parent = mkdtempSync(path.join(tmpdir(), "ha-writer-sab-cost-")),
+    repoId = workspaceId("writer-sab-cost"),
+    stateRoot = path.join(parent, "writer-epochs"),
+    sabAllocations: number[] = [],
+    syncCalls: string[] = [];
+  let clock = Date.parse("2026-09-13T00:00:00.000Z");
+  let supervisor: Awaited<ReturnType<typeof openWriterSupervisor>> | undefined;
+  try {
+    mkdirSync(path.join(parent, "repo"));
+    const rootDir = canonicalRoot(path.join(parent, "repo"));
+    initRepo(rootDir);
+    const authority = openPersistentWriterEpoch({ stateRoot, holderId: "writer-sab-cost" }),
+      lease = authority.acquire(repoId);
+    authority.close();
+    const fence = {
+      schema: "harness-writer-epoch-fence/v1" as const,
+      stateRoot,
+      repoId,
+      epoch: lease.epoch,
+      holderId: lease.holderId,
+    };
+    await (
+      await openBootstrappedRepoCell({
+        repoId,
+        rootDir,
+        ownerId: "writer-sab-seed",
+        defaultWriterEpochFence: fence,
+      })
+    ).close();
+    supervisor = await openWriterSupervisor(
+      // An injected clock is what wires the sync capability: every event stamp crosses the fence
+      // through syncCapability, so writes are the round trips this test counts allocations against.
+      {
+        repoId,
+        rootDir,
+        ownerId: "writer-sab-cost",
+        defaultWriterEpochFence: fence,
+        now: () => new Date((clock += 1_000)).toISOString(),
+      },
+      {
+        createWorker: (url, options) => {
+          const worker = new Worker(url, { ...options, execArgv: [...options.execArgv, "--import", sabProbe] });
+          worker.on(
+            "message",
+            (message: {
+              readonly schema?: string;
+              readonly capability?: string;
+              readonly byteLength?: number;
+              sync?: unknown;
+            }) => {
+              if (message?.schema === "writer-sab-allocation-probe/v1") sabAllocations.push(Number(message.byteLength));
+              else if (message?.schema === "harness-repo-writer-capability-call/v1" && message.sync)
+                syncCalls.push(String(message.capability));
+            },
+          );
+          return worker;
+        },
+      },
+    );
+    const binding = { actor, source: "local" as const, writerEpoch: fence.epoch, writerEpochFence: fence };
+    for (const taskId of ["task_sab_a", "task_sab_b", "task_sab_c"]) {
+      const receipt = await supervisor.request<{ readonly outcome: string }>(
+        "run",
+        { action: { kind: "task-create", taskId, title: "SAB reuse" } },
+        binding,
+      );
+      assert.equal(receipt.outcome, "applied", JSON.stringify(receipt));
+    }
+    assert.ok(
+      syncCalls.length >= 3,
+      `expected the injected clock to cross the fence per write, saw ${syncCalls.length}`,
+    );
+    // One 1 MiB response buffer serves every round trip: the writer thread blocks in Atomics.wait
+    // while the supervisor overwrites the shared bytes, so calls never overlap. (The 8-byte state
+    // cell is reused too, but 8-byte SABs are not uniquely attributable here — the kernel's local
+    // VCS bridge allocates its own.)
+    assert.equal(sabAllocations.filter((byteLength) => byteLength === 1024 * 1024).length, 1);
+  } finally {
+    await supervisor?.close();
+    rmSync(parent, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
# English

## Summary

Fix-plan batch 13 (A1, non-load-bearing write amplification). (R3-03-F5) `lifecycle-log` re-checks the log size before every append instead of once per process, so a long-lived daemon actually rotates. (R1-01-F6) the writer worker keeps one 8-byte state + 1 MiB bytes SharedArrayBuffer pair per worker lifetime for the sync-capability handshake instead of allocating a fresh 1 MiB pair on every request; the state words are re-armed before each post. (R1-01-F8) `reviveBinding` compares writer epoch fences field by field (`sameWriterEpochFence`) instead of a reference short-circuit that structured clone always defeats, followed by a double `JSON.stringify`. (R1-01-F7, stringify half) the decisions-readiness cache key is `commitSha + ledger head revision` instead of `commitSha + JSON.stringify(all decision rows)`; the git half (a `git rev-parse HEAD` subprocess per `decisions.list`) is out of this batch and remains open in the fix plan. (R2-03-F10) the JSON line frame reader caps an unterminated inbound line at 4 MiB (`JSON_LINE_FRAME_MAX_BYTES`) and returns an error the existing `failConnection` path turns into a -32700 parse error; previously a newline-less peer grew the buffer without bound. (R2-01-F12) `compiledVerticals` growth is documented as bounded by declaration revisions and left unchanged.

## Architectural Justification

Per-request work that does not vary per request (buffers, rotation state, serialised cache keys) is hoisted to the lifetime that owns it, and an unbounded input buffer gets the bound its producer contract already implies.

## What Changed

- `packages/daemon/src/lifecycle-log.ts` (+6/-4): `prepared` flag keeps only the mkdir duty (`preparedDirectory`); `rotateLifecycleLog` runs before every append (its first line is a `statSync` early-exit).
- `packages/daemon/src/repo-writer-worker.ts` (+31/-14): lazily held SAB pair reused across sync-capability calls, declared at the top of `startRepoWriterWorker` so open-time capabilities (killpoint, fleetRoster) can call the hoisted `syncCapability` without a temporal-dead-zone error (the first CI run of this PR caught exactly that in `repo-cell-lock-release.integration` and `daemon-host-recovery`), state words reset before each post; `sameWriterEpochFence` field comparison replaces the reference check + double stringify.
- `packages/daemon/src/repo-cell-api.ts` (+1/-1): decisions cache key by `store.readHead()?.revision` (file is shrink-only; line-neutral).
- `packages/daemon/src/transport/frame-codec.ts` (+26/-2): `JSON_LINE_FRAME_MAX_BYTES = 4 MiB`; the reader drops the over-long buffer and returns an error; only consumer is `serveJsonRpcStream` (daemon inbound, `transport/json-rpc-stream.ts`), which already fails the connection with a readable parse error.
- Tests: `packages/daemon/test/lifecycle-log.test.ts` (fast, new: rotation happens on a later append after the first one), `frame-codec.contract.test.ts` (contract, new: frames under the cap pass, an unterminated line over the cap errors and clears the buffer), `writer-sync-capability-cost.integration.test.ts` + `fixtures/writer-sab-allocation-probe.mjs` (integration, new: repeated sync-capability calls allocate one SAB pair), `decision-surface.test.ts` (+1 case: the cache key does not re-serialise decision rows).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +64/-21 production (four files); tests +240/-0 (three new test files, one fixture, one extended case).

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root and in the branch worktree (before the final rebase; the two commits main gained since, #2593 kernel lookups and #2594 protocol exits, do not touch the writer, lifecycle log or transport): every operation and metric identical, G38 passes on both. The probes count rows, hashes, git processes and bytes; this batch removes per-call allocations and serialisations inside the writer worker and the decisions cache, which they do not observe — the cost evidence is the allocation/serialisation-count tests listed under verification.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_62c0ccaaf06a87f09006ccffd4 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/fixplan-a1-write-amp`
- Public scope: Daemon writer worker, lifecycle log, decisions readiness cache, inbound JSON line framing (fix-plan R3-03-F5, R1-01-F6, R1-01-F7 stringify half, R1-01-F8, R2-03-F10; R2-01-F12 examined and left).
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: R1-01-F7 git half (`git rev-parse HEAD` per `decisions.list`) stays open; no outbound frame cap (the finding was inbound only); no CI/gate/allowlist change; wire shapes and error codes unchanged.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `c5e061491`
- Branch merge-base with `origin/main`: `c5e061491`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/fixplan-a1-write-amp`
- Private evidence commit/path: task_62c0ccaaf06a87f09006ccffd4 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO ground-truth on the rebased head 8ce8be728 (base c5e061491): fast/contract `lifecycle-log`, `frame-codec.contract`, `decision-surface`, `local-json-rpc-client`, `writer-supervisor-liveness`, `fleet-transport.contract` plus contract `json-rpc-protocol` 48/48 green locally, and isolated Ubuntu `writer-sync-capability-cost.integration` 1/1 and `fleet-writer-epoch.integration` 8/8 green; `tsc -b` clean; gates `check-file-complexity`, `run-local-line-density` G36, `canonical-event-compat`, `check-cli-structure`, `check-bypass-write-boundary` (107 governed calls), `check-import-boundaries` pass, `check-pr-governance` skipped (no protected surface); G1 identical base vs head. Worker report (`artifacts/reports/fixplan-a1-write-amp.md`): fast 758 run / 753 pass with the 5 reds being the task-bound git push guard on `tools/pr-merge.test.mjs` and `tools/run-local-line-budget.test.mjs` fixtures (not diff-related); contract 1133/1133; isolated integration writer-sync-capability-cost 1/1, decision-surface 5/5, fleet-writer-epoch 8/8, json-rpc-protocol 48/48, writer-request-cost 1/1, artifact-entity-action 9/9; grep of `Invalid JSON-RPC frame`/`32700`, `writer epoch descriptor changed in transit`, `exceeded 1 MiB` shows no out-of-package assertion surface. After the TDZ fix (head after 8ce8be728): isolated Ubuntu `repo-cell-lock-release.integration` 1/1, `daemon-host-recovery` 17/17, `writer-sync-capability-cost.integration` 1/1 green.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; read the four production diffs, verified `createJsonLineFrameReader` has exactly one production consumer (`serveJsonRpcStream`, daemon inbound) so the cap cannot truncate daemon responses, checked the largest inline inbound contracts (256 KiB doc-sync, disk-path artifacts) sit far under 4 MiB, re-ran the targeted fast/contract/isolated suites and gates on the final rebase, and accepted the git-half of R1-01-F7 staying open as documented.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The inbound cap is a behaviour change for any peer that sends a single JSON-RPC line over 4 MiB: the connection fails with a parse error instead of being buffered. Legitimate inbound payloads are far below it (doc-sync inline content is capped at 256 KiB, artifact sources are read from disk by path, entity content reads are 2 MiB and outbound); client-side response reading does not use this reader, so large responses such as an unbounded `repo.tasks.list` are unaffected. SAB reuse relies on the state words being re-armed before each post; the integration test pins one allocation across repeated calls but not the handshake ordering itself, which the existing writer liveness/epoch suites exercise. The `Buffer.byteLength` check runs on the whole buffered string per chunk; for normal requests the buffer is one small line.

## References

- Task: task_62c0ccaaf06a87f09006ccffd4

---

# 中文

## 概要

fix-plan 批 13（A1，非承重写放大）。(R3-03-F5) `lifecycle-log` 每次 append 前重新检查日志大小，不再每进程只查一次，长驻 daemon 因此真的会轮转。(R1-01-F6) writer worker 为 sync-capability 握手按 worker 生命周期持有一对 8 字节 state + 1 MiB bytes 的 SharedArrayBuffer 复用，不再每个请求新分配 1 MiB；每次 post 前重置 state 字。(R1-01-F8) `reviveBinding` 用 `sameWriterEpochFence` 逐字段比较 writer epoch fence，取代必被 structured clone 打破的引用短路加两次 `JSON.stringify`。(R1-01-F7 的 stringify 半边) decisions 就绪缓存键改为 `commitSha + ledger head revision`，不再 `commitSha + JSON.stringify(全部 decision 行)`；git 半边（每次 `decisions.list` 一个 `git rev-parse HEAD` 子进程）不在本批，fix plan 中仍 open。(R2-03-F10) JSON line 帧读取器把未终止的入站行封顶 4 MiB（`JSON_LINE_FRAME_MAX_BYTES`），超限返回错误、由既有 `failConnection` 路径转成 -32700 解析错误；此前不换行的对端会让缓冲无界增长。(R2-01-F12) `compiledVerticals` 的增长记录为受声明 revision 封界，不改。

## 架构辩护

不随请求变化的逐请求工作（缓冲、轮转状态、序列化缓存键）提升到拥有它的生命周期；无界输入缓冲拿到其生产方契约本已隐含的上限。

## 改动内容

- `packages/daemon/src/lifecycle-log.ts`（+6/-4）：`prepared` 旗标只保留 mkdir 职责（`preparedDirectory`）；每次 append 前跑 `rotateLifecycleLog`（首行即 `statSync` 早退）。
- `packages/daemon/src/repo-writer-worker.ts`（+31/-14）：惰性持有的 SAB 对跨 sync-capability 调用复用，声明放在 `startRepoWriterWorker` 顶部，让 open 期间的能力（killpoint、fleetRoster）调用提升的 `syncCapability` 时不撞 TDZ（本 PR 第一次 CI 在 `repo-cell-lock-release.integration` 与 `daemon-host-recovery` 正好抓到这个），每次 post 前重置 state 字；`sameWriterEpochFence` 逐字段比较替代引用检查加两次 stringify。
- `packages/daemon/src/repo-cell-api.ts`（+1/-1）：decisions 缓存键用 `store.readHead()?.revision`（文件只减不增；行数中性）。
- `packages/daemon/src/transport/frame-codec.ts`（+26/-2）：`JSON_LINE_FRAME_MAX_BYTES = 4 MiB`；读取器丢弃超长缓冲并返回错误；唯一消费方是 `serveJsonRpcStream`（daemon 入站，`transport/json-rpc-stream.ts`），它已有可读解析错误的断连路径。
- 测试：`packages/daemon/test/lifecycle-log.test.ts`（fast，新：首次之后的 append 也会轮转）、`frame-codec.contract.test.ts`（contract，新：上限内帧通过，超限未终止行报错并清空缓冲）、`writer-sync-capability-cost.integration.test.ts` + `fixtures/writer-sab-allocation-probe.mjs`（integration，新：重复 sync-capability 调用只分配一对 SAB）、`decision-surface.test.ts`（+1 例：缓存键不重新序列化 decision 行）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+64/-21 production (four files); tests +240/-0 (three new test files, one fixture, one extended case)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_62c0ccaaf06a87f09006ccffd4（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/fixplan-a1-write-amp`
- 公开范围：daemon writer worker、lifecycle log、decisions 就绪缓存、入站 JSON line 分帧（fix-plan R3-03-F5、R1-01-F6、R1-01-F7 stringify 半边、R1-01-F8、R2-03-F10；R2-01-F12 核过不改）。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：R1-01-F7 的 git 半边（每次 `decisions.list` 一个 `git rev-parse HEAD`）仍 open；不加出站帧上限（原 finding 只涉入站）；不改 CI/gate/allowlist；wire 形状与错误码不变。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`c5e061491`
- 分支与 `origin/main` 的 merge-base：`c5e061491`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/fixplan-a1-write-amp`
- 私有证据路径：task_62c0ccaaf06a87f09006ccffd4 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO 在 rebase 后 head 8ce8be728（base c5e061491）核实：fast/contract `lifecycle-log`、`frame-codec.contract`、`decision-surface`、`local-json-rpc-client`、`writer-supervisor-liveness`、`fleet-transport.contract` 加本机 contract `json-rpc-protocol` 48/48 全绿，Ubuntu 隔离 `writer-sync-capability-cost.integration` 1/1、`fleet-writer-epoch.integration` 8/8 全绿；`tsc -b` 干净；gates `check-file-complexity`、`run-local-line-density` G36、`canonical-event-compat`、`check-cli-structure`、`check-bypass-write-boundary`（107 个受治理调用）、`check-import-boundaries` 通过，`check-pr-governance` 跳过（未触碰 protected surface）；G1 base 与 head 全等。worker 报告（`artifacts/reports/fixplan-a1-write-amp.md`）：fast 758 跑 / 753 过，5 个红是 task-bound git push guard 命中 `tools/pr-merge.test.mjs` 与 `tools/run-local-line-budget.test.mjs` 的 fixture（与 diff 无关）；contract 1133/1133；隔离 integration writer-sync-capability-cost 1/1、decision-surface 5/5、fleet-writer-epoch 8/8、json-rpc-protocol 48/48、writer-request-cost 1/1、artifact-entity-action 9/9；grep `Invalid JSON-RPC frame`/`32700`、`writer epoch descriptor changed in transit`、`exceeded 1 MiB` 无包外断言面。 TDZ 修复后（8ce8be728 之后的 head）：Ubuntu 隔离 `repo-cell-lock-release.integration` 1/1、`daemon-host-recovery` 17/17、`writer-sync-capability-cost.integration` 1/1 全绿。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；通读四个生产 diff，核实 `createJsonLineFrameReader` 只有一个生产消费方（`serveJsonRpcStream`，daemon 入站）所以上限不可能截断 daemon 响应，核对最大的内联入站契约（256 KiB doc-sync、按路径的 artifact）远在 4 MiB 之下，在最终 rebase 上重跑定向 fast/contract/隔离套件与 gates，并接受 R1-01-F7 git 半边按文档保持 open。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 入站上限对任何单行 JSON-RPC 超过 4 MiB 的对端是行为变化：连接以解析错误失败而不是继续缓冲。合法入站负载远低于此（doc-sync 内联内容上限 256 KiB，artifact 源按路径从磁盘读，entity 内容读 2 MiB 且为出站）；客户端读响应不经这个读取器，所以 `repo.tasks.list` 这类大响应不受影响。SAB 复用依赖每次 post 前重置 state 字；integration 测试钉住重复调用只分配一次，但不钉握手顺序本身，后者由既有 writer liveness/epoch 套件覆盖。`Buffer.byteLength` 检查按块对整个缓冲字符串执行；正常请求缓冲只有一小行。

## 参考

- 任务：task_62c0ccaaf06a87f09006ccffd4

