### PR TITLE
fix(daemon): bound the unparameterized repo.tasks.list read and narrow verifyReadiness

### DIFF
--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -687,8 +687,8 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
     return context.dispatchRead(readHandlers, method, payload) as DaemonGuiReadResultMap[typeof method];
   };
   const read: RepoCell["read"] = async (method, payload = {}, binding) => readNow(method, payload, binding);
-  // Narrow/paged query payloads for the two wide GUI reads: an empty payload keeps the
-  // unparameterized full result; any explicit facet takes the indexed narrow path.
+  // Narrow/paged query payload for the task list read: an empty payload keeps one default-bounded
+  // page (guiTasks applies TASK_LIST_PAGE_LIMIT); any explicit facet passes through as given.
   function taskListQueryFromPayload(payload: Readonly<Record<string, unknown>>): TaskProjectionListQuery {
     const common = queryPayloadFacets(payload, "repo.tasks.list");
     return {
@@ -1024,8 +1024,8 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
       return context.replica;
     },
     verifyReadiness: async () => {
-      const projected = await read("repo.tasks.list"),
-        ready = projected.status === "ready";
+      if (context.state !== "attached") throw context.cellCodedError("repo_unavailable", context.latched());
+      const ready = context.projection.readCut().status === "ready";
       if (!ready) throw context.cellCodedError("repo_unavailable", "RepoCell L2 projection is not ready.");
       return { cellState: "attached", l2State: "ready" };
     },

--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -688,7 +688,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
   };
   const read: RepoCell["read"] = async (method, payload = {}, binding) => readNow(method, payload, binding);
   // Narrow/paged query payload for the task list read: an empty payload keeps one default-bounded
-  // page (guiTasks applies TASK_LIST_PAGE_LIMIT); any explicit facet passes through as given.
+  // page (guiTasks defaults `limit` to 500, the GUI page width); any explicit facet passes through as given.
   function taskListQueryFromPayload(payload: Readonly<Record<string, unknown>>): TaskProjectionListQuery {
     const common = queryPayloadFacets(payload, "repo.tasks.list");
     return {

--- a/packages/daemon/src/task-query-read.ts
+++ b/packages/daemon/src/task-query-read.ts
@@ -195,7 +195,7 @@ export function makeTaskQueryReadModel(input: {
     };
   }
   function guiTasks(query: TaskProjectionListQuery = {}): DaemonTaskSnapshotListResult {
-    const lifecycle = projection.list(query),
+    const lifecycle = projection.list({ ...query, limit: query.limit ?? 500 }),
       { dependencies, derives, taskStatuses, blockingByTaskId } = readBlockingAssessments(
         lifecycle.rows.map(({ taskId }) => taskId),
       ),

--- a/packages/daemon/test/repo-cell-readiness.test.ts
+++ b/packages/daemon/test/repo-cell-readiness.test.ts
@@ -1,0 +1,63 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createRepoCellApi, type RepoCellApiContext } from "../src/repo-cell-api.ts";
+
+type Cut = { readonly status: "ready" | "pending"; readonly watermark: number; readonly sourceRevision: number };
+
+function readinessContext(
+  cut: Cut,
+  counters: { list: number; readCut: number },
+  state = "attached",
+): RepoCellApiContext {
+  return {
+    extracted: {},
+    mode: "local",
+    fleetRoster: null,
+    input: { repoId: "repository" },
+    state,
+    causeClass: null,
+    latched: () => "latched",
+    cellCodedError: (code: string, message: string) => Object.assign(new Error(message), { code }),
+    projection: {
+      readCut: () => {
+        counters.readCut += 1;
+        return cut;
+      },
+      list: () => {
+        counters.list += 1;
+        return { ...cut, rows: [], warnings: [] };
+      },
+    },
+  } as unknown as RepoCellApiContext;
+}
+
+test("verifyReadiness probes the projection cut without materializing task rows", async () => {
+  const counters = { list: 0, readCut: 0 },
+    cell = createRepoCellApi(readinessContext({ status: "ready", watermark: 7, sourceRevision: 7 }, counters));
+
+  assert.deepEqual(await cell.verifyReadiness(), { cellState: "attached", l2State: "ready" });
+  assert.equal(counters.readCut, 1);
+  assert.equal(counters.list, 0, "a readiness verdict must not read the task snapshot list");
+});
+
+test("verifyReadiness fails closed on a pending cut and a latched cell", async () => {
+  const pending = { list: 0, readCut: 0 };
+  await assert.rejects(
+    createRepoCellApi(
+      readinessContext({ status: "pending", watermark: 6, sourceRevision: 7 }, pending),
+    ).verifyReadiness(),
+    (error: Error & { code?: string }) =>
+      error.code === "repo_unavailable" && /L2 projection is not ready/u.test(error.message),
+  );
+  assert.equal(pending.list, 0);
+
+  const latched = { list: 0, readCut: 0 };
+  await assert.rejects(
+    createRepoCellApi(
+      readinessContext({ status: "ready", watermark: 7, sourceRevision: 7 }, latched, "unavailable"),
+    ).verifyReadiness(),
+    /latched/u,
+  );
+  assert.equal(latched.readCut, 0);
+});

--- a/packages/daemon/test/task-query-read.test.ts
+++ b/packages/daemon/test/task-query-read.test.ts
@@ -156,6 +156,22 @@ test("task control narrows graph, status, and decision reads to the selected lif
   assert.deepEqual(decisionCalls, [["dec_event"]]);
 });
 
+test("an unparameterized guiTasks read serves one default-bounded page, never the full ledger", () => {
+  const listCalls: TaskProjectionListQuery[] = [],
+    projection = projectionStub({
+      taskRows: Array.from({ length: 501 }, (_, index) =>
+        protocolTaskRow(`task_page_${String(index).padStart(4, "0")}`),
+      ),
+      listCalls,
+    });
+
+  const result = queryRead(process.cwd(), projection).guiTasks();
+
+  assert.deepEqual(listCalls, [{ limit: 500 }]);
+  assert.equal(result.rows.length, 500);
+  assert.deepEqual(result.page, { limit: 500, cursor: null, nextCursor: "task_page_0499" });
+});
+
 test("task snapshot list isolates an invalid row and continues serving valid rows", () => {
   const invalidWitness = {
       schema: "code-doc-witness/v1",
@@ -328,15 +344,22 @@ function projectionStub(
   return {
     list: (query: TaskProjectionListQuery = {}) => {
       options.listCalls?.push(query);
+      const selected = query.status
+        ? taskRows.filter((row) => (row as ReturnType<typeof protocolTaskRow>).snapshot.task.status === query.status)
+        : taskRows;
+      if (query.limit === undefined && query.cursor === undefined) return { ...cut, rows: selected, warnings: [] };
+      const limit = query.limit ?? 100,
+        visible = selected.slice(0, limit),
+        last = visible.at(-1) as { readonly taskId: string } | undefined;
       return {
         ...cut,
-        rows: query.status
-          ? taskRows.filter((row) => (row as ReturnType<typeof protocolTaskRow>).snapshot.task.status === query.status)
-          : taskRows,
+        rows: visible,
         warnings: [],
-        ...(query.limit === undefined
-          ? {}
-          : { page: { limit: query.limit, cursor: query.cursor ?? null, nextCursor: null } }),
+        page: {
+          limit,
+          cursor: query.cursor ?? null,
+          nextCursor: selected.length > limit && last ? last.taskId : null,
+        },
       };
     },
     read: () => ({ ...cut, packagePath: null }),

--- a/packages/daemon/test/task-surface-pages-facts.integration.test.ts
+++ b/packages/daemon/test/task-surface-pages-facts.integration.test.ts
@@ -172,7 +172,11 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
         blockingAssessment: { blockers: { targetTaskId: string }[] };
       }[];
     };
-    assert.equal(unparameterized.page, undefined, "unparameterized task list must not carry a page facet");
+    assert.deepEqual(
+      unparameterized.page,
+      { limit: 500, cursor: null, nextCursor: null },
+      "unparameterized task list keeps the default-bounded page",
+    );
     assert.deepEqual(
       unparameterized.rows
         .find(({ taskId }) => taskId === "task_real_Alpha")
@@ -217,7 +221,7 @@ test("wide task reads keep byte-identical unparameterized results and serve narr
       ["task_real_Beta", "task_real_Delta"],
     );
     assert.equal(active.rows.length, 2);
-    assert.equal(active.page, undefined);
+    assert.deepEqual(active.page, { limit: 500, cursor: null, nextCursor: null });
     const windowed = await cell.read("repo.tasks.list", {
       updatedAfter: "2026-08-15T00:00:00.000Z",
     });


### PR DESCRIPTION
# English

## Summary

Fix-plan batch 8 close-out: an unparameterized `repo.tasks.list` no longer serves the whole ledger. `guiTasks` defaults `limit` to 500 (the GUI page width) so the daemon RPC handler and the fleet pass-through return one default-bounded page with `page.nextCursor` set when more rows exist; the wire shape is unchanged because `DaemonTaskSnapshotListResult.page` is an existing optional field the validator already accepts and the GUI renderer already consumes. `verifyReadiness` (called on daemon-host attach and writer recover) no longer materialises every task row just to read `status`: it checks `projection.readCut().status` behind the same `attached` guard `readNow` uses, mirroring the proxy's `verifyReadiness`. Semantic change approved by the owner in advance: callers that relied on 'empty payload = full result' must page; the enumeration in the worker report shows every production caller already passes a limit or reads the projection directly.

## Architectural Justification

The task list read is paged by default like the relation graph read already is; readiness asks the projection for its cut state instead of materialising rows to infer it.

## What Changed

- `packages/daemon/src/task-query-read.ts` (+1/-1): `projection.list({ ...query, limit: query.limit ?? 500 })`.
- `packages/daemon/src/repo-cell-api.ts` (+4/-4): `verifyReadiness` narrow probe with explicit state guard; comment above `taskListQueryFromPayload` rewritten (CEO follow-up commit names the 500-row default instead of a GUI-only constant).
- Tests: `packages/daemon/test/repo-cell-readiness.test.ts` (fast, new: readiness never calls `list`; pending-cut and latched-cell failure paths), `task-query-read.test.ts` (projection stub pages faithfully; new case: 501 seeded rows → 500 rows + `page={limit:500,cursor:null,nextCursor:…}`), `task-surface-pages-facts.integration.test.ts` (two page assertions flipped to the default-bounded shape, matching the relation-graph precedent).

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +5/-5 production (net 0; both touched files sit at their shrink-only ceiling); tests +98/-8 (one new fast file, two updated).

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root and on the rebased branch head: every operation and metric identical, G38 passes on both. The probe's own `task-list` read passes an explicit `limit: 3`, so the new default does not enter its numbers; the size evidence is the hermetic 1500-task before/after table under verification.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_d5ebd5f8fafd14383e5c48ce01 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/task-list-bounded`
- Public scope: Daemon task list read model default bound and the readiness probe (fix-plan batch 8 residual: 28.4 MB unparameterized `repo.tasks.list`).
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Internal `projection.list` full readers stay full because they need whole-set semantics and never serialise an RPC response: `projectedTaskIds` (write-path identity), `migration-import-run` (dedup), wip snapshot (status filter). `invalidRows` of an unparameterized response now covers the first 500 rows; later pages expose their own. No CI/gate/allowlist change.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `c5e061491`
- Branch merge-base with `origin/main`: `c5e061491`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/task-list-bounded`
- Private evidence commit/path: task_d5ebd5f8fafd14383e5c48ce01 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO ground-truth on the rebased head (base c5e061491): fast `task-query-read`, `repo-cell-readiness`, `repo-cell-proxy`, `local-json-rpc-client` 18/18; isolated Ubuntu `task-surface-pages-facts.integration` + `agenda.integration` 5/5; `tsc -b` clean; gates `check-file-complexity`, `run-local-line-density` G36, `check-cli-structure`, `check-bypass-write-boundary`, `check-import-boundaries`, `canonical-event-compat` pass; G1 identical base vs head; `latched()`/`cellCodedError` guard verified identical to `readNow`'s. Worker (GLM, report `artifacts/reports/task-list-bounded.md`): fast+contract 1130/1130; 21 touched-surface files green through the isolated dispatcher; hermetic 1500-task unparameterized read base → head: 1500 rows / 3,267,173 B / p50 35.6 ms → 500 rows + page / 1,088,250 B / p50 12.1 ms (11.1 ms after rebase); negative control: the pre-change `projection.list({})` path returns 600/600 rows with no page; mutation: dropping the default turns the new unit test red. One pre-existing red found on the Ubuntu target unrelated to this change (`daemon-registry.test.ts`, reproduced on base) → task_d324fb2f.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; read the two production diffs, verified the readiness guard mirrors `readNow` (same `latched()` / `cellCodedError` pair) and the proxy's `verifyReadiness`, checked `page` is a pre-existing optional wire field, fixed a comment that named a GUI-only constant, rebased and re-ran the targeted suites, isolated files, gates and G1, and filed the pre-existing Ubuntu red the worker surfaced as its own task.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Any out-of-tree caller that sent an empty `repo.tasks.list` payload and expected every row now gets 500 plus a cursor. The readiness probe no longer exercises the list read path on attach; readiness of the projection is still what it checks, and the list path is covered by the read tests. Production default-daemon p50 on the 28.4 MB ledger was not measured (shared surface); the hermetic table is the evidence.

## References

- Task: task_d5ebd5f8fafd14383e5c48ce01

---

# 中文

## 概要

fix-plan 批 8 收尾：无参 `repo.tasks.list` 不再交付整本台账。`guiTasks` 默认 `limit` 500（GUI 页宽），daemon RPC handler 与 fleet 透传返回一页默认有界结果，行数超出时带 `page.nextCursor`；wire 形状不变，因为 `DaemonTaskSnapshotListResult.page` 是校验器已接受、GUI renderer 已消费的既有可选字段。`verifyReadiness`（daemon-host attach 与 writer recover 调用）不再为读一个 `status` 物化全部任务行：在与 `readNow` 相同的 `attached` 守卫后查 `projection.readCut().status`，与 proxy 的 `verifyReadiness` 同构。语义变化已由 owner 预先批准：依赖「空 payload = 全量」的调用方必须分页；worker 报告的枚举显示所有生产调用方已传 limit 或直接读投影。

## 架构辩护

任务列表读默认分页，与 relation graph 读已有的形状一致；就绪探针向投影询问 cut 状态，而不是物化行来推断。

## 改动内容

- `packages/daemon/src/task-query-read.ts`（+1/-1）：`projection.list({ ...query, limit: query.limit ?? 500 })`。
- `packages/daemon/src/repo-cell-api.ts`（+4/-4）：`verifyReadiness` 窄探针加显式状态守卫；`taskListQueryFromPayload` 上方注释重写（CEO 追加提交把引用 GUI 专有常量的措辞改为 500 行默认值）。
- 测试：`packages/daemon/test/repo-cell-readiness.test.ts`（fast，新：readiness 不调 `list`；pending cut 与 latched cell 双失败路径）、`task-query-read.test.ts`（投影 stub 忠实分页；新例：seed 501 行 → 500 行 + `page={limit:500,cursor:null,nextCursor:…}`）、`task-surface-pages-facts.integration.test.ts`（两处 page 断言翻到默认有界形状，对齐 relation graph 先例）。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+5/-5 production (net 0; both touched files sit at their shrink-only ceiling); tests +98/-8 (one new fast file, two updated)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_d5ebd5f8fafd14383e5c48ce01（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/task-list-bounded`
- 公开范围：daemon 任务列表读模型默认上界与就绪探针（fix-plan 批 8 残余：28.4 MB 无参 `repo.tasks.list`）。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：内部 `projection.list` 全量读者保持全量，因为它们需要全集合语义且不序列化 RPC 响应：`projectedTaskIds`（写路径身份判定）、`migration-import-run`（dedup）、wip snapshot（status 过滤）。无参响应的 `invalidRows` 现在覆盖前 500 行，后续页各自暴露。不改 CI/gate/allowlist。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`c5e061491`
- 分支与 `origin/main` 的 merge-base：`c5e061491`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/task-list-bounded`
- 私有证据路径：task_d5ebd5f8fafd14383e5c48ce01 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO 在 rebase 后 head（base c5e061491）核实：fast `task-query-read`、`repo-cell-readiness`、`repo-cell-proxy`、`local-json-rpc-client` 18/18；Ubuntu 隔离 `task-surface-pages-facts.integration` + `agenda.integration` 5/5；`tsc -b` 干净；gates `check-file-complexity`、`run-local-line-density` G36、`check-cli-structure`、`check-bypass-write-boundary`、`check-import-boundaries`、`canonical-event-compat` 通过；G1 base 与 head 全等；`latched()`/`cellCodedError` 守卫核实与 `readNow` 相同。worker（GLM，报告 `artifacts/reports/task-list-bounded.md`）：fast+contract 1130/1130；21 个触碰面文件经隔离派测全绿；hermetic 1500-task 无参读 base → head：1500 行 / 3,267,173 B / p50 35.6 ms → 500 行 + page / 1,088,250 B / p50 12.1 ms（rebase 后 11.1 ms）；阴性对照：改前 `projection.list({})` 路径返回 600/600 行无 page；变异：去掉默认值则新单测红。Ubuntu 目标发现一处与本改动无关的存量红（`daemon-registry.test.ts`，base 复现）→ task_d324fb2f。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；通读两个生产 diff，核实就绪守卫与 `readNow`（同一对 `latched()` / `cellCodedError`）及 proxy 的 `verifyReadiness` 同构，核实 `page` 是既有可选 wire 字段，改掉一处引用 GUI 专有常量的注释，rebase 后重跑定向套件、隔离文件、gates 与 G1，并把 worker 发现的 Ubuntu 存量红单独立 task。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 树外调用方若发空 `repo.tasks.list` payload 并期待全部行，现在拿到 500 行加游标。就绪探针在 attach 时不再走列表读路径；它检查的仍是投影就绪，列表路径由读测试覆盖。生产 default daemon 上 28.4 MB 台账的 p50 未实测（共享面）；hermetic 表为证据。

## 参考

- 任务：task_d5ebd5f8fafd14383e5c48ce01

