### PR TITLE
perf(migration): read and index each conversion and import source once

### DIFF
--- a/packages/daemon/src/migration-import-projection-restatement.ts
+++ b/packages/daemon/src/migration-import-projection-restatement.ts
@@ -93,7 +93,7 @@ export function addOracleDecision(context: MigrationImportContext, source: Proje
 export function addOracleFact(context: MigrationImportContext, source: ProjectionOracleFact): boolean {
   const fields = source.fields,
     sourceRef = `fact/${source.factId}`;
-  if ([...context.factMap.values()].includes(sourceRef) || context.factMap.has(sourceRef)) return true;
+  if (context.factTargets.has(sourceRef) || context.factMap.has(sourceRef)) return true;
   const observedAt = context.timestamp(fields.observedAt),
     taskId = typeof fields.taskId === "string" ? fields.taskId : undefined,
     mappedTaskId = taskId === undefined ? undefined : context.taskMap.get(taskId);
@@ -119,10 +119,10 @@ export function addOracleFact(context: MigrationImportContext, source: Projectio
   });
   let targetFactId = source.factId,
     targetRef = `fact/${targetFactId}`;
-  if (context.existingFacts.has(targetRef) || [...context.factMap.values()].includes(targetRef)) {
+  if (context.existingFacts.has(targetRef) || context.factTargets.has(targetRef)) {
     targetFactId = `F-${sha256Text(`${context.sourceKey}\0${sourceRef}`).slice(0, 8).toUpperCase()}`;
     targetRef = `fact/${targetFactId}`;
-    if (context.existingFacts.has(targetRef) || [...context.factMap.values()].includes(targetRef))
+    if (context.existingFacts.has(targetRef) || context.factTargets.has(targetRef))
       throw context.idRemapConflict("fact", sourceRef, targetRef);
     context.remappings.push({
       entityType: "fact",
@@ -132,6 +132,7 @@ export function addOracleFact(context: MigrationImportContext, source: Projectio
     });
   }
   context.factMap.set(sourceRef, targetRef);
+  context.factTargets.add(targetRef);
   recordDerivation(context, "fact", source.factId, "entity", `projection:fact@${context.oracle.watermark}`);
   context.drafts.push({
     kind: "fact",

--- a/packages/daemon/src/migration-import-reconciliation.ts
+++ b/packages/daemon/src/migration-import-reconciliation.ts
@@ -5,14 +5,21 @@ import type { MigrationKindReconciliation } from "./migration-import-types.ts";
 export function reconcileProjectionOracle(
   context: MigrationImportContext,
 ): Readonly<Record<MigrationOracleKind, MigrationKindReconciliation>> {
+  const factIds = new Set(
+    [...context.factMap.entries()].flatMap(([source, target]) => [factId(source), factId(target)]),
+  );
   return Object.fromEntries(
-    migrationOracleKinds.map((kind) => [kind, reconcileKind(context, kind)]),
+    migrationOracleKinds.map((kind) => [kind, reconcileKind(context, kind, factIds)]),
   ) as unknown as Readonly<Record<MigrationOracleKind, MigrationKindReconciliation>>;
 }
 
-function reconcileKind(context: MigrationImportContext, kind: MigrationOracleKind): MigrationKindReconciliation {
+function reconcileKind(
+  context: MigrationImportContext,
+  kind: MigrationOracleKind,
+  factIds: ReadonlySet<string>,
+): MigrationKindReconciliation {
   const sourceIds = oracleIds(context, kind),
-    includedIds = new Set([...sourceIds].filter((id) => isIncluded(context, kind, id))),
+    includedIds = new Set([...sourceIds].filter((id) => isIncluded(context, kind, id, factIds))),
     derivedIds = intersection(sourceIds, context.derivedIds[kind]),
     archivedIds = intersection(sourceIds, context.archivedIds[kind]),
     retiredIds = kind === "relation" ? intersection(sourceIds, context.retiredIds) : new Set<string>(),
@@ -44,19 +51,25 @@ function oracleIds(context: MigrationImportContext, kind: MigrationOracleKind): 
   return new Set(context.oracle.runtimeSessions.keys());
 }
 
-function isIncluded(context: MigrationImportContext, kind: MigrationOracleKind, id: string): boolean {
+function isIncluded(
+  context: MigrationImportContext,
+  kind: MigrationOracleKind,
+  id: string,
+  factIds: ReadonlySet<string>,
+): boolean {
   if (context.archivedIds[kind].has(id)) return true;
   if (kind === "task") return context.taskMap.has(id);
   if (kind === "decision") return context.decisionMap.has(id);
-  if (kind === "fact")
-    return [...context.factMap.entries()].some(
-      ([source, target]) => source.endsWith(`/${id}`) || target.endsWith(`/${id}`),
-    );
+  if (kind === "fact") return factIds.has(id);
   if (kind === "relation") return context.relationMap.has(id) || context.retiredIds.has(id);
   if (kind === "execution") return context.nativeExecutionIds.has(id);
   if (kind === "agent") return context.agentMap.has(id);
   if (kind === "schedule") return context.scheduleMap.has(id);
   return context.runtimeSessionMap.has(id);
+}
+
+function factId(ref: string): string {
+  return ref.slice(ref.lastIndexOf("/") + 1);
 }
 
 function intersection(left: ReadonlySet<string>, right: ReadonlySet<string>): Set<string> {

--- a/packages/daemon/src/migration-import-relations.ts
+++ b/packages/daemon/src/migration-import-relations.ts
@@ -39,7 +39,9 @@ export interface MigrationRelationsContext {
   readonly taskMap: Map<string, string>;
   readonly decisionMap: Map<string, string>;
   readonly factMap: Map<string, string>;
+  readonly factTargets: Set<string>;
   readonly relationMap: Map<string, string>;
+  readonly legacyRelationIdsByCanonicalId: ReadonlyMap<string, string>;
   readonly prepare: (
     sourceKey: string,
     actor: ActorIdentity,
@@ -72,6 +74,16 @@ export interface MigrationRelationsContext {
   readonly retiredIds: Set<string>;
 }
 
+export function migrationRelationIndexes(source: ColdRebuildSource, relationMap: Map<string, string>) {
+  return {
+    relationMap,
+    factTargets: new Set<string>(),
+    legacyRelationIdsByCanonicalId: new Map(
+      [...source.legacyRelationIds].map(([legacyId, canonicalId]) => [canonicalId, legacyId]),
+    ),
+  };
+}
+
 export function reboundRelation(context: MigrationRelationsContext, row: RelationGraphEdgeRow): ReboundRelation | null {
   const source = context.reboundRef(row.sourceRef),
     target = context.reboundRef(row.targetRef),
@@ -99,9 +111,7 @@ export function reboundRelation(context: MigrationRelationsContext, row: Relatio
     rationale: row.rationale,
     state: truthGap ? "retired" : normalizeLegacyRelationState(row.state),
   };
-  const legacyRelationId = [...context.cold.legacyRelationIds.entries()].find(
-    ([, canonicalId]) => canonicalId === row.relationId,
-  )?.[0];
+  const legacyRelationId = context.legacyRelationIdsByCanonicalId.get(row.relationId);
   if (truthGap && !context.retiredIds.has(row.relationId)) {
     context.retiredIds.add(row.relationId);
     context.dispositions.push({
@@ -182,7 +192,11 @@ export function prepareRelation(
 export function dropMap(context: MigrationRelationsContext, kind: Draft["kind"], id: string): void {
   if (kind === "task") context.taskMap.delete(id);
   if (kind === "decision") context.decisionMap.delete(id);
-  if (kind === "fact") context.factMap.delete(id);
+  if (kind === "fact") {
+    const target = context.factMap.get(id);
+    context.factMap.delete(id);
+    if (target && ![...context.factMap.values()].includes(target)) context.factTargets.delete(target);
+  }
 }
 
 export function actorFor(context: MigrationRelationsContext, entityId: string): ActorIdentity {
@@ -240,51 +254,56 @@ export function existingSourceEntity(
 
 export function readMigrationOperationRestatements(store: CanonicalEventStore): ReadonlyMap<string, string> {
   const mappings = new Map<string, string>();
-  for (const event of store.read().events) {
-    if (
-      !isMigrationImportEvent(event) ||
-      event.payload.entity.kind !== "id-map" ||
-      event.type !== "entity_migrated" ||
-      event.source !== "migration-import/v1" ||
-      event.payload.generation !== "v0"
-    )
-      continue;
-    const claim = event.payload.entity.documentClaim,
-      digest = claim.sha256,
-      markerOpId = `op_${sha256Text(`fact-rekey\0${digest}`)}`;
-    if (
-      event.opId !== markerOpId ||
-      event.eventId !== `event-${sha256Text(markerOpId)}` ||
-      event.payload.migratedFrom !== `fact-rekey:${digest}` ||
-      event.payload.entity.importId !== `fact-rekey-${digest.slice(0, 16)}` ||
-      claim.path !== `migrations/fact-rekey/${digest.slice(0, 16)}/id-map.json` ||
-      claim.mediaType !== "application/json" ||
-      claim.policyId !== "typed-migration-import/v1"
-    )
-      continue;
-    const bytes = store.readContentBlob(claim.sha256);
-    if (bytes === null || bytes.byteLength !== claim.size) continue;
-    let body: string, parsed: unknown;
-    try {
-      body = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-      parsed = JSON.parse(body);
-    } catch (error) {
-      consumeKnownError(error);
-      continue;
-    }
-    if (sha256Text(body) !== claim.sha256) continue;
-    if (!isRecordValue(parsed) || parsed.schema !== "fact-rekey-id-map/v1" || !isRecordValue(parsed.maps)) continue;
-    for (const kind of ["fact", "relation"] as const) {
-      const entries = parsed.maps[kind];
-      if (!isRecordValue(entries)) continue;
-      for (const [sourceId, targetId] of Object.entries(entries)) {
-        if (typeof targetId !== "string" || !validRestatementId(kind, sourceId, targetId)) continue;
-        const key = `${kind}\0${sourceId}`,
-          existing = mappings.get(key);
-        mappings.set(key, existing === undefined || existing === targetId ? targetId : "");
+  let cursor: string | null = null;
+  do {
+    const batch = store.readBatch(cursor, 256);
+    cursor = batch.cursor;
+    for (const event of batch.events) {
+      if (
+        !isMigrationImportEvent(event) ||
+        event.payload.entity.kind !== "id-map" ||
+        event.type !== "entity_migrated" ||
+        event.source !== "migration-import/v1" ||
+        event.payload.generation !== "v0"
+      )
+        continue;
+      const claim = event.payload.entity.documentClaim,
+        digest = claim.sha256,
+        markerOpId = `op_${sha256Text(`fact-rekey\0${digest}`)}`;
+      if (
+        event.opId !== markerOpId ||
+        event.eventId !== `event-${sha256Text(markerOpId)}` ||
+        event.payload.migratedFrom !== `fact-rekey:${digest}` ||
+        event.payload.entity.importId !== `fact-rekey-${digest.slice(0, 16)}` ||
+        claim.path !== `migrations/fact-rekey/${digest.slice(0, 16)}/id-map.json` ||
+        claim.mediaType !== "application/json" ||
+        claim.policyId !== "typed-migration-import/v1"
+      )
+        continue;
+      const bytes = store.readContentBlob(claim.sha256);
+      if (bytes === null || bytes.byteLength !== claim.size) continue;
+      let body: string, parsed: unknown;
+      try {
+        body = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+        parsed = JSON.parse(body);
+      } catch (error) {
+        consumeKnownError(error);
+        continue;
+      }
+      if (sha256Text(body) !== claim.sha256) continue;
+      if (!isRecordValue(parsed) || parsed.schema !== "fact-rekey-id-map/v1" || !isRecordValue(parsed.maps)) continue;
+      for (const kind of ["fact", "relation"] as const) {
+        const entries = parsed.maps[kind];
+        if (!isRecordValue(entries)) continue;
+        for (const [sourceId, targetId] of Object.entries(entries)) {
+          if (typeof targetId !== "string" || !validRestatementId(kind, sourceId, targetId)) continue;
+          const key = `${kind}\0${sourceId}`,
+            existing = mappings.get(key);
+          mappings.set(key, existing === undefined || existing === targetId ? targetId : "");
+        }
       }
     }
-  }
+  } while (cursor !== null);
   return mappings;
 }
 

--- a/packages/daemon/src/migration-import-relations.ts
+++ b/packages/daemon/src/migration-import-relations.ts
@@ -256,10 +256,13 @@ export function existingSourceEntity(
 
 export function readMigrationOperationRestatements(store: CanonicalEventStore): ReadonlyMap<string, string> {
   const mappings = new Map<string, string>();
-  let cursor: string | null = null;
-  do {
+  // readBatch signals exhaustion through `done`; its cursor stays non-null at the stream end.
+  let cursor: string | null = null,
+    done = false;
+  while (!done) {
     const batch = store.readBatch(cursor, 256);
     cursor = batch.cursor;
+    done = batch.done;
     for (const event of batch.events) {
       if (
         !isMigrationImportEvent(event) ||
@@ -305,7 +308,7 @@ export function readMigrationOperationRestatements(store: CanonicalEventStore): 
         }
       }
     }
-  } while (cursor !== null);
+  }
   return mappings;
 }
 

--- a/packages/daemon/src/migration-import-relations.ts
+++ b/packages/daemon/src/migration-import-relations.ts
@@ -78,9 +78,11 @@ export function migrationRelationIndexes(source: ColdRebuildSource, relationMap:
   return {
     relationMap,
     factTargets: new Set<string>(),
-    legacyRelationIdsByCanonicalId: new Map(
-      [...source.legacyRelationIds].map(([legacyId, canonicalId]) => [canonicalId, legacyId]),
-    ),
+    // First legacy id per canonical id, matching the registry-order `find` this index replaces.
+    legacyRelationIdsByCanonicalId: [...source.legacyRelationIds].reduce((index, [legacyId, canonicalId]) => {
+      if (!index.has(canonicalId)) index.set(canonicalId, legacyId);
+      return index;
+    }, new Map<string, string>()),
   };
 }
 

--- a/packages/daemon/src/migration-import-report.ts
+++ b/packages/daemon/src/migration-import-report.ts
@@ -119,19 +119,17 @@ export function reportTable(
         `| ${row.passed ? "PASS" : "FAIL"} |`,
       ].join(" ");
     }),
-    sampleRows = migrationOracleKinds.flatMap((kind) => [
-      ...fieldDerivations
-        .filter(({ entityType }) => entityType === kind)
-        .slice(0, 20)
-        .map(({ entityId, field, derived_from }) => `- SAMPLE derived ${kind} ${entityId}.${field} <- ${derived_from}`),
-      ...dispositions
-        .filter(({ entityType }) => entityType === kind)
-        .slice(0, 20)
-        .map(
-          ({ entityId, disposition, sourcePath, reason }) =>
-            `- SAMPLE ${disposition} ${kind} ${entityId} (${sourcePath}): ${reason}`,
-        ),
-    ]),
+    derivationSamples = sampleBuckets(),
+    dispositionSamples = sampleBuckets();
+  for (const { entityType, entityId, field, derived_from } of fieldDerivations)
+    if (derivationSamples[entityType].length < 20)
+      derivationSamples[entityType].push(`- SAMPLE derived ${entityType} ${entityId}.${field} <- ${derived_from}`);
+  for (const { entityType, entityId, disposition, sourcePath, reason } of dispositions)
+    if (dispositionSamples[entityType].length < 20)
+      dispositionSamples[entityType].push(
+        `- SAMPLE ${disposition} ${entityType} ${entityId} (${sourcePath}): ${reason}`,
+      );
+  const sampleRows = migrationOracleKinds.flatMap((kind) => [...derivationSamples[kind], ...dispositionSamples[kind]]),
     backfillDifferenceRows = backfillRows.map(
       ({ entityType, entityId, action, sourceAnchor }) =>
         `| ${entityType} | ${entityId} | ${action} | ${sourceAnchor} |`,
@@ -219,6 +217,13 @@ export function reportTable(
     `ID map: ${dryRun || !authored.passed ? `would write ${idMapPath}` : idMapPath}`,
     ["Reconciliation: ", reconciliation, ""].join(""),
   ].join("\n");
+}
+
+function sampleBuckets(): Record<MigrationOracleKind, string[]> {
+  return Object.fromEntries(migrationOracleKinds.map((kind) => [kind, []])) as unknown as Record<
+    MigrationOracleKind,
+    string[]
+  >;
 }
 
 export function fromColdIssue(issue: ColdRebuildIssue): Skip {

--- a/packages/daemon/src/migration-import-run.ts
+++ b/packages/daemon/src/migration-import-run.ts
@@ -49,6 +49,7 @@ import {
   actorFor as actorForImpl,
   dropMap as dropMapImpl,
   existingSourceEntity as existingSourceEntityImpl,
+  migrationRelationIndexes,
   mappedIdentifier as mappedIdentifierImpl,
   prepareRelation as prepareRelationImpl,
   readMigrationOperationRestatements,
@@ -278,16 +279,15 @@ export async function runSingleMigrationImport(
     decisionGraph = input.projection.readDecisionGraph(),
     existingTasks = new Set(input.projection.list().rows.map(({ taskId }) => taskId)),
     existingDecisions = new Set(decisionGraph.decisionAnchors.map(({ decisionId }) => decisionId)),
-    existingFacts = new Set(input.projection.readFactGraph().facts.map(({ ref }) => ref)),
+    factGraph = input.projection.readFactGraph(),
+    existingFacts = new Set(factGraph.facts.map(({ ref }) => ref)),
     existingAgents = new Map(input.projection.listEntities("agent").map(({ id, value }) => [id, value])),
     existingSchedules = new Map(input.projection.listEntities("schedule").map(({ id, value }) => [id, value])),
     existingRuntimeSessions = new Map(
       input.projection.readRuntimeSessions().map((value) => [value.runtimeSessionId, value]),
     ),
     operationRestatements = readMigrationOperationRestatements(input.store),
-    existingRelations = new Set(
-      [...decisionGraph.edges, ...input.projection.readFactGraph().edges].map(({ relationId }) => relationId),
-    );
+    existingRelations = new Set([...decisionGraph.edges, ...factGraph.edges].map(({ relationId }) => relationId));
   const taskMap = new Map<string, string>(),
     decisionMap = new Map<string, string>(),
     factMap = new Map<string, string>(),
@@ -417,7 +417,7 @@ export async function runSingleMigrationImport(
     existingSchedules,
     existingRuntimeSessions,
     backfillRows,
-    relationMap,
+    ...migrationRelationIndexes(cold, relationMap),
   };
 
   for (const entry of taskRead.entries) addTask(entry);
@@ -460,7 +460,7 @@ export async function runSingleMigrationImport(
           contextTimestamp(source.fields.decided_at) ?? contextTimestamp(source.fields.proposed_at) ?? input.now(),
       });
   for (const source of oracle.facts.values())
-    if (!factMap.has(`fact/${source.factId}`) && ![...factMap.values()].includes(`fact/${source.factId}`))
+    if (!factMap.has(`fact/${source.factId}`) && !extracted.factTargets.has(`fact/${source.factId}`))
       scheduleArchivedEntity(extracted, {
         entityKind: "fact",
         entityId: source.factId,

--- a/packages/daemon/src/migration-import.ts
+++ b/packages/daemon/src/migration-import.ts
@@ -235,17 +235,18 @@ function addFact(context: MigrationImportContext, row: RelationFactRow): void {
   if (held?.kind === "fact") {
     const targetRef = `fact/${held.fact.factId}`;
     context.factMap.set(factRef, targetRef);
+    context.factTargets.add(targetRef);
     if (row.ref !== factRef && !context.factMap.has(row.ref)) context.factMap.set(row.ref, targetRef);
     context.alreadyImported.fact += 1;
     return;
   }
   let targetFactId = row.factId,
     targetRef = `fact/${targetFactId}`;
-  const sourceTargetOccupied = [...context.factMap.values()].includes(targetRef);
+  const sourceTargetOccupied = context.factTargets.has(targetRef);
   if (context.existingFacts.has(targetRef) || sourceTargetOccupied) {
     targetFactId = `F-${sha256Text(`${context.sourceKey}\0${factRef}`).slice(0, 8).toUpperCase()}`;
     targetRef = `fact/${targetFactId}`;
-    if (context.existingFacts.has(targetRef) || [...context.factMap.values()].includes(targetRef))
+    if (context.existingFacts.has(targetRef) || context.factTargets.has(targetRef))
       throw context.idRemapConflict("fact", factRef, targetRef);
     context.remappings.push({
       entityType: "fact",
@@ -261,6 +262,7 @@ function addFact(context: MigrationImportContext, row: RelationFactRow): void {
     });
   }
   context.factMap.set(factRef, targetRef);
+  context.factTargets.add(targetRef);
   if (row.ref !== factRef && !context.factMap.has(row.ref)) context.factMap.set(row.ref, targetRef);
   context.drafts.push({
     kind: "fact",

--- a/packages/kernel/src/store/generation-two-conversion.ts
+++ b/packages/kernel/src/store/generation-two-conversion.ts
@@ -77,7 +77,12 @@ export function runGenerationTwoConversion(input: {
     if (relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".."))
       throw new Error("conversion destination must be outside the immutable backup");
     if (input.mode === "convert") {
-      drillLedgerBackup({ backupDir, shadowParent: path.dirname(destinationRoot), destinationRoot });
+      drillLedgerBackup({
+        backupDir,
+        shadowParent: path.dirname(destinationRoot),
+        destinationRoot,
+        verifiedManifest: manifest,
+      });
       convert(source, destinationRoot, plan, events, rows);
     }
     // Activation follows verification, never precedes it: a destination that fails verification
@@ -348,24 +353,26 @@ function convert(
     for (const outcome of outcomes) {
       const members = mappedMembers(byOpId, outcome.memberOpIds),
         converted = members.map((mapping) => events[mapping.destinationRevision! - 1]!),
-        blobs = converted.flatMap((event, index) =>
-          contentClaims(event).map((claim) => {
-            const witness =
-              members[index]!.disposition === "retained-read-only" &&
-              event.schema === "migration-import-event/v1" &&
-              event.payload.entity.kind === "repo-document" &&
-              claim.sha256 === event.payload.entity.documentClaim.sha256;
-            const body = witness
-              ? new TextEncoder().encode(rows[members[index]!.sourceRevision - 1]!.eventJson)
-              : source.readContentObject(claim.sha256)!;
-            return { ...claim, body };
-          }),
+        blobs = new Map(
+          converted.flatMap((event, index) =>
+            contentClaims(event).map((claim) => {
+              const witness =
+                members[index]!.disposition === "retained-read-only" &&
+                event.schema === "migration-import-event/v1" &&
+                event.payload.entity.kind === "repo-document" &&
+                claim.sha256 === event.payload.entity.documentClaim.sha256;
+              const body = witness
+                ? new TextEncoder().encode(rows[members[index]!.sourceRevision - 1]!.eventJson)
+                : source.readContentObject(claim.sha256)!;
+              return [claim.sha256, { ...claim, body }] as const;
+            }),
+          ),
         );
       destination.appendCommand({
         fence,
         intent: { opId: outcome.opId, intentDigest: outcome.intentDigest, summary: outcome.summary },
         events: converted,
-        blobs,
+        blobs: [...blobs.values()],
         ...(outcome.rejectionCode === null ? {} : { rejectionCode: outcome.rejectionCode }),
         historicalRecord: {
           recordedAt: outcome.recordedAt,

--- a/packages/kernel/src/store/ledger-backup.ts
+++ b/packages/kernel/src/store/ledger-backup.ts
@@ -86,6 +86,7 @@ export function drillLedgerBackup(input: {
   readonly shadowParent: string;
   readonly destinationRoot?: string;
   readonly retention?: number;
+  readonly verifiedManifest?: LedgerBackupManifestV1;
 }): {
   readonly shadowRoot: string;
   readonly manifest: LedgerBackupManifestV1;
@@ -93,9 +94,9 @@ export function drillLedgerBackup(input: {
   readonly warnings: readonly string[];
 } {
   const backupDir = path.resolve(input.backupDir),
-    manifest = readManifest(backupDir),
+    manifest = input.verifiedManifest ?? readManifest(backupDir),
     payloadRoot = path.join(backupDir, "payload");
-  verifyManifest(payloadRoot, manifest);
+  if (!input.verifiedManifest) verifyManifest(payloadRoot, manifest);
   fileSystem.mkdir(input.shadowParent, { recursive: true });
   if (input.destinationRoot && fileSystem.exists(input.destinationRoot))
     throw new Error("restore destination already exists");

--- a/packages/kernel/src/store/legacy-generation-conversion.ts
+++ b/packages/kernel/src/store/legacy-generation-conversion.ts
@@ -313,7 +313,6 @@ function readLegacySnapshot(snapshotPath: string): ImmutableLegacySnapshotV2 {
     digest = snapshotSourceDigest(value.repoId, eventBytes, value.objects, value.sourceEvidence);
   if (digest !== value.sourceDigest)
     throw new TaskEventStoreError("invalid_store", "legacy generation snapshot digest differs");
-  for (const object of value.objects) readSnapshotObject(snapshotPath, object.sha256, object.size);
   return { ...value, eventBytes };
 }
 

--- a/packages/kernel/src/store/sqlite-ledger-reconcile.ts
+++ b/packages/kernel/src/store/sqlite-ledger-reconcile.ts
@@ -114,6 +114,8 @@ export function reconcileSqliteEvents(input: {
         metadata.revision === rows.length,
       rowDigestMatches =
         rows.length >= expectedRows.length &&
+        stableStringify(rows.slice(0, expectedRows.length).map(({ recordedAt: _recordedAt, ...row }) => row)) ===
+          stableStringify(expectedRows) &&
         rows.every((row, index) => {
           const event = parsedRows[index];
           return (

--- a/packages/kernel/src/store/sqlite-ledger-reconcile.ts
+++ b/packages/kernel/src/store/sqlite-ledger-reconcile.ts
@@ -114,8 +114,6 @@ export function reconcileSqliteEvents(input: {
         metadata.revision === rows.length,
       rowDigestMatches =
         rows.length >= expectedRows.length &&
-        stableStringify(rows.slice(0, expectedRows.length).map(({ recordedAt: _recordedAt, ...row }) => row)) ===
-          stableStringify(expectedRows) &&
         rows.every((row, index) => {
           const event = parsedRows[index];
           return (

--- a/tools/gate-allowlists/check-fallback-boundaries.json
+++ b/tools/gate-allowlists/check-fallback-boundaries.json
@@ -291,12 +291,6 @@
     ],
     "fullHistoryScans": [
       {
-        "file": "packages/daemon/src/migration-import-relations.ts",
-        "function": "readMigrationOperationRestatements",
-        "task": "task_403e958e3fefd3496820e8843d",
-        "reason": "Existing request-path historical scan pending a bounded-read deletion task."
-      },
-      {
         "file": "packages/daemon/src/repo-cell-api.ts",
         "function": "\"repo.agentRuntime.events.read\"",
         "task": "task_403e958e3fefd3496820e8843d",


### PR DESCRIPTION
# English

## Summary

Fix-plan batch 17: migration import and generation conversion stop re-reading and re-materialising the same data. (R4-migration-F2) restatements are read with `readBatch(cursor, 256)` instead of materialising the whole ledger through `store.read()`. (R4-migration-F4 / R4-retry-F4 / R3-06-F8) the relation import builds a target fact `Set` and a first-match legacy-relation-id map once, reconciliation builds its fact-suffix `Set` once, and one `readFactGraph` is shared across the existing-facts and existing-relations passes instead of one per pass. (R4-migration-F3) `ledger-backup` accepts the manifest the same call chain already verified (`verifiedManifest?`) and generation-two conversion passes it, still verifying after the shadow copy. (R4-migration-F5) the eager whole-object sweep in `readLegacySnapshot` is deleted; the actual claim read still checks bytes, size and sha. (R3-06-F7) generation-two conversion deduplicates blobs per outcome with a sha256 `Map` before appending. (R4-migration-F8, report half) the import report buckets its samples in one pass. Left as they are after CEO review: the whole-table `stableStringify` comparison in `sqlite-ledger-reconcile.ts` (R4-migration-F6 — restored to main; the per-row digests do not replace a whole-table equality check, deferred), and two findings whose only fix changes command/transaction boundaries (R4-migration-F1 single-command batching, R2-01-F7 streaming contract-migrate) — DEFER, out of a de-duplication batch. R4-migration-F7, R3-06-F5, R1-04-F5, R1-01-F1, R1-04-F4 were already fixed on main.

## Architectural Justification

Offline conversion and import read each source once and index it; verification happens at the boundary that first sees the data and is passed as a witness, not repeated per consumer.

## What Changed

- `packages/daemon/src/migration-import-relations.ts`: target fact `Set`, first-match `legacyRelationIdsByCanonicalId` (CEO corrected the worker's last-match reduce), restatements via `readBatch(cursor, 256)`, terminated on the store's `done` flag (the worker's `while (cursor !== null)` never ended because `readBatch` keeps a non-null cursor at the stream end; the first CI run of this PR hung `migration-import-replay-records` / `migration-import-relations-actors` and failed the daemon-singleton `platform stop during a long migration replay` case — CEO fix).
- `packages/daemon/src/migration-import-reconciliation.ts`: fact-suffix `Set` built once.
- `packages/daemon/src/migration-import-run.ts`: single `readFactGraph` shared across passes.
- `packages/daemon/src/migration-import-report.ts`: one-pass sample buckets.
- `packages/daemon/src/migration-import.ts`, `migration-import-projection-restatement.ts`: follow the shared indexes.
- `packages/kernel/src/store/generation-two-conversion.ts`: blob dedupe `Map`, passes `verifiedManifest`.
- `packages/kernel/src/store/ledger-backup.ts`: optional `verifiedManifest` witness.
- `packages/kernel/src/store/legacy-generation-conversion.ts`: eager object sweep removed.
- `packages/kernel/src/store/sqlite-ledger-reconcile.ts`: no change versus main (worker's removal of the whole-table comparison reverted by the CEO).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +147/-95 production across nine files (kernel store conversion/backup, daemon migration import); no test files changed.

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root and in the branch worktree: every operation and metric identical, G38 passes on both. The probes exercise the online write/read paths; this batch changes offline migration, conversion and backup code that they never enter — the equivalence evidence is the round-5 baseline-vs-head digest comparison under verification.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_848e22f6ae746215a9cd5a6ef0 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/fixplan-b-migration`
- Public scope: Offline migration import, legacy/generation-two conversion and ledger backup read paths (fix-plan R4-migration-F2/F3/F4/F5/F8, R4-retry-F4, R3-06-F7/F8).
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: R4-migration-F1 and R2-01-F7 (transaction/command boundary changes) DEFERRED by CEO ruling; R4-migration-F6 (whole-table reconcile comparison) kept; R3-06-F6 (event-shape lazy seen set) deferred because `event-shape-migration.ts` sits at its complexity ceiling and a new module would need an offline-maintenance allowlist change; one stale fallback-boundaries allowlist key removed (see Governance Declaration), no other CI/gate change; no wire or on-disk format change.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/gate-allowlists/check-fallback-boundaries.json` (one `fullHistoryScans` key removed; the manifest-derived `check-pr-governance` rules do not list this file, so this declaration is voluntary)
- Protected surface scope: ratchet tightening only. `readMigrationOperationRestatements` no longer matches the gate's full-history-scan detector after the `store.read()` → `readBatch(cursor, 256)` rewrite, so the gate itself fails with `stale: … #readMigrationOperationRestatements` and instructs removing the key. No key is added, no detector or budget is changed.
- Authority: the allowlist file's own baseline rule ("remove a key when the corresponding production exit is deleted"); CI/gate standard `harness/governance/standards/ci-cd-standard.md`.
- Machine-check boundary: `node tools/check-fallback-boundaries.mjs` passes with fullHistoryScans=8 (was 9). Honest residual: the function still walks the whole event history in 256-row batches — memory is bounded, the scan is not; the bounded-read deletion the removed key pointed at (task_403e958e) remains open and is out of this batch.
- Break-glass: no

## Verification

- Base `origin/main` SHA: `c5e061491`
- Branch merge-base with `origin/main`: `c5e061491`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/fixplan-b-migration`
- Private evidence commit/path: task_848e22f6ae746215a9cd5a6ef0 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO ground-truth on the rebased head 9bc58cfec (base c5e061491): round-5 fixture `tmp/scale-fixtures/1e4-r5` via `node tools/scale/b5-real.mjs --source-root <branch> --baseline-root <main>`: `digestEqual` true, `resultSetEqual` tasks/graph/factSearch/factsAll all true (the tool throws if task or graph bytes differ), query p95s within noise (taskList 537 ms base vs 572 ms head, relationGraph 11.4 vs 11.6 ms); G1 identical base vs head. Worker (GLM, report `artifacts/report.md`): fast `migration-import-{oracle,relation-witness,task-restatement,task-witness}` 19/19; isolated Ubuntu `legacy-generation` 10/10 (+1 scale-conditional skip), `ledger-backup` 6/6, `generation-two-content` 1/1, `migration-import` 7/7 (re-run after rebase); `typecheck`, eslint on touched files, `git diff --check`, `check-file-complexity`, `run-local-line-density`, `check-bypass-write-boundary`, `check-cli-structure`, `canonical-event-compat --check` pass; G33 production-delta pass. The CEO's follow-up commit (first-match map, reconcile restore) was re-checked with the same fast set and the isolated `legacy-generation`/`migration-import` files. After the allowlist key removal: `check-fallback-boundaries` fullHistoryScans=8 pass; `check-pr-governance --base/--head` reports no manifest-protected surface. After the loop fix: isolated Ubuntu `migration-import-replay-records.integration` 8/8, `migration-import-relations-actors.integration` 6/6, `packages/cli/test/daemon-singleton-cli` 3/3 green.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; read the nine diffs, caught and fixed the worker's inverted map (reduce last-match vs required first-match), restored the whole-table reconcile comparison the worker had deleted (R4-migration-F6 stays deferred), ruled DEFER on the two transaction-boundary findings the worker escalated, and ran the round-5 baseline-vs-head digest comparison the worker could not run (no fixture in its worktree).
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- `readMigrationOperationRestatements` still parses every event; peak memory is bounded by the 256-row batch, not by a SQL pre-filter. The target-fact `Set` drop path removes a target only when its last alias is deleted. `verifiedManifest` is a witness passed within one call chain, not a cache: a caller that passes an unverified manifest would bypass the pre-copy check, and the post-copy verification still runs. No behaviour change for online commands.

## References

- Task: task_848e22f6ae746215a9cd5a6ef0

---

# 中文

## 概要

fix-plan 批 17：迁移导入与代际转换不再重复读取、重复物化同一份数据。(R4-migration-F2) restatement 用 `readBatch(cursor, 256)` 流读，不再 `store.read()` 物化整本台账。(R4-migration-F4 / R4-retry-F4 / R3-06-F8) 关系导入一次构建目标 fact `Set` 与首匹配的 legacy relation id 映射，reconciliation 一次构建 fact 后缀 `Set`，existing-facts 与 existing-relations 两个 pass 共用一次 `readFactGraph`。(R4-migration-F3) `ledger-backup` 接受同一调用链已验证过的 manifest（`verifiedManifest?`），generation-two 转换传入，shadow copy 之后仍验证。(R4-migration-F5) 删除 `readLegacySnapshot` 的 eager 全对象扫描；真正的 claim 读取仍校验 bytes/size/sha。(R3-06-F7) generation-two 转换每个 outcome 用 sha256 `Map` 去重 blob 后再 append。(R4-migration-F8 报告半边) 导入报告样本单遍分桶。CEO 评审后保持不动的：`sqlite-ledger-reconcile.ts` 的整表 `stableStringify` 对比（R4-migration-F6——恢复为 main，逐行 digest 不能替代整表相等检查，deferred），以及两个只有改动 command/事务边界才能修的 finding（R4-migration-F1 单命令合批、R2-01-F7 流式 contract-migrate）——DEFER，不属于去重批。R4-migration-F7、R3-06-F5、R1-04-F5、R1-01-F1、R1-04-F4 已在 main 修过。

## 架构辩护

离线转换与导入对每个来源只读一次并建索引；验证发生在第一个看到数据的边界并作为见证向下传递，不在每个消费方重复。

## 改动内容

- `packages/daemon/src/migration-import-relations.ts`：目标 fact `Set`、首匹配 `legacyRelationIdsByCanonicalId`（CEO 修正 worker 的末匹配 reduce）、`readBatch(cursor, 256)` 流读 restatement，以 store 的 `done` 旗标终止（worker 写的 `while (cursor !== null)` 永不结束，因为 `readBatch` 在流尾仍返回非空 cursor；本 PR 首轮 CI 因此挂死 `migration-import-replay-records` / `migration-import-relations-actors` 并让 daemon-singleton 的「长迁移回放中 platform stop」用例失败——CEO 修复）。
- `packages/daemon/src/migration-import-reconciliation.ts`：fact 后缀 `Set` 一次构建。
- `packages/daemon/src/migration-import-run.ts`：单次 `readFactGraph` 跨 pass 共享。
- `packages/daemon/src/migration-import-report.ts`：单遍样本分桶。
- `packages/daemon/src/migration-import.ts`、`migration-import-projection-restatement.ts`：随共享索引调整。
- `packages/kernel/src/store/generation-two-conversion.ts`：blob 去重 `Map`，传 `verifiedManifest`。
- `packages/kernel/src/store/ledger-backup.ts`：可选 `verifiedManifest` 见证。
- `packages/kernel/src/store/legacy-generation-conversion.ts`：删 eager 对象扫描。
- `packages/kernel/src/store/sqlite-ledger-reconcile.ts`：与 main 无差异（worker 删掉的整表对比已由 CEO 恢复）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+147/-95 production across nine files (kernel store conversion/backup, daemon migration import); no test files changed。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_848e22f6ae746215a9cd5a6ef0（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/fixplan-b-migration`
- 公开范围：离线迁移导入、legacy/generation-two 转换与台账备份读路径（fix-plan R4-migration-F2/F3/F4/F5/F8、R4-retry-F4、R3-06-F7/F8）。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：R4-migration-F1 与 R2-01-F7（事务/命令边界改动）按 CEO 裁决 DEFER；R4-migration-F6（整表 reconcile 对比）保留；R3-06-F6（event-shape 惰性 seen 集）因 `event-shape-migration.ts` 已达复杂度上限、拆新模块需改 offline-maintenance allowlist 而 deferred；删一个过期的 fallback-boundaries allowlist key（见 Governance Declaration），其余 CI/gate 不改；不改 wire 与落盘格式。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：是——`tools/gate-allowlists/check-fallback-boundaries.json`（删一个 `fullHistoryScans` key；manifest 派生的 `check-pr-governance` 规则未列此文件，本声明为主动声明）
- 范围：只收紧棘轮。`readMigrationOperationRestatements` 由 `store.read()` 改 `readBatch(cursor, 256)` 后不再命中 gate 的全历史扫描检测器，gate 本身以 `stale: … #readMigrationOperationRestatements` 失败并要求删 key。不加 key、不改检测器与预算。
- 依据：allowlist 文件自身 baseline 规则（「对应生产出口删除时移除 key」）；CI/gate 标准 `harness/governance/standards/ci-cd-standard.md`。
- 机器校验边界：`node tools/check-fallback-boundaries.mjs` 通过，fullHistoryScans=8（原 9）。如实残留：该函数仍按 256 行分批走完整个事件历史——内存有界、扫描无界；被删 key 指向的有界读删除任务（task_403e958e）仍 open，不在本批。
- Break-glass：否

## 验证

- 基线 `origin/main` SHA：`c5e061491`
- 分支与 `origin/main` 的 merge-base：`c5e061491`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/fixplan-b-migration`
- 私有证据路径：task_848e22f6ae746215a9cd5a6ef0 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO 在 rebase 后 head 9bc58cfec（base c5e061491）核实：round-5 夹具 `tmp/scale-fixtures/1e4-r5` 经 `node tools/scale/b5-real.mjs --source-root <分支> --baseline-root <main>`：`digestEqual` true，`resultSetEqual` tasks/graph/factSearch/factsAll 全 true（task 或 graph 字节不同时工具直接抛错），查询 p95 在噪声内（taskList base 537 ms vs head 572 ms，relationGraph 11.4 vs 11.6 ms）；G1 base 与 head 全等。worker（GLM，报告 `artifacts/report.md`）：fast `migration-import-{oracle,relation-witness,task-restatement,task-witness}` 19/19；Ubuntu 隔离 `legacy-generation` 10/10（+1 条 scale 条件 skip）、`ledger-backup` 6/6、`generation-two-content` 1/1、`migration-import` 7/7（rebase 后复跑）；`typecheck`、触碰文件 eslint、`git diff --check`、`check-file-complexity`、`run-local-line-density`、`check-bypass-write-boundary`、`check-cli-structure`、`canonical-event-compat --check` 通过；G33 production-delta 通过。CEO 的后续提交（首匹配映射、reconcile 恢复）用同一 fast 集与隔离 `legacy-generation`/`migration-import` 文件复核。 删 allowlist key 后：`check-fallback-boundaries` fullHistoryScans=8 通过；`check-pr-governance --base/--head` 报无 manifest 保护面。 循环修复后：Ubuntu 隔离 `migration-import-replay-records.integration` 8/8、`migration-import-relations-actors.integration` 6/6、`packages/cli/test/daemon-singleton-cli` 3/3 全绿。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；通读九个 diff，发现并修正 worker 反向映射的末匹配（reduce）与要求的首匹配不符，恢复 worker 删掉的整表 reconcile 对比（R4-migration-F6 仍 deferred），对 worker 上报的两个事务边界 finding 裁决 DEFER，并代 worker 跑了它 worktree 里没有夹具而跑不了的 round-5 baseline-vs-head digest 对比。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- `readMigrationOperationRestatements` 仍解析全部 event；峰值内存受 256 行 batch 封界，不是 SQL 预筛。目标 fact `Set` 的 drop 路径只在最后一个别名删除时移除目标。`verifiedManifest` 是同一调用链内传递的见证而非缓存：传入未验证 manifest 的调用方会绕过拷贝前检查，拷贝后验证仍执行。在线命令无行为变化。

## 参考

- 任务：task_848e22f6ae746215a9cd5a6ef0

