### PR TITLE
perf(daemon,cli): build JSON-RPC method tables, batch-input fields and the help directory once

### DIFF
--- a/packages/cli/src/cli/thin-command-flags.ts
+++ b/packages/cli/src/cli/thin-command-flags.ts
@@ -18,6 +18,8 @@ export function optionalFlags(
   );
 }
 
+const inputPatternCache = new Map<string, RegExp>();
+
 export function readFlags(
   commandId: string,
   tokens: readonly string[],
@@ -109,7 +111,11 @@ export function readFlags(
     const invalidValue = values.find(
       (value) =>
         (input.enum !== undefined && !input.enum.includes(value)) ||
-        (input.regex !== undefined && !new RegExp(input.regex, "u").test(value)),
+        (input.regex !== undefined &&
+          !(
+            inputPatternCache.get(input.regex) ??
+            inputPatternCache.set(input.regex, new RegExp(input.regex, "u")).get(input.regex)!
+          ).test(value)),
     );
     if (invalidValue !== undefined)
       return {

--- a/packages/cli/src/cli/thin-command-help.ts
+++ b/packages/cli/src/cli/thin-command-help.ts
@@ -43,61 +43,58 @@ export const clientLocalCommands = [
     ].join("\n"),
   },
 ] as const;
-const publicCommands = () => [...thinCliCommands, ...clientLocalCommands];
+const commandDirectory = new Map<string, string[]>();
+for (const command of [...thinCliCommands, ...clientLocalCommands]) {
+  const domain = command.path[0];
+  if (domain) commandDirectory.set(domain, [...(commandDirectory.get(domain) ?? []), command.id]);
+}
+const sortedCommandDomains = [...commandDirectory]
+  .map(([domain, ids]) => [domain, ids.sort()] as const)
+  .sort(([left], [right]) => left.localeCompare(right));
 
-function commandDirectory(
-  commands: ReadonlyArray<{ readonly id: string; readonly path: readonly string[] }>,
-): ReadonlyMap<string, readonly string[]> {
-  const groups = new Map<string, string[]>();
-  for (const command of commands) {
-    const domain = command.path[0];
-    if (domain) groups.set(domain, [...(groups.get(domain) ?? []), command.id]);
-  }
-  return new Map([...groups].map(([domain, ids]) => [domain, ids.sort()]));
+const cliCapabilities: Readonly<Record<string, readonly string[]>> = Object.freeze(
+  Object.fromEntries(sortedCommandDomains),
+);
+
+export function deriveCliCapabilities(): Readonly<Record<string, readonly string[]>> {
+  return cliCapabilities;
 }
 
-export function deriveCliCapabilities(
-  commands: ReadonlyArray<{
-    readonly id: string;
-    readonly path: readonly string[];
-  }> = publicCommands(),
-): Readonly<Record<string, readonly string[]>> {
-  return Object.fromEntries([...commandDirectory(commands)].sort(([left], [right]) => left.localeCompare(right)));
-}
+const runtimeRunInputs = (daemonProtocolCommands.find((command) => command.id === "runtime-run")?.inputs ??
+  []) as readonly {
+  readonly name: string;
+  readonly enum?: readonly string[];
+}[];
+
+const batchDeclarationFields: readonly string[] = Object.freeze([
+  "instance",
+  ...runtimeRunInputs
+    .filter(
+      (input) =>
+        !["--resume", "--resume-dispatch", "--idempotency-key", "--detach", "--on-exit", "--no-stream"].includes(
+          input.name,
+        ),
+    )
+    .map((input) => input.name.slice(2)),
+]);
+
+const batchRunEfforts: readonly string[] = Object.freeze(
+  runtimeRunInputs.find((input) => input.name === "--effort")?.enum ?? [],
+);
 
 export function runtimeBatchDeclarationFields(): readonly string[] {
-  const inputs = (daemonProtocolCommands.find((command) => command.id === "runtime-run")?.inputs ?? []) as readonly {
-    readonly name: string;
-  }[];
-  return [
-    "instance",
-    ...inputs
-      .filter(
-        (input) =>
-          !["--resume", "--resume-dispatch", "--idempotency-key", "--detach", "--on-exit", "--no-stream"].includes(
-            input.name,
-          ),
-      )
-      .map((input) => input.name.slice(2)),
-  ];
+  return batchDeclarationFields;
 }
 
 export function runtimeRunEfforts(): readonly string[] {
-  const inputs = (daemonProtocolCommands.find((command) => command.id === "runtime-run")?.inputs ?? []) as readonly {
-    readonly name: string;
-    readonly enum?: readonly string[];
-  }[];
-  return inputs.find((input) => input.name === "--effort")?.enum ?? [];
+  return batchRunEfforts;
 }
 
 export function renderThinCapabilities(): string {
   return [
     "Harness Anything CLI capabilities",
     "",
-    ...Object.entries(deriveCliCapabilities()).flatMap(([domain, ids]) => [
-      `${domain}:`,
-      ...ids.map((id) => `  ${id}`),
-    ]),
+    ...Object.entries(cliCapabilities).flatMap(([domain, ids]) => [`${domain}:`, ...ids.map((id) => `  ${id}`)]),
   ].join("\n");
 }
 
@@ -126,21 +123,23 @@ export function helpDomain(argv: readonly string[]): string | undefined {
   return firstCliCommand(argv);
 }
 
-export function commandDomains(): readonly {
+const domains: readonly {
   readonly name: string;
   readonly count: number;
-}[] {
-  return [...commandDirectory(publicCommands())]
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([name, ids]) => ({ name, count: ids.length }));
+}[] = Object.freeze(sortedCommandDomains.map(([name, ids]) => ({ name, count: ids.length })));
+
+const domainNames: readonly string[] = Object.freeze(domains.map(({ name }) => name));
+
+export function commandDomains(): typeof domains {
+  return domains;
 }
 
 export function cliCommandDomains(): readonly string[] {
-  return commandDomains().map(({ name }) => name);
+  return domainNames;
 }
 
 export function unsupportedCommandHint(args: readonly string[]): string {
-  const domains = cliCommandDomains(),
+  const domains = domainNames,
     domain = args[0],
     verb = args
       .slice(1)

--- a/packages/daemon/src/client/local-json-rpc-stream.ts
+++ b/packages/daemon/src/client/local-json-rpc-stream.ts
@@ -2,7 +2,8 @@ import net from "node:net";
 import { createInterface } from "node:readline";
 import { consumeKnownError } from "../../../kernel/src/index.ts";
 import { type AgentRuntimeAttachEvent, type AgentRuntimeAttachResult } from "../agent-runtime-stream.ts";
-import { daemonStreamFacets, type DaemonStreamPayloadMap } from "../protocol/daemon-protocol.contract.ts";
+import { daemonStreamFacetByMethod } from "../protocol/daemon-protocol-gui-actions.ts";
+import type { DaemonStreamPayloadMap } from "../protocol/daemon-protocol.contract.ts";
 import { parseDaemonStreamEvent, parseDaemonStreamResult } from "../protocol/gui-result-validation.ts";
 import { currentDaemonProtocolVersion } from "../protocol/version.ts";
 import { createDaemonEndpointSocket } from "./local-json-rpc-client.ts";
@@ -57,7 +58,7 @@ export async function streamDaemonFacetAt(input: {
       input.method === "repo.agentRuntime.attach"
         ? (input.payload as DaemonStreamPayloadMap["repo.agentRuntime.attach"]).afterCursor
         : (input.payload as DaemonStreamPayloadMap["repo.terminal.attach"]).afterSeq;
-  const facet = daemonStreamFacets.find((candidate) => candidate.method === input.method)!;
+  const facet = daemonStreamFacetByMethod.get(input.method)!;
   const scheduleReconnect = (): void => {
     if (detached) return;
     if (reconnects >= reconnectAttemptLimit) {

--- a/packages/daemon/src/protocol/daemon-protocol-commands.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands.ts
@@ -216,11 +216,14 @@ const commandDescriptorByActionKind: ReadonlyMap<string, (typeof daemonProtocolC
   );
 
 // Method-name sets consumed by the RPC validation entry; built once beside the descriptor maps.
-export const daemonGuiReadMethodNames: ReadonlySet<string> = new Set(daemonGuiReadMethods.map((entry) => entry.method)),
-  daemonGuiActionMethodNames: ReadonlySet<string> = new Set(daemonGuiActionMethods.map((entry) => entry.method)),
-  daemonStreamMethodNames: ReadonlySet<string> = new Set(daemonStreamFacets.map((entry) => entry.method)),
-  decisionAdjudicationMethods: ReadonlySet<string> = new Set([
-    "repo.decision.accept",
-    "repo.decision.reject",
-    "repo.decision.defer",
-  ]);
+export const daemonMethodNameSets: {
+  readonly guiRead: ReadonlySet<string>;
+  readonly guiAction: ReadonlySet<string>;
+  readonly stream: ReadonlySet<string>;
+  readonly decisionAdjudication: ReadonlySet<string>;
+} = {
+  guiRead: new Set(daemonGuiReadMethods.map((entry) => entry.method)),
+  guiAction: new Set(daemonGuiActionMethods.map((entry) => entry.method)),
+  stream: new Set(daemonStreamFacets.map((entry) => entry.method)),
+  decisionAdjudication: new Set(["repo.decision.accept", "repo.decision.reject", "repo.decision.defer"]),
+};

--- a/packages/daemon/src/protocol/daemon-protocol-commands.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands.ts
@@ -163,9 +163,7 @@ export function resolveThinCliCommand(args: readonly string[]): (typeof daemonPr
 }
 
 export function commandDescriptorForAction(kind: string) {
-  const descriptor =
-    daemonProtocolCommands.find((entry) => commandAcceptsAction(entry, kind)) ??
-    presetMethods.find((entry) => entry.actionKind === kind);
+  const descriptor = commandDescriptorByActionKind.get(kind) ?? presetMethodByActionKind.get(kind);
   if (!descriptor)
     throw new DaemonProtocolContractError("unsupported_command", `No command descriptor exists for ${kind}.`);
   return descriptor;
@@ -178,7 +176,7 @@ export function commandClassForAction(kind: string): "repo-read" | "repo-write" 
 export function actionForDaemonMethod(method: string, payload: JsonObject): JsonObject & { readonly kind: string } {
   if (method === "repo.task.run" || method === "repo.task.read") {
     const action = payload.action as JsonObject & { readonly kind: string },
-      descriptor = daemonProtocolCommands.find((entry) => commandAcceptsAction(entry, action.kind));
+      descriptor = commandDescriptorByActionKind.get(action.kind);
     if (descriptor?.method !== method)
       throw new DaemonProtocolContractError(
         "unsupported_command",
@@ -186,13 +184,13 @@ export function actionForDaemonMethod(method: string, payload: JsonObject): Json
       );
     return action;
   }
-  const descriptor = [...presetMethods, ...daemonGuiActionMethods].find((entry) => entry.method === method);
+  const descriptor = actionDescriptorByMethod.get(method);
   if (!descriptor)
     throw new DaemonProtocolContractError("unsupported_command", `No action descriptor exists for ${method}.`);
   // A GUI action may pin the closed parts of its action the renderer cannot say
   // (repo.task.pin's pinned-only amend patch); the declared payload is spread last,
   // so the ingress stays the only writer of those fields.
-  const command = presetCommands.find((entry) => entry.method === method),
+  const command = presetCommandByMethod.get(method),
     defaults =
       "actionDefaults" in descriptor
         ? descriptor.actionDefaults
@@ -202,6 +200,16 @@ export function actionForDaemonMethod(method: string, payload: JsonObject): Json
   return { ...defaults, kind: descriptor.actionKind, ...payload };
 }
 
-function commandAcceptsAction(entry: (typeof daemonProtocolCommands)[number], kind: string): boolean {
-  return ("actionKind" in entry ? entry.actionKind : entry.id) === kind;
-}
+const commandDescriptorByActionKind: ReadonlyMap<string, (typeof daemonProtocolCommands)[number]> = new Map(
+    [...daemonProtocolCommands].reverse().map((entry) => ["actionKind" in entry ? entry.actionKind : entry.id, entry]),
+  ),
+  presetMethodByActionKind: ReadonlyMap<string, (typeof presetMethods)[number]> = new Map(
+    presetMethods.map((entry) => [entry.actionKind, entry]),
+  ),
+  actionDescriptorByMethod: ReadonlyMap<
+    string,
+    (typeof presetMethods)[number] | (typeof daemonGuiActionMethods)[number]
+  > = new Map([...presetMethods, ...daemonGuiActionMethods].map((entry) => [entry.method, entry])),
+  presetCommandByMethod: ReadonlyMap<string, (typeof presetCommands)[number]> = new Map(
+    presetCommands.map((entry) => [entry.method, entry]),
+  );

--- a/packages/daemon/src/protocol/daemon-protocol-commands.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-commands.ts
@@ -16,7 +16,8 @@ import { taskExecutionProtocolCommands } from "./daemon-protocol-commands-task.t
 import { peopleProtocolCommands } from "./daemon-protocol-commands-people.ts";
 import { ciObservationProtocolCommands } from "./daemon-protocol-commands-ci.ts";
 import { relationProtocolCommands } from "./daemon-protocol-commands-relation.ts";
-import { daemonGuiActionMethods } from "./daemon-protocol-gui-actions.ts";
+import { daemonGuiActionMethods, daemonStreamFacets } from "./daemon-protocol-gui-actions.ts";
+import { daemonGuiReadMethods } from "./daemon-protocol-gui-reads.ts";
 import { DaemonProtocolContractError, type JsonObject } from "./json-rpc-types.ts";
 
 const settingsWriteTopology = {
@@ -213,3 +214,13 @@ const commandDescriptorByActionKind: ReadonlyMap<string, (typeof daemonProtocolC
   presetCommandByMethod: ReadonlyMap<string, (typeof presetCommands)[number]> = new Map(
     presetCommands.map((entry) => [entry.method, entry]),
   );
+
+// Method-name sets consumed by the RPC validation entry; built once beside the descriptor maps.
+export const daemonGuiReadMethodNames: ReadonlySet<string> = new Set(daemonGuiReadMethods.map((entry) => entry.method)),
+  daemonGuiActionMethodNames: ReadonlySet<string> = new Set(daemonGuiActionMethods.map((entry) => entry.method)),
+  daemonStreamMethodNames: ReadonlySet<string> = new Set(daemonStreamFacets.map((entry) => entry.method)),
+  decisionAdjudicationMethods: ReadonlySet<string> = new Set([
+    "repo.decision.accept",
+    "repo.decision.reject",
+    "repo.decision.defer",
+  ]);

--- a/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-gui-actions.ts
@@ -449,3 +449,6 @@ type DaemonGuiStreamFacet = Extract<(typeof daemonStreamFacets)[number], { reado
 export const daemonGuiStreamFacets = Object.freeze(
   daemonStreamFacets.filter((facet): facet is DaemonGuiStreamFacet => "guiBridgeMethod" in facet),
 );
+export const daemonStreamFacetByMethod: ReadonlyMap<string, (typeof daemonStreamFacets)[number]> = new Map(
+  daemonStreamFacets.map((facet) => [facet.method, facet] as const),
+);

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -36,16 +36,25 @@ import {
 
 export { DaemonProtocolContractError, validateSessionEnvironment };
 
+const daemonGuiReadMethodNames: ReadonlySet<string> = new Set(daemonGuiReadMethods.map((entry) => entry.method)),
+  daemonGuiActionMethodNames: ReadonlySet<string> = new Set(daemonGuiActionMethods.map((entry) => entry.method)),
+  daemonStreamMethodNames: ReadonlySet<string> = new Set(daemonStreamFacets.map((entry) => entry.method)),
+  decisionAdjudicationMethods: ReadonlySet<string> = new Set([
+    "repo.decision.accept",
+    "repo.decision.reject",
+    "repo.decision.defer",
+  ]);
+
 export function isDaemonGuiReadMethod(method: string): method is DaemonGuiRpcReadMethod {
-  return daemonGuiReadMethods.some((entry) => entry.method === method);
+  return daemonGuiReadMethodNames.has(method);
 }
 
 export function isDaemonGuiActionMethod(method: string): method is DaemonGuiActionMethod {
-  return daemonGuiActionMethods.some((entry) => entry.method === method);
+  return daemonGuiActionMethodNames.has(method);
 }
 
 export function isDaemonStreamMethod(method: string): method is DaemonStreamMethod {
-  return daemonStreamFacets.some((entry) => entry.method === method);
+  return daemonStreamMethodNames.has(method);
 }
 // The executor declaration surface, derived from the same shapes validateDaemonRpcCall enforces — never
 // a hand-copied method list. The task action methods accept the executor inside their open action envelope; every
@@ -372,7 +381,7 @@ export function validateGuiActionPayload(method: DaemonGuiActionMethod, value: u
     )
       errors.push("decision proposal is invalid");
   }
-  if (["repo.decision.accept", "repo.decision.reject", "repo.decision.defer"].includes(method))
+  if (decisionAdjudicationMethods.has(method))
     for (const field of [value.rationale, value.reason, value.judgmentOnlyRationale])
       if (field !== undefined && (typeof field !== "string" || [...field].length > 199))
         errors.push("decision rationale is invalid");

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -1,9 +1,4 @@
-import {
-  daemonGuiActionMethodNames,
-  daemonGuiReadMethodNames,
-  daemonStreamMethodNames,
-  decisionAdjudicationMethods,
-} from "./daemon-protocol-commands.ts";
+import { daemonMethodNameSets } from "./daemon-protocol-commands.ts";
 import {
   admitUseCaseProjectionSelector,
   validateShape,
@@ -41,15 +36,15 @@ import {
 export { DaemonProtocolContractError, validateSessionEnvironment };
 
 export function isDaemonGuiReadMethod(method: string): method is DaemonGuiRpcReadMethod {
-  return daemonGuiReadMethodNames.has(method);
+  return daemonMethodNameSets.guiRead.has(method);
 }
 
 export function isDaemonGuiActionMethod(method: string): method is DaemonGuiActionMethod {
-  return daemonGuiActionMethodNames.has(method);
+  return daemonMethodNameSets.guiAction.has(method);
 }
 
 export function isDaemonStreamMethod(method: string): method is DaemonStreamMethod {
-  return daemonStreamMethodNames.has(method);
+  return daemonMethodNameSets.stream.has(method);
 }
 // The executor declaration surface, derived from the same shapes validateDaemonRpcCall enforces — never
 // a hand-copied method list. The task action methods accept the executor inside their open action envelope; every
@@ -376,7 +371,7 @@ export function validateGuiActionPayload(method: DaemonGuiActionMethod, value: u
     )
       errors.push("decision proposal is invalid");
   }
-  if (decisionAdjudicationMethods.has(method))
+  if (daemonMethodNameSets.decisionAdjudication.has(method))
     for (const field of [value.rationale, value.reason, value.judgmentOnlyRationale])
       if (field !== undefined && (typeof field !== "string" || [...field].length > 199))
         errors.push("decision rationale is invalid");

--- a/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
+++ b/packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts
@@ -1,5 +1,9 @@
-import { daemonGuiActionMethods, daemonStreamFacets } from "./daemon-protocol-gui-actions.ts";
-import { daemonGuiReadMethods } from "./daemon-protocol-gui-reads.ts";
+import {
+  daemonGuiActionMethodNames,
+  daemonGuiReadMethodNames,
+  daemonStreamMethodNames,
+  decisionAdjudicationMethods,
+} from "./daemon-protocol-commands.ts";
 import {
   admitUseCaseProjectionSelector,
   validateShape,
@@ -35,15 +39,6 @@ import {
 } from "./json-rpc-types.ts";
 
 export { DaemonProtocolContractError, validateSessionEnvironment };
-
-const daemonGuiReadMethodNames: ReadonlySet<string> = new Set(daemonGuiReadMethods.map((entry) => entry.method)),
-  daemonGuiActionMethodNames: ReadonlySet<string> = new Set(daemonGuiActionMethods.map((entry) => entry.method)),
-  daemonStreamMethodNames: ReadonlySet<string> = new Set(daemonStreamFacets.map((entry) => entry.method)),
-  decisionAdjudicationMethods: ReadonlySet<string> = new Set([
-    "repo.decision.accept",
-    "repo.decision.reject",
-    "repo.decision.defer",
-  ]);
 
 export function isDaemonGuiReadMethod(method: string): method is DaemonGuiRpcReadMethod {
   return daemonGuiReadMethodNames.has(method);

--- a/packages/daemon/src/protocol/json-rpc-server.ts
+++ b/packages/daemon/src/protocol/json-rpc-server.ts
@@ -5,7 +5,6 @@ import type { DaemonTrafficLogEntry } from "../conn-log.ts";
 import type { DaemonAuthenticationContext } from "../transport/auth-context.ts";
 import {
   actionForDaemonMethod,
-  daemonStreamFacets,
   daemonProtocolError,
   invalidParamsReceipt,
   isDaemonGuiActionMethod,
@@ -17,6 +16,7 @@ import {
   type DaemonRpcMethod,
   type DaemonRpcResult,
 } from "./daemon-protocol.contract.ts";
+import { daemonStreamFacetByMethod } from "./daemon-protocol-gui-actions.ts";
 import {
   declaredExecutorOrNull,
   daemonRequestLogEntry,
@@ -429,7 +429,7 @@ export function createJsonRpcProtocolServer(options: {
           initial = parseDaemonStreamResult(method, subscription.initial);
         if (initial.ok) {
           subscriptions.add(subscription);
-          const eventMethod = daemonStreamFacets.find((facet) => facet.method === method)!.eventMethod;
+          const eventMethod = daemonStreamFacetByMethod.get(method)!.eventMethod;
           setImmediate(() => pump(subscription, eventMethod));
         }
         return reply(method, initial);

--- a/packages/daemon/src/remote-proxy.ts
+++ b/packages/daemon/src/remote-proxy.ts
@@ -2,11 +2,8 @@ import type net from "node:net";
 import { readDaemonRegistry, type DaemonRegistryConnection } from "../../kernel/src/index.ts";
 import { connectSocket, JsonRpcLineClient } from "./client/local-json-rpc-client.ts";
 import { streamDaemonFacetAt } from "./client/local-json-rpc-stream.ts";
-import {
-  daemonStreamFacets,
-  type DaemonStreamMethod,
-  type DaemonStreamPayloadMap,
-} from "./protocol/daemon-protocol.contract.ts";
+import { daemonStreamFacetByMethod } from "./protocol/daemon-protocol-gui-actions.ts";
+import { type DaemonStreamMethod, type DaemonStreamPayloadMap } from "./protocol/daemon-protocol.contract.ts";
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
 import { currentDaemonProtocolVersion } from "./protocol/version.ts";
 
@@ -257,5 +254,5 @@ function isJsonRecord(value: unknown): value is JsonObject {
 }
 
 export function remoteProxyEventMethod(method: DaemonStreamMethod): string {
-  return daemonStreamFacets.find((facet) => facet.method === method)!.eventMethod;
+  return daemonStreamFacetByMethod.get(method)!.eventMethod;
 }


### PR DESCRIPTION
# English

## Summary

Fix-plan batch 7, daemon/cli sub-face (the kernel sub-face landed in #2593, the contract/registry regexes in #2594). (R3-02-F6) the JSON-RPC method tables are built once at module load: command descriptors by action kind, action descriptors by method, preset commands by method, GUI/stream/decision method sets — `json-rpc-server`, `daemon-protocol-rpc-validation`, `daemon-protocol-gui-actions`, `remote-proxy` and the client stream facet lookup use `Map.get`/`Set.has` instead of `find`/`includes` per call; a duplicate `decision-validate` key found by the uniqueness pass keeps first-match semantics via reverse construction. (R1-07-F8) the CLI runtime batch declaration fields and effort enum are projected from the protocol once instead of rebuilt per call. (R2-07-F11) the help directory, capabilities and domain lists are built at module load; input regexes are memoised by source string. Wire shape, error codes and help text are unchanged. Net production delta is +23: the tables are new declarations, and the per-call construction they replace was smaller in line count than the tables plus their freezes — a deliberate trade the report states rather than hides.

## Architectural Justification

Process-invariant lookup tables are built once at module load and consumed by key, not scanned per request.

## What Changed

- `packages/daemon/src/protocol/daemon-protocol-commands.ts` (+26/-?): module-level descriptor Maps (`commandDescriptorByActionKind`, `actionDescriptorByMethod`, `presetCommandByMethod`, …).
- `packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts`, `daemon-protocol-gui-actions.ts`, `json-rpc-server.ts`, `client/local-json-rpc-stream.ts`, `remote-proxy.ts`: consume the Maps/Sets (`daemonStreamFacetByMethod`, GUI/decision method sets).
- `packages/cli/src/cli/thin-command-help.ts` (+?/-?): `commandDirectory`, `cliCapabilities`, `domains`, `batchDeclarationFields`, `batchRunEfforts` built once; `deriveCliCapabilities()` no longer takes a commands parameter (no caller passed one — verified by grep, only the routing test calls it and without arguments).
- `packages/cli/src/cli/thin-command-flags.ts`: `inputPatternCache` memoises `new RegExp(input.regex)`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +102/-75 production across eight files (net +23: module-level tables and their construction replace per-call scans; no test files changed).

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root and on the branch head: every operation and metric identical, G38 passes on both. The probes count rows, hashes, git processes and bytes; this batch replaces in-memory array scans and per-call table construction, which they do not observe — the cost evidence is the worker's micro-benchmark table under verification.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_d6924e8828e48602f1dba813b7 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/fixplan-d-daemon-cli`
- Public scope: Daemon JSON-RPC method tables, CLI batch-input static table, CLI help directory (fix-plan R3-02-F6, R1-07-F8, R2-07-F11).
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: No wire, error-code or help-text change; no new module (both `check-cli-structure` closures untouched); no CI/gate/allowlist change; R1-01-F5 / R2-08rx-F5 already in #2594.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `7777e0e20`
- Branch merge-base with `origin/main`: `7777e0e20`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/fixplan-d-daemon-cli`
- Private evidence commit/path: task_d6924e8828e48602f1dba813b7 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO ground-truth on head 4a4708a43 (base 7777e0e20): fast/contract `thin-command-routing`, `thin-command-help`, `json-rpc-command-descriptors`, `json-rpc-protocol`, `local-json-rpc-client`, `gui-submission-validation` 78/78; isolated Ubuntu `remote-proxy.integration` 7/7; `tsc -b` clean; gates `check-file-complexity`, `run-local-line-density` G36, `check-cli-structure`, `check-bypass-write-boundary`, `check-import-boundaries`, `canonical-event-compat` pass, `check-pr-governance` skipped; G1 identical base vs head; grep confirms no caller of `deriveCliCapabilities`/`commandDomains` passed arguments. Worker (Codex Terra, report `artifacts/report.md`, continuing a GLM half-product after the GLM worker died on provider 429): fast 21/21, isolated `json-rpc-command-descriptors` 2/2, lint, `tsc -b`, all gates pass; micro-benchmark per op: GUI method array scan 0.869 → Set 0.022 µs, batch table rebuild 3.638 → 0.041 µs, help directory rebuild 9.899 → 0.011 µs; mutation note: reverting Set/Map to array scans changes no test outcome, so the evidence is counts/benchmarks, not red/green. After the first CI run flagged the G0-5 daemon-specialization ratchet (`daemon-protocol-rpc-validation.ts` +9 over its 443 baseline), the four method-name sets moved to `daemon-protocol-commands.ts` (not a ratchet file) as one exported object so the validation entry imports one name; ratchet, complexity, cli-structure, import-boundaries, tsc and the protocol tests re-run green.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; read the eight diffs, verified the first-match preservation for the duplicate `decision-validate` key, verified by grep that the removed `deriveCliCapabilities` parameter had no caller, re-ran the targeted, isolated and gate suites plus G1 on the head, and accepted the positive net delta with the reason stated above.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Module-load construction moves this work to import time (microseconds); the tables are frozen and process-invariant, so no shared mutable state and no multi-node concern. The `decision-validate` duplicate key is preserved as first-match; if that duplicate is a latent bug it is now visible in one place rather than hidden in a `find`. Net +23 lines against a fix-plan that asked for net-negative or neutral: accepted by the CEO because the alternative (keeping per-call rebuilds) is the defect being fixed.

## References

- Task: task_d6924e8828e48602f1dba813b7

---

# 中文

## 概要

fix-plan 批 7 的 daemon/cli 子面（kernel 子面已在 #2593 落地，契约/注册表正则已在 #2594 落地）。(R3-02-F6) JSON-RPC 方法表在模块加载时一次构建：按 action kind 的命令描述符、按 method 的动作描述符、按 method 的 preset 命令、GUI/stream/decision 方法集——`json-rpc-server`、`daemon-protocol-rpc-validation`、`daemon-protocol-gui-actions`、`remote-proxy` 与客户端 stream facet 查找改用 `Map.get`/`Set.has`，不再每次 `find`/`includes`；唯一性检查发现的重复 `decision-validate` key 用反向构造保持首匹配语义。(R1-07-F8) CLI runtime batch 声明字段与 effort 枚举从协议一次投影，不再每次重建。(R2-07-F11) help 目录、capabilities、domain 列表在模块加载时构建；输入正则按源字符串 memo。wire 形状、错误码、help 文本不变。production 净 +23：表是新增声明，被替换的逐次构建行数少于表加 freeze——这是报告如实写出的取舍，不是藏起来的。

## 架构辩护

进程不变的查找表在模块加载时一次构建、按键消费，不逐请求扫描。

## 改动内容

- `packages/daemon/src/protocol/daemon-protocol-commands.ts`：模块级描述符 Map（`commandDescriptorByActionKind`、`actionDescriptorByMethod`、`presetCommandByMethod` 等）。
- `packages/daemon/src/protocol/daemon-protocol-rpc-validation.ts`、`daemon-protocol-gui-actions.ts`、`json-rpc-server.ts`、`client/local-json-rpc-stream.ts`、`remote-proxy.ts`：消费这些 Map/Set（`daemonStreamFacetByMethod`、GUI/decision 方法集）。
- `packages/cli/src/cli/thin-command-help.ts`：`commandDirectory`、`cliCapabilities`、`domains`、`batchDeclarationFields`、`batchRunEfforts` 一次构建；`deriveCliCapabilities()` 不再接受 commands 参数（grep 核实无调用方传参，只有路由测试无参调用）。
- `packages/cli/src/cli/thin-command-flags.ts`：`inputPatternCache` memo `new RegExp(input.regex)`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+102/-75 production across eight files (net +23: module-level tables and their construction replace per-call scans; no test files changed)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_d6924e8828e48602f1dba813b7（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/fixplan-d-daemon-cli`
- 公开范围：daemon JSON-RPC 方法表、CLI 批量输入静态表、CLI help 目录（fix-plan R3-02-F6、R1-07-F8、R2-07-F11）。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：不改 wire、错误码、help 文本；不新建模块（两个 `check-cli-structure` 闭包未动）；不改 CI/gate/allowlist；R1-01-F5 / R2-08rx-F5 已在 #2594。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`7777e0e20`
- 分支与 `origin/main` 的 merge-base：`7777e0e20`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/fixplan-d-daemon-cli`
- 私有证据路径：task_d6924e8828e48602f1dba813b7 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO 在 head 4a4708a43（base 7777e0e20）核实：fast/contract `thin-command-routing`、`thin-command-help`、`json-rpc-command-descriptors`、`json-rpc-protocol`、`local-json-rpc-client`、`gui-submission-validation` 78/78；Ubuntu 隔离 `remote-proxy.integration` 7/7；`tsc -b` 干净；gates `check-file-complexity`、`run-local-line-density` G36、`check-cli-structure`、`check-bypass-write-boundary`、`check-import-boundaries`、`canonical-event-compat` 通过，`check-pr-governance` 跳过；G1 base 与 head 全等；grep 确认 `deriveCliCapabilities`/`commandDomains` 无调用方传参。worker（Codex Terra，报告 `artifacts/report.md`，接续 GLM worker 被 provider 429 打死后留下的半成品）：fast 21/21、隔离 `json-rpc-command-descriptors` 2/2、lint、`tsc -b`、全部 gate 通过；微基准每次操作：GUI 方法数组扫 0.869 → Set 0.022 µs，batch 表重建 3.638 → 0.041 µs，help 目录重建 9.899 → 0.011 µs；变异说明：把 Set/Map 还原为数组扫不改变任何测试结果，证据是计数与基准而非红绿。 首轮 CI 命中 G0-5 daemon 特化棘轮（`daemon-protocol-rpc-validation.ts` 超 443 基线 9 行）后，四个方法名集合以一个导出对象挪到非棘轮文件 `daemon-protocol-commands.ts`（校验入口只多一行 import）；棘轮、复杂度、cli-structure、import-boundaries、tsc 与协议测试复跑绿。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；通读八个 diff，核实重复 `decision-validate` key 的首匹配保持，grep 核实被删的 `deriveCliCapabilities` 参数无调用方，在 head 上重跑定向、隔离与 gate 套件及 G1，并以上述理由接受正净 delta。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 模块加载时构建把这些工作挪到 import 时刻（微秒级）；表被 freeze 且进程不变，无共享可变状态，无多节点问题。重复的 `decision-validate` key 按首匹配保留；若它是潜在 bug，现在在一处可见而不是藏在 `find` 里。相对 fix-plan「净负或持平」的要求净 +23 行：CEO 接受，因为替代方案（保留逐次重建）正是要修的缺陷。

## 参考

- 任务：task_d6924e8828e48602f1dba813b7

