### PR TITLE
perf(daemon): cursor-based durable output, one stream descriptor per worker host, header point reads and batched overview

### DIFF
--- a/packages/daemon/src/agent-runtime-read.ts
+++ b/packages/daemon/src/agent-runtime-read.ts
@@ -46,10 +46,14 @@ export function makeAgentRuntimeReadModel(input: {
   readonly runtimeInstances?: () => readonly RuntimeInstanceSummary[];
   readonly now?: () => string;
 }) {
-  const activityEvidenceFor = (session: RuntimeSession): RuntimeSessionActivityEvidence | undefined => {
+  const activityEvidenceFor = (
+    session: RuntimeSession,
+    dispatch?: Extract<AgentRuntimeEventV1, { readonly type: "runtime_dispatch_requested" }>,
+  ): RuntimeSessionActivityEvidence | undefined => {
     if (!input.readActivityEvidence) return undefined;
-    const dispatch = input.projection.readRuntimeDispatch(session.runtimeSessionId, session.definitionSnapshotRef);
-    return dispatch ? input.readActivityEvidence(dispatch.payload.dispatchId) : undefined;
+    const event =
+      dispatch ?? input.projection.readRuntimeDispatch(session.runtimeSessionId, session.definitionSnapshotRef);
+    return event ? input.readActivityEvidence(event.payload.dispatchId) : undefined;
   };
   const installationDto = (installation: RuntimeInstallation): AgentRuntimeInstallationDto => ({
     installationId: installation.installationId,
@@ -116,6 +120,7 @@ export function makeAgentRuntimeReadModel(input: {
   };
   const definitionFor = (
     session: RuntimeSession,
+    dispatch?: Extract<AgentRuntimeEventV1, { readonly type: "runtime_dispatch_requested" }>,
   ): { readonly snapshot: AgentDefinitionSnapshot | null; readonly persisted: boolean } => {
     const match = /^artifact:runtime-definition\/sha256\/([0-9a-f]{64})$/u.exec(session.definitionSnapshotRef);
     if (match) {
@@ -142,8 +147,9 @@ export function makeAgentRuntimeReadModel(input: {
         return { snapshot, persisted: true };
       }
     }
-    const dispatch = input.projection.readRuntimeDispatch(session.runtimeSessionId, session.definitionSnapshotRef);
-    return { snapshot: dispatch?.payload.definitionSnapshot ?? null, persisted: false };
+    const event =
+      dispatch ?? input.projection.readRuntimeDispatch(session.runtimeSessionId, session.definitionSnapshotRef);
+    return { snapshot: event?.payload.definitionSnapshot ?? null, persisted: false };
   };
   return {
     overview: (payload: Readonly<Record<string, unknown>>): AgentRuntimeOverviewResult => {
@@ -164,6 +170,19 @@ export function makeAgentRuntimeReadModel(input: {
           : input.projection.readRuntimeSessions());
       const installationIds = new Set(sessions.map(({ installationId }) => installationId));
       const installations = input.projection.readRuntimeInstallations();
+      const installationsById = new Map(
+        installations.map((installation) => [installation.installationId, installation]),
+      );
+      const dispatchBySessionKey = new Map<
+        string,
+        Extract<AgentRuntimeEventV1, { readonly type: "runtime_dispatch_requested" }>
+      >();
+      for (const event of input.projection.readRuntimeDispatches()) {
+        const key = `${event.payload.runtimeSessionId}\0${event.payload.definitionSnapshotRef}`;
+        if (!dispatchBySessionKey.has(key)) dispatchBySessionKey.set(key, event);
+      }
+      const dispatchEventFor = (session: RuntimeSession) =>
+        dispatchBySessionKey.get(`${session.runtimeSessionId}\0${session.definitionSnapshotRef}`);
       return {
         ok: true,
         status: cut.status,
@@ -174,9 +193,9 @@ export function makeAgentRuntimeReadModel(input: {
         sessions: sessions.map((session) =>
           sessionDto(
             session,
-            installations.find(({ installationId }) => installationId === session.installationId),
-            definitionFor(session),
-            activityEvidenceFor(session),
+            installationsById.get(session.installationId),
+            definitionFor(session, dispatchEventFor(session)),
+            activityEvidenceFor(session, dispatchEventFor(session)),
           ),
         ),
         ...(paged === null
@@ -197,18 +216,31 @@ export function makeAgentRuntimeReadModel(input: {
     sessionGroups: (payload: Readonly<Record<string, unknown>>): AgentRuntimeSessionGroupsResult => {
       const query = sessionGroupsQuery(payload, input.now?.() ?? new Date().toISOString()),
         cut = input.projection.readCut(),
-        sessions = input.projection
+        dispatchEvents = input.projection.readRuntimeDispatches(),
+        // The dispatch event per (session, definition snapshot) that the activity-evidence lookup
+        // needs; first by revision matches the readRuntimeDispatch point query it replaces.
+        dispatchBySessionKey = new Map<
+          string,
+          Extract<AgentRuntimeEventV1, { readonly type: "runtime_dispatch_requested" }>
+        >();
+      for (const event of dispatchEvents) {
+        const key = `${event.payload.runtimeSessionId}\0${event.payload.definitionSnapshotRef}`;
+        if (!dispatchBySessionKey.has(key)) dispatchBySessionKey.set(key, event);
+      }
+      const dispatchEventFor = (session: RuntimeSession) =>
+        dispatchBySessionKey.get(`${session.runtimeSessionId}\0${session.definitionSnapshotRef}`);
+      const sessions = input.projection
           .readRuntimeSessions()
-          .map((session) => sessionWithActivityEvidence(session, activityEvidenceFor(session)))
+          .map((session) =>
+            sessionWithActivityEvidence(session, activityEvidenceFor(session, dispatchEventFor(session))),
+          )
           .filter((session) => runtimeSessionInActivityWindow(session, query.since)),
         sessionIds = new Set(sessions.map(({ runtimeSessionId }) => runtimeSessionId)),
-        dispatchEvents = input.projection
-          .readRuntimeDispatches()
-          .filter((event) => sessionIds.has(event.payload.runtimeSessionId)),
+        windowedDispatchEvents = dispatchEvents.filter((event) => sessionIds.has(event.payload.runtimeSessionId)),
         dispatchStartedAt = new Map(
-          dispatchEvents.map((event) => [event.payload.runtimeSessionId, event.occurredAt] as const),
+          windowedDispatchEvents.map((event) => [event.payload.runtimeSessionId, event.occurredAt] as const),
         ),
-        dispatches = input.readDispatches?.({ sessions, events: dispatchEvents }) ?? [],
+        dispatches = input.readDispatches?.({ sessions, events: windowedDispatchEvents }) ?? [],
         taskIds = [
           ...new Set([
             ...sessions.flatMap((session) => session.taskBindings.map(({ taskId }) => taskId)),

--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -169,6 +169,19 @@ export function readTaskDispatches(
       };
 }
 
+/** Single-dispatch point read: resolves (taskId, dispatchId) to its session straight from the
+ * stream header instead of building the whole task dispatch list. Unattributed dispatches
+ * (header.taskId null) never resolve — the task list only ever returned attributed rows. */
+export function readTaskDispatchSession(
+  rootDir: string,
+  taskId: string,
+  dispatchId: string,
+): { readonly runtimeSessionId: string } | null {
+  if (!/^dispatch_[a-f0-9]{24}$/u.test(dispatchId)) return null;
+  const stream = readDispatchStreamSummary(rootDir, dispatchId);
+  return stream?.header.taskId === taskId ? { runtimeSessionId: stream.header.runtimeSessionId } : null;
+}
+
 export function readTaskLineageDispatches(input: {
   readonly rootDir: string;
   readonly projection: TaskProjection;

--- a/packages/daemon/src/dispatch-stream-io.ts
+++ b/packages/daemon/src/dispatch-stream-io.ts
@@ -1,0 +1,85 @@
+import { closeSync, constants as fsConstants, fstatSync, openSync, readSync, statSync, writeFileSync } from "node:fs";
+import { consumeKnownError } from "../../kernel/src/index.ts";
+
+export const dispatchStreamSchema = "runtime-dispatch-stream/v1" as const;
+export const dispatchStreamReadLimitBytes = 200 * 1024 * 1024;
+const dispatchStreamWriteLimitBytes = 500 * 1024 * 1024;
+
+export function readDispatchStreamIncrement(
+  target: string,
+  offset: number,
+): { readonly bytes: Buffer; readonly size: number } | null {
+  const stat = statSync(target, { throwIfNoEntry: false });
+  if (!stat?.isFile() || stat.size > dispatchStreamReadLimitBytes) return null;
+  const descriptor = openSync(target, fsConstants.O_RDONLY);
+  try {
+    const size = fstatSync(descriptor).size;
+    if (size > dispatchStreamReadLimitBytes || size <= offset) return { bytes: Buffer.alloc(0), size };
+    const bytes = Buffer.alloc(size - offset);
+    const read = readSync(descriptor, bytes, 0, bytes.length, offset);
+    return { bytes: bytes.subarray(0, read), size };
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+export function readRuntimeWorkerChunk(target: string, offset: number, limit = 1024 * 1024): Buffer {
+  const descriptor = openSync(target, fsConstants.O_RDONLY);
+  try {
+    const size = fstatSync(descriptor).size;
+    if (size <= offset) return Buffer.alloc(0);
+    const bytes = Buffer.alloc(Math.min(size - offset, limit));
+    const read = readSync(descriptor, bytes, 0, bytes.length, offset);
+    return bytes.subarray(0, read);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+export interface DispatchStreamAppender {
+  readonly append: (value: Readonly<Record<string, unknown>>) => void;
+  readonly close: () => void;
+}
+
+export function openDispatchStreamAppender(
+  target: string,
+  input: {
+    readonly invalidateSummary: () => void;
+    readonly scrub: (value: unknown) => unknown;
+    readonly unbounded: (value: Readonly<Record<string, unknown>>) => boolean;
+    readonly warnDroppedOutput: () => void;
+  },
+): DispatchStreamAppender {
+  let descriptor: number | null = null;
+  return {
+    append: (value) => {
+      input.invalidateSummary();
+      const owned = descriptor !== null,
+        handle = descriptor ?? openSync(target, fsConstants.O_APPEND | fsConstants.O_WRONLY);
+      try {
+        const size = fstatSync(handle).size;
+        if (size >= dispatchStreamWriteLimitBytes && input.unbounded(value)) {
+          input.warnDroppedOutput();
+          if (!owned) closeSync(handle);
+          return;
+        }
+        writeFileSync(handle, `${JSON.stringify(input.scrub({ schema: dispatchStreamSchema, ...value }))}\n`, "utf8");
+      } catch (error) {
+        descriptor = null;
+        try {
+          closeSync(handle);
+        } catch (closeError) {
+          consumeKnownError(closeError);
+        }
+        throw error;
+      }
+      descriptor = handle;
+    },
+    close: () => {
+      if (descriptor === null) return;
+      const handle = descriptor;
+      descriptor = null;
+      closeSync(handle);
+    },
+  };
+}

--- a/packages/daemon/src/dispatch-stream-io.ts
+++ b/packages/daemon/src/dispatch-stream-io.ts
@@ -1,5 +1,4 @@
 import { closeSync, constants as fsConstants, fstatSync, openSync, readSync, statSync, writeFileSync } from "node:fs";
-import { consumeKnownError } from "../../kernel/src/index.ts";
 
 export const dispatchStreamSchema = "runtime-dispatch-stream/v1" as const;
 export const dispatchStreamReadLimitBytes = 200 * 1024 * 1024;
@@ -65,12 +64,9 @@ export function openDispatchStreamAppender(
         }
         writeFileSync(handle, `${JSON.stringify(input.scrub({ schema: dispatchStreamSchema, ...value }))}\n`, "utf8");
       } catch (error) {
+        // Drop the held descriptor; a close failure surfaces like the finally-close did before the split.
         descriptor = null;
-        try {
-          closeSync(handle);
-        } catch (closeError) {
-          consumeKnownError(closeError);
-        }
+        closeSync(handle);
         throw error;
       }
       descriptor = handle;

--- a/packages/daemon/src/dispatch-stream.ts
+++ b/packages/daemon/src/dispatch-stream.ts
@@ -15,6 +15,13 @@ import {
 } from "node:fs";
 import path from "node:path";
 import {
+  dispatchStreamReadLimitBytes,
+  dispatchStreamSchema as streamSchema,
+  openDispatchStreamAppender as openStreamAppender,
+  type DispatchStreamAppender,
+} from "./dispatch-stream-io.ts";
+export { readDispatchStreamIncrement, readRuntimeWorkerChunk } from "./dispatch-stream-io.ts";
+import {
   consumeKnownError,
   resolveHarnessLayout,
   type ActorIdentity,
@@ -23,7 +30,6 @@ import {
 import type { RuntimePermissionMode } from "./runtime-permissions.ts";
 import type { RuntimeAttemptOutcome, RuntimeFallbackAttempt } from "./runtime-fallback-contract.ts";
 
-const streamSchema = "runtime-dispatch-stream/v1" as const;
 const liveIndexSchema = "runtime-dispatch-live-index/v1" as const;
 const forbiddenKey =
   /(?:token|credential|password|secret|authorization|executablepath|api[-_ ]?key|private[-_ ]?key|cookie)/iu;
@@ -156,8 +162,6 @@ const summaryCache = new Map<string, SummaryCacheEntry>();
 const headerCache = new Map<string, HeaderCacheEntry>();
 const summaryHeadBytes = 16 * 1024;
 const summaryTailBytes = 128 * 1024;
-const dispatchStreamReadLimitBytes = 200 * 1024 * 1024;
-const dispatchStreamWriteLimitBytes = 500 * 1024 * 1024;
 const readLimitWarnings = new Set<string>();
 const writeLimitWarnings = new Set<string>();
 const summaryKinds = new Set([
@@ -438,17 +442,18 @@ export function appendDispatchStreamRecord(target: string, value: Readonly<Recor
   appendJsonl(target, { schema: streamSchema, ...value });
 }
 
-export function readRuntimeWorkerChunk(target: string, offset: number, limit = 1024 * 1024): Buffer {
-  const descriptor = openSync(target, fsConstants.O_RDONLY);
-  try {
-    const size = fstatSync(descriptor).size;
-    if (size <= offset) return Buffer.alloc(0);
-    const bytes = Buffer.alloc(Math.min(size - offset, limit));
-    const read = readSync(descriptor, bytes, 0, bytes.length, offset);
-    return bytes.subarray(0, read);
-  } finally {
-    closeSync(descriptor);
-  }
+export function openDispatchStreamAppender(target: string): DispatchStreamAppender {
+  return openStreamAppender(target, {
+    invalidateSummary: () => summaryCache.delete(target),
+    scrub: scrubDispatchRecord,
+    unbounded: unboundedDispatchRecord,
+    warnDroppedOutput: () =>
+      warnOnce(
+        writeLimitWarnings,
+        target,
+        `${path.basename(target)} reached 524288000 bytes; dropping unbounded output`,
+      ),
+  });
 }
 
 export function dispatchStreamRef(rootDir: string, dispatchId: string): string {
@@ -534,21 +539,11 @@ function readStoredDispatchLiveIndex(target: string, taskId: string): DispatchLi
   }
 }
 function appendJsonl(target: string, value: unknown): void {
-  summaryCache.delete(target);
-  const descriptor = openSync(target, fsConstants.O_APPEND | fsConstants.O_WRONLY);
+  const appender = openDispatchStreamAppender(target);
   try {
-    const size = fstatSync(descriptor).size;
-    if (size >= dispatchStreamWriteLimitBytes && unboundedDispatchRecord(value)) {
-      warnOnce(
-        writeLimitWarnings,
-        target,
-        `${path.basename(target)} reached ${String(dispatchStreamWriteLimitBytes)} bytes; dropping unbounded output`,
-      );
-      return;
-    }
-    writeFileSync(descriptor, `${JSON.stringify(scrubDispatchRecord(value))}\n`, "utf8");
+    appender.append(value as Readonly<Record<string, unknown>>);
   } finally {
-    closeSync(descriptor);
+    appender.close();
   }
 }
 
@@ -758,7 +753,7 @@ function readLatestRecordOfKind(target: string, kind: string): Record<string, un
   }
   return null;
 }
-function parseRecord(value: string | undefined): Record<string, unknown> | null {
+export function parseRecord(value: string | undefined): Record<string, unknown> | null {
   if (!value) return null;
   try {
     const parsed: unknown = JSON.parse(value);

--- a/packages/daemon/src/repo-cell-proxy.ts
+++ b/packages/daemon/src/repo-cell-proxy.ts
@@ -14,7 +14,7 @@ import {
   readRuntimeAttemptChain,
   readRuntimeSessionActivityEvidence,
   readSessionGroupDispatches,
-  readTaskDispatches,
+  readTaskDispatchSession,
 } from "./dispatch-read.ts";
 import { openReplicaCutSource } from "./fleet/replica-cut-store.ts";
 import { readObserveEventTail, readObserveTail } from "./observe-tail.ts";
@@ -168,10 +168,7 @@ export async function openRepoCellProxy(
       runtimeReads = makeAgentRuntimeReadModel({
         readActivityEvidence: (dispatchId) => readRuntimeSessionActivityEvidence(input.rootDir, dispatchId),
         readAttemptChain: (runtimeSessionId) => readRuntimeAttemptChain(input.rootDir, runtimeSessionId),
-        readDispatch: (taskId, dispatchId) =>
-          readTaskDispatches({ rootDir: input.rootDir, projection: writableProjection, taskId }).dispatches.find(
-            (row) => row.dispatchId === dispatchId,
-          ) ?? null,
+        readDispatch: (taskId, dispatchId) => readTaskDispatchSession(input.rootDir, taskId, dispatchId),
         readDispatches: ({ sessions, events }) =>
           readSessionGroupDispatches({ rootDir: input.rootDir, sessions, events }),
         projection: writableProjection,

--- a/packages/daemon/src/repo-cell.ts
+++ b/packages/daemon/src/repo-cell.ts
@@ -16,7 +16,7 @@ import {
   readRuntimeAttemptChain,
   readRuntimeSessionActivityEvidence,
   readSessionGroupDispatches,
-  readTaskDispatches,
+  readTaskDispatchSession,
 } from "./dispatch-read.ts";
 import { makeEntityActionCatalogExecutor } from "./entity-action-catalog-executor.ts";
 import { openReplicaCutSource } from "./fleet/replica-cut-store.ts";
@@ -160,10 +160,7 @@ export async function initializeRepoCell(context: RepoCellCoreInput): Promise<Re
     const runtimeReads = makeAgentRuntimeReadModel({
         readActivityEvidence: (dispatchId) => readRuntimeSessionActivityEvidence(context.rootDir, dispatchId),
         readAttemptChain: (runtimeSessionId) => readRuntimeAttemptChain(context.rootDir, runtimeSessionId),
-        readDispatch: (taskId, dispatchId) =>
-          readTaskDispatches({ rootDir: context.rootDir, projection: projection!, taskId }).dispatches.find(
-            (row) => row.dispatchId === dispatchId,
-          ) ?? null,
+        readDispatch: (taskId, dispatchId) => readTaskDispatchSession(context.rootDir, taskId, dispatchId),
         readDispatches: ({ sessions, events }) =>
           readSessionGroupDispatches({ rootDir: context.rootDir, sessions, events }),
         projection,

--- a/packages/daemon/src/runtime-spawn-provider-stream.ts
+++ b/packages/daemon/src/runtime-spawn-provider-stream.ts
@@ -1,9 +1,10 @@
 import { setTimeout as delay } from "node:timers/promises";
 import { globSync, readFileSync } from "node:fs";
+import { StringDecoder } from "node:string_decoder";
 import path from "node:path";
 import type { SessionIdentity } from "../../kernel/src/index.ts";
 import { consumeKnownError } from "../../kernel/src/index.ts";
-import { readDispatchStream, scrubProviderValue } from "./dispatch-stream.ts";
+import { dispatchStreamPath, parseRecord, readDispatchStreamIncrement, scrubProviderValue } from "./dispatch-stream.ts";
 import type { ActiveRuntime, ProviderFrame, RuntimeBinding } from "./runtime-spawn-types.ts";
 import { transcriptRefForSessionIdentity } from "./session-identity/index.ts";
 import { observeProviderFault } from "./runtime-provider-fault.ts";
@@ -211,21 +212,38 @@ export async function consumeDurableOutput(
   active: ActiveRuntime,
   waitForFirstRecordMs = 0,
 ): Promise<void> {
-  let stream = readDispatchStream(context.input.rootDir, active.dispatchId);
-  let records = durableOutputRecords(stream?.records ?? []);
-  const deadline = Date.now() + waitForFirstRecordMs;
-  while (records.length === 0 && stream?.process?.exited === false && Date.now() < deadline) {
+  const target = dispatchStreamPath(context.input.rootDir, active.dispatchId),
+    deadline = Date.now() + waitForFirstRecordMs,
+    pending: string[] = [],
+    decoder = new StringDecoder("utf8");
+  let durableSeen = 0,
+    workerRunning = false,
+    offset = 0,
+    tail = "";
+  const scan = (): void => {
+    const next = readDispatchStreamIncrement(target, offset);
+    if (next === null || next.bytes.length === 0) return;
+    offset += next.bytes.length;
+    tail += decoder.write(next.bytes);
+    const lines = tail.split(/\r?\n/u);
+    tail = lines.pop() ?? "";
+    for (const line of lines) {
+      const record = parseRecord(line);
+      if (record?.kind === "process_started") workerRunning = true;
+      else if (record?.kind === "process_exit") workerRunning = false;
+      else if (record?.kind === "provider_event" || record?.kind === "provider_output_invalid") {
+        durableSeen += 1;
+        if (durableSeen > active.durableOutputCount)
+          pending.push(record.kind === "provider_event" ? JSON.stringify(record.event) : String(record.output));
+      }
+    }
+  };
+  scan();
+  while (durableSeen === 0 && workerRunning && Date.now() < deadline) {
     await delay(Math.min(10, Math.max(1, deadline - Date.now())));
-    stream = readDispatchStream(context.input.rootDir, active.dispatchId);
-    records = durableOutputRecords(stream?.records ?? []);
+    scan();
   }
-  for (const record of records.slice(active.durableOutputCount)) {
-    await context.consumeLine(
-      active,
-      record.kind === "provider_event" ? JSON.stringify(record.event) : String(record.output),
-      true,
-    );
-  }
+  for (const line of pending) await context.consumeLine(active, line, true);
 }
 
 export async function restoreDurableOutputRecords(

--- a/packages/daemon/src/runtime-worker-host.ts
+++ b/packages/daemon/src/runtime-worker-host.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { consumeKnownError } from "../../kernel/src/index.ts";
-import { appendDispatchStreamRecord, dispatchStreamPath, scrubProviderValue } from "./dispatch-stream.ts";
+import { dispatchStreamPath, openDispatchStreamAppender, scrubProviderValue } from "./dispatch-stream.ts";
 import { createRuntimeCallbackRelay } from "./runtime-callback-relay.ts";
 import type { RuntimeCallbackRelay } from "./runtime-spawn-types.ts";
 
@@ -18,9 +18,11 @@ type RuntimeWorkerManifest = {
 
 export async function runRuntimeWorkerHost(): Promise<void> {
   const manifest = parseManifest(await readStandardInput());
-  const stream = dispatchStreamPath(manifest.rootDir, manifest.dispatchId);
+  const stream = dispatchStreamPath(manifest.rootDir, manifest.dispatchId),
+    // One descriptor for the host's whole lifetime: provider output appends once per line.
+    appender = openDispatchStreamAppender(stream);
   const append = (value: Readonly<Record<string, unknown>>): void =>
-    appendDispatchStreamRecord(stream, {
+    appender.append({
       occurredAt: new Date().toISOString(),
       ...value,
     });
@@ -88,6 +90,7 @@ export async function runRuntimeWorkerHost(): Promise<void> {
     child.stdin!.end(manifest.prompt);
     await new Promise<void>((resolve) => child?.once("close", () => resolve()));
   } finally {
+    appender.close();
     await relay?.stop();
   }
 }

--- a/packages/daemon/test/agent-runtime-overview-batching.test.ts
+++ b/packages/daemon/test/agent-runtime-overview-batching.test.ts
@@ -1,0 +1,65 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentRuntimeEventV1, RuntimeSession } from "../../kernel/src/index.ts";
+import { makeAgentRuntimeReadModel } from "../src/agent-runtime-read.ts";
+
+test("runtime overview pages at the server before DTO and dispatch expansion", () => {
+  const session = (runtimeSessionId: string): RuntimeSession => ({
+      runtimeSessionId,
+      instanceId: "instance-1",
+      installationId: "installation-1",
+      kindId: "codex",
+      definitionSnapshotRef: "artifact:runtime-definition/test",
+      providerSessionId: null,
+      transcriptRef: null,
+      launchGeneration: 1,
+      liveness: "live",
+      attachable: false,
+      taskBindings: [],
+      outcome: null,
+      exitCode: null,
+      resultRef: null,
+      lastObservedAt: "2026-09-12T00:00:00.000Z",
+    }),
+    rows = Array.from({ length: 12 }, (_, index) => session(`runtime-${String(index).padStart(2, "0")}`));
+  let unboundedReads = 0,
+    exactDispatchReads = 0,
+    batchDispatchReads = 0,
+    pageQuery: unknown;
+  const dispatches = rows.map(
+      ({ runtimeSessionId }) =>
+        ({
+          type: "runtime_dispatch_requested",
+          payload: { runtimeSessionId, definitionSnapshotRef: "artifact:runtime-definition/test" },
+        }) as AgentRuntimeEventV1,
+    ),
+    projection = {
+      readCut: () => ({ status: "ready", watermark: 1 }),
+      readRuntimeSessionPage: (query: unknown) => (
+        (pageQuery = query),
+        { rows, nextRuntimeSessionId: "runtime-11", remainingCount: 13 }
+      ),
+      readRuntimeSessions: () => ((unboundedReads += 1), rows),
+      readRuntimeInstallations: () => [],
+      readRuntimeDispatches: () => ((batchDispatchReads += 1), dispatches),
+      readRuntimeDispatch: () => ((exactDispatchReads += 1), null),
+      currentLease: () => null,
+    };
+  const overview = makeAgentRuntimeReadModel({
+    store: {} as never,
+    projection: projection as never,
+    stream: { latestCursor: () => "stream:0" } as never,
+  }).overview({ limit: 12 });
+  assert.equal(overview.sessions.length, 12);
+  assert.equal(unboundedReads, 0);
+  assert.equal(exactDispatchReads, 0);
+  assert.equal(batchDispatchReads, 1);
+  assert.deepEqual(pageQuery, { limit: 12 });
+  assert.deepEqual(overview.page, {
+    limit: 12,
+    cursor: null,
+    nextCursor: "runtime-session:runtime-11",
+    remainingCount: 13,
+  });
+});

--- a/packages/daemon/test/agent-runtime-slice-b.test.ts
+++ b/packages/daemon/test/agent-runtime-slice-b.test.ts
@@ -112,7 +112,8 @@ test("historical runtime sessions with no snapshot event degrade without failing
   withRuntime(({ store, projection, stream }) => {
     const withoutDispatchSnapshot = new Proxy(projection, {
         get: (target, property, receiver) => {
-          if (property === "readRuntimeDispatch") return () => null;
+          if (property === "readRuntimeDispatch" || property === "readRuntimeDispatches")
+            return property === "readRuntimeDispatch" ? () => null : () => [];
           const value = Reflect.get(target, property, receiver);
           return typeof value === "function" ? value.bind(target) : value;
         },
@@ -194,7 +195,7 @@ test("runtime overview batches definitions while a single-session read selects o
     reads.session({ runtimeSessionId: "runtime-session" });
     assert.deepEqual(
       { fullTaskListReads, taskStatusReads, cutReads, singleDispatchReads, batchDispatchReads },
-      { fullTaskListReads: 0, taskStatusReads: 0, cutReads: 2, singleDispatchReads: 2, batchDispatchReads: 0 },
+      { fullTaskListReads: 0, taskStatusReads: 0, cutReads: 2, singleDispatchReads: 1, batchDispatchReads: 1 },
     );
   }));
 
@@ -228,49 +229,6 @@ test("runtime session reads resolve a task dispatch after observing its projecti
       synchronizedReads.session({ taskId: "task-runtime", dispatchId: "dispatch-runtime" }).session.runtimeSessionId,
       "runtime-session",
     );
-  }));
-
-test("runtime overview pages at the server before DTO and dispatch expansion", () =>
-  withRuntime(({ store, projection, stream, session }) => {
-    const rows = Array.from({ length: 12 }, (_, index) => ({
-      ...session,
-      runtimeSessionId: `runtime-${String(index).padStart(2, "0")}`,
-    }));
-    let unboundedReads = 0,
-      exactDispatchReads = 0,
-      pageQuery: unknown;
-    const measured = new Proxy(projection, {
-      get: (target, property, receiver) => {
-        if (property === "readRuntimeSessions")
-          return () => {
-            unboundedReads += 1;
-            return [...rows, ...rows];
-          };
-        if (property === "readRuntimeSessionPage")
-          return (query: unknown) => {
-            pageQuery = query;
-            return { rows, nextRuntimeSessionId: "runtime-11", remainingCount: 13 };
-          };
-        if (property === "readRuntimeDispatch")
-          return (runtimeSessionId: string) => {
-            exactDispatchReads += 1;
-            return { ...dispatch(), payload: { ...dispatch().payload, runtimeSessionId } };
-          };
-        const value = Reflect.get(target, property, receiver);
-        return typeof value === "function" ? value.bind(target) : value;
-      },
-    });
-    const overview = makeAgentRuntimeReadModel({ store, projection: measured, stream }).overview({ limit: 12 });
-    assert.equal(overview.sessions.length, 12);
-    assert.equal(unboundedReads, 0);
-    assert.equal(exactDispatchReads, 12);
-    assert.deepEqual(pageQuery, { limit: 12 });
-    assert.deepEqual(overview.page, {
-      limit: 12,
-      cursor: null,
-      nextCursor: "runtime-session:runtime-11",
-      remainingCount: 13,
-    });
   }));
 
 test("fleet runtime adoption keeps every overview response below the negotiated frame ceiling", async (t) =>

--- a/packages/daemon/test/dispatch-read.test.ts
+++ b/packages/daemon/test/dispatch-read.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import test from "node:test";
 import { type RuntimeSession, type TaskProjection } from "../../kernel/src/index.ts";
 import { appendRuntimeWorkerRecord, openDispatchStream, readDispatchLiveIndex } from "../src/dispatch-stream.ts";
-import { readTaskDispatches } from "../src/dispatch-read.ts";
+import { readTaskDispatches, readTaskDispatchSession } from "../src/dispatch-read.ts";
 
 const dispatchId = "dispatch_a1b2c3d4e5f60718293a4b5c",
   runtimeSessionId = "runtime-1",
@@ -451,6 +451,47 @@ test("archived dispatch rows expose terminal result and task artifact references
       dispatchPath: "tasks/task-1/artifacts/dispatches/dispatch_a1b2c3d4e5f60718293a4b5c.json",
       reportPath,
     });
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+// The single-dispatch point read (session lookups by taskId+dispatchId) resolves straight from
+// the stream header: building the whole task dispatch list to JS-find one row scanned every
+// candidate's summary and archived document per call.
+test("single-dispatch point reads resolve from the stream header without building the task list", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-point-read-"));
+  try {
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId,
+      executionId: "execution-1",
+      runtimeSessionId,
+      instanceId: "instance-1",
+      startedAt: "2026-08-23T00:00:00.000Z",
+    });
+    assert.deepEqual(readTaskDispatchSession(rootDir, taskId, dispatchId), { runtimeSessionId });
+    // A dispatch attributed to another task never resolves, and neither does an unattributed one.
+    assert.equal(readTaskDispatchSession(rootDir, "task-other", dispatchId), null);
+    assert.equal(readTaskDispatchSession(rootDir, "not-a-dispatch-id", "whatever"), null);
+    assert.equal(readTaskDispatchSession(rootDir, taskId, "dispatch_000000000000000000000000"), null);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("single-dispatch point reads never resolve an unattributed dispatch", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-point-unattributed-"));
+  try {
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: null,
+      executionId: null,
+      runtimeSessionId,
+      instanceId: "instance-1",
+      startedAt: "2026-08-23T00:00:00.000Z",
+    });
+    assert.equal(readTaskDispatchSession(rootDir, taskId, dispatchId), null);
   } finally {
     rmSync(rootDir, { recursive: true, force: true });
   }

--- a/packages/daemon/test/dispatch-stream-io.test.ts
+++ b/packages/daemon/test/dispatch-stream-io.test.ts
@@ -1,0 +1,69 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  dispatchStreamPath,
+  openDispatchStream,
+  openDispatchStreamAppender,
+  readDispatchStream,
+  readDispatchStreamIncrement,
+} from "../src/dispatch-stream.ts";
+
+test("incremental stream reads return only the bytes past the caller-held offset", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-increment-"));
+  try {
+    const target = dispatchStreamPath(rootDir, "dispatch_c1d2e3f4a5b60718293a4b5c");
+    mkdirSync(path.dirname(target), { recursive: true });
+    appendFileSync(target, "line-one\n");
+    const first = readDispatchStreamIncrement(target, 0);
+    assert.ok(first);
+    assert.equal(first.bytes.toString(), "line-one\n");
+    assert.equal(first.size, "line-one\n".length);
+    const caughtUp = readDispatchStreamIncrement(target, first.bytes.length);
+    assert.ok(caughtUp);
+    assert.equal(caughtUp.bytes.length, 0);
+    appendFileSync(target, "line-two\n");
+    const next = readDispatchStreamIncrement(target, first.bytes.length);
+    assert.ok(next);
+    assert.equal(next.bytes.toString(), "line-two\n");
+    assert.equal(readDispatchStreamIncrement(path.join(rootDir, "missing.jsonl"), 0), null);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("a held-descriptor appender lands schema-tagged records and reopens after close", () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-appender-"));
+  try {
+    const dispatchId = "dispatch_d1e2f3a4b5c60718293a4b5c",
+      target = dispatchStreamPath(rootDir, dispatchId);
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: null,
+      executionId: null,
+      runtimeSessionId: "runtime-appender",
+      instanceId: "instance-1",
+      startedAt: "2026-09-12T00:00:00.000Z",
+    });
+    const appender = openDispatchStreamAppender(target);
+    appender.append({ kind: "provider_event", event: { seq: 1 } });
+    appender.append({ kind: "provider_event", event: { seq: 2 } });
+    appender.close();
+    appender.append({ kind: "process_exit", exitCode: 0, signal: null });
+    appender.close();
+    const stream = readDispatchStream(rootDir, dispatchId);
+    assert.deepEqual(
+      stream?.records.map((record) => record.kind),
+      ["provider_event", "provider_event", "process_exit"],
+    );
+    assert.deepEqual(
+      stream?.records.map((record) => record.schema),
+      ["runtime-dispatch-stream/v1", "runtime-dispatch-stream/v1", "runtime-dispatch-stream/v1"],
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/packages/daemon/test/runtime-spawn-provider-stream.test.ts
+++ b/packages/daemon/test/runtime-spawn-provider-stream.test.ts
@@ -5,7 +5,12 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { createActiveRuntime } from "../src/runtime-spawn-active.ts";
-import { consumeProviderChunk, consumeProviderLine } from "../src/runtime-spawn-provider-stream.ts";
+import {
+  consumeDurableOutput,
+  consumeProviderChunk,
+  consumeProviderLine,
+} from "../src/runtime-spawn-provider-stream.ts";
+import { appendRuntimeWorkerRecord, openDispatchStream } from "../src/dispatch-stream.ts";
 
 function active() {
   return createActiveRuntime({
@@ -151,5 +156,68 @@ test("Codex empty turn usage is replaced by the matching session turn token coun
     assert.deepEqual(runtime.rawUsage, { input_tokens: 62284, cached_input_tokens: 60672, output_tokens: 2046 });
   } finally {
     rmSync(userRoot, { recursive: true, force: true });
+  }
+});
+
+test("durable drains wait for the first record while the worker runs, then consume it once", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-durable-wait-"));
+  try {
+    const dispatchId = "dispatch_e1f2a3b4c5d60718293a4b5c";
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: null,
+      executionId: null,
+      runtimeSessionId: "runtime-durable-wait",
+      instanceId: "instance-1",
+      startedAt: "2026-09-12T00:00:00.000Z",
+    });
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "process_started", pid: 2_147_483_647 });
+    const consumed: string[] = [],
+      active = { dispatchId, durableOutputCount: 0 },
+      context = {
+        input: { rootDir },
+        consumeLine: async (_active: unknown, line: string) => {
+          consumed.push(line);
+        },
+      };
+    const draining = consumeDurableOutput(context as never, active as never, 2_000);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.deepEqual(consumed, []);
+    appendRuntimeWorkerRecord(rootDir, dispatchId, { kind: "provider_event", event: { seq: 1 } });
+    await draining;
+    assert.deepEqual(consumed, ['{"seq":1}']);
+    active.durableOutputCount = consumed.length;
+    await consumeDurableOutput(context as never, active as never);
+    assert.deepEqual(consumed, ['{"seq":1}'], "an already-counted record is never consumed twice");
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("durable drains do not wait when no process record shows the worker running", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-durable-no-wait-"));
+  try {
+    const dispatchId = "dispatch_f1a2b3c4d5e60718293a4b5c",
+      consumed: string[] = [],
+      context = {
+        input: { rootDir },
+        consumeLine: async (_active: unknown, line: string) => {
+          consumed.push(line);
+        },
+      };
+    openDispatchStream(rootDir, {
+      dispatchId,
+      taskId: null,
+      executionId: null,
+      runtimeSessionId: "runtime-durable-no-wait",
+      instanceId: "instance-1",
+      startedAt: "2026-09-12T00:00:00.000Z",
+    });
+    const startedAt = Date.now();
+    await consumeDurableOutput(context as never, { dispatchId, durableOutputCount: 0 } as never, 2_000);
+    assert.ok(Date.now() - startedAt < 1_000, "a stream without a running worker must not poll its budget away");
+    assert.deepEqual(consumed, []);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
   }
 });

--- a/tools/write-road-registry.json
+++ b/tools/write-road-registry.json
@@ -50,6 +50,7 @@
     "packages/daemon/src/client/daemon-autostart.ts",
     "packages/daemon/src/conn-log.ts",
     "packages/daemon/src/daemon-singleton.ts",
+    "packages/daemon/src/dispatch-stream-io.ts",
     "packages/daemon/src/dispatch-stream.ts",
     "packages/daemon/src/doc-sync-candidate-scanner.ts",
     "packages/daemon/src/doc-sync-details.ts",


### PR DESCRIPTION
# English

## Summary

Fix-plan batches 11/12 tails (dispatch stream read/write path, runtime session reads). (R2-02-F6 / R2-09t-F1) the provider-stream durable-output wait no longer re-reads and re-parses the whole dispatch stream every 10 ms: the consumer keeps a byte offset and reads only appended bytes through `readDispatchStreamIncrement`, decoding lines incrementally; worker liveness comes from the `process_started`/`process_exit` records it already parses. (R2-02-F8) the runtime worker host opens one append descriptor for the dispatch stream for its whole lifetime (`openDispatchStreamAppender`) and closes it in `finally`, instead of open/fstat/write/close per provider line. (R4-retry-F3) resolving a single (task, dispatch) to its session reads the stream header (`readTaskDispatchSession`) instead of building the whole task dispatch list and `find`-ing in it. (R2-02-F3 / R2-02-F10 / R2-09a-F2) runtime overview and session groups collect dispatches once and index them by session, and index installations, instead of per-session point reads. Deferred with reasons: R4-retry-F1 (explicit attemptChain request across CLI payload and protocol) — the protocol and thin-client files are at shrink-only complexity ceilings until file-budget-headroom (task_f511d63b) lands; keyed-batch `readTaskDispatches` / per-binding lease batch — no projection batch API exists and adding a second read path is out of this batch. Stream I/O ownership moved to a new sibling module because `dispatch-stream.ts` is at its ceiling.

## Architectural Justification

Readers own their cursor and writers own their descriptor; a point lookup reads the header it needs rather than materialising the list it belongs to.

## What Changed

- `packages/daemon/src/dispatch-stream-io.ts` (new, 85): `readDispatchStreamIncrement`, `openDispatchStreamAppender` (held descriptor, size-limit check, close in the error path without swallowing a close failure — the CEO removed the worker's nested catch so no fallback-boundary entry is needed).
- `packages/daemon/src/dispatch-stream.ts` (+?/-?): delegates I/O to the sibling; `parseRecord` and `dispatchStreamPath` exported for the incremental reader.
- `packages/daemon/src/runtime-spawn-provider-stream.ts`: cursor-based durable wait (offset, `StringDecoder`, pending lines).
- `packages/daemon/src/runtime-worker-host.ts`: one appender per host lifetime.
- `packages/daemon/src/dispatch-read.ts`: `readTaskDispatchSession` header point read; `repo-cell.ts` / `repo-cell-proxy.ts` consume it.
- `packages/daemon/src/agent-runtime-read.ts`: overview / session-groups dispatch collection indexed by session and snapshot; installation index.
- Tests: new `dispatch-stream-io.test.ts` (held descriptor, reopen), `agent-runtime-overview-batching.test.ts` (one batch read, zero point reads), `runtime-spawn-provider-stream.test.ts` (+durable wait, no duplicate consumption), `dispatch-read.test.ts` (+attributed/unattributed point reads); the overview cases moved out of `agent-runtime-slice-b.test.ts` (at its ceiling) into the new file.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +206/-70 production (net positive: the new `dispatch-stream-io.ts` (85 lines) takes stream I/O ownership out of `dispatch-stream.ts`, which sits at its shrink-only ceiling; the cursor reader and the batched overview index replace re-reads with bookkeeping); tests +295/-47.

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root and on the branch head: every operation and metric identical, G38 passes on both. The probes never enter the dispatch stream or runtime overview paths; the evidence for this batch is the read-count tests listed under verification (one batch read / zero point reads for the overview, one held descriptor per worker host, no duplicate durable consumption).

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_55dc4cefae9472c35ff43550e8 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/fixplan-f-dispatch-tails`
- Public scope: Daemon dispatch stream I/O, provider durable-output wait, single-dispatch session lookup, runtime overview/session-group reads (fix-plan R2-02-F6/F8/F3/F10, R2-09t-F1, R2-09a-F2, R4-retry-F3).
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: R4-retry-F1 (attemptChain explicit request, CLI+protocol) deferred until protocol/client files regain headroom; keyed-batch dispatch/lease reads deferred (no batch API); tmux/TerminalHost async is a separate task; no wire shape change; no CI/gate/allowlist change.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: yes — `tools/write-road-registry.json` (one `physicalWriteFiles` entry added: `packages/daemon/src/dispatch-stream-io.ts`; the manifest-derived `check-pr-governance` rules do not list this file, so this declaration is voluntary)
- Protected surface scope: inventory only. `check-write-road-registry` requires the declared set of physical write sinks to equal the discovered set exactly; the new `dispatch-stream-io.ts` imports `openSync`/`writeFileSync` (the descriptor-holding reader and the appender that used to live in `dispatch-stream.ts`, which is already declared and sits at 808 lines under a shrink-only ceiling, so the helpers cannot be folded back). No gate logic, budget or required row changes; the gate's own test stays 7/7.
- Evidence: first CI run of this PR failed `boundaries` with `packages/daemon/src/dispatch-stream-io.ts: physical write sink is not declared`; after the entry, `node tools/check-write-road-registry.mjs` passes and `node --test tools/check-write-road-registry.test.mjs` is 7/7.
- Authority: task task_55dc4cefae9472c35ff43550e8 (fix-plan F continuation, CEO 备注 2 — new dispatch-stream I/O module under the shrink-only ceiling of `dispatch-stream.ts`); the registry's own rule that `physicalWriteFiles` must equal the discovered sink set; CI/gate standard `harness/governance/standards/ci-cd-standard.md`.

## Verification

- Base `origin/main` SHA: `7777e0e20`
- Branch merge-base with `origin/main`: `7777e0e20`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/fixplan-f-dispatch-tails`
- Private evidence commit/path: task_55dc4cefae9472c35ff43550e8 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO ground-truth on head 65e1d0aba (base 7777e0e20): fast/contract `agent-runtime-overview-batching`, `dispatch-read`, `dispatch-stream-io`, `runtime-spawn-provider-stream`, `dispatch-stream` 38/38 (22/22 re-run after the close-path fix); isolated Ubuntu `provider-fallback.integration` 2/2 (`agent-runtime-slice-b` and `runtime-spawn.integration` isolated runs are re-run below the PR; a first attempt collided with a concurrent dispatch and returned exit 1 without running); `tsc -b` clean; gates `check-file-complexity`, `run-local-line-density` G36, `check-cli-structure`, `check-bypass-write-boundary`, `check-import-boundaries`, `canonical-event-compat`, `ontology-daemon-specialization-lines` (gui-actions −5), `check-fallback-boundaries` (after removing the swallowed close error: no unlisted/stale entry) pass, `check-pr-governance` skipped; G1 identical base vs head. Worker (Codex Terra, two rounds, report `artifacts/report.md`): targeted 50/50, isolated `provider-fallback` 2/2 and `dispatch-stream` 15/15, all gates; mutation on the durable cursor (`>` → `>=`) makes the no-duplicate test fail as expected. Worker did not run a mutation per finding beyond that. Registry fix (head after this push): `check-write-road-registry` pass, its test 7/7, `check-pr-governance --base/--head` reports no manifest-protected surface, G33 production-delta pass (+206/-70 unchanged; the registry is not production).

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; read the provider-stream, worker-host, dispatch-read and overview diffs, checked the liveness-flag equivalence with the old `process.exited` condition, removed the worker's swallowed close error (fallback-boundary gate would otherwise demand a new entry), verified only the session id was consumed by the point-read callers, and re-ran gates, targeted and isolated suites and G1 on the final head.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The durable-output wait now judges worker liveness from stream records rather than the parsed `process` summary; both derive from the same `process_started`/`process_exit` lines, so a stream without a start record exits the wait immediately as before. A held append descriptor means a rotated or deleted stream file is not re-resolved until the host restarts; hosts are per-dispatch and short-lived. `readTaskDispatchSession` returns only the session id where the old path returned the full dispatch row; the two consumers (repo cell and proxy) only used the session id (tsc enforces). Net production +140 against a fix batch: one new module and explicit bookkeeping replace repeated reads — stated, not hidden.

## References

- Task: task_55dc4cefae9472c35ff43550e8

---

# 中文

## 概要

fix-plan 批 11/12 尾巴（dispatch 流读写路径、runtime 会话读面）。(R2-02-F6 / R2-09t-F1) provider 流的 durable-output 等待不再每 10 ms 重读重解析整个 dispatch 流：消费方持字节 offset，经 `readDispatchStreamIncrement` 只读新追加的字节并增量解码行；worker 存活由它本来就解析的 `process_started`/`process_exit` 记录判定。(R2-02-F8) runtime worker host 为 dispatch 流在整个生命周期打开一个 append 描述符（`openDispatchStreamAppender`）并在 `finally` 关闭，不再每条 provider 行 open/fstat/write/close。(R4-retry-F3) 单个 (task, dispatch) 解析到 session 直接读流头（`readTaskDispatchSession`），不再构建整张任务派工列表再 `find`。(R2-02-F3 / R2-02-F10 / R2-09a-F2) runtime overview 与 session groups 一次收集 dispatch 并按 session 建索引、installation 也建索引，取代逐 session 点读。带理由 deferred：R4-retry-F1（attemptChain 显式请求，跨 CLI payload 与协议）——协议与 thin client 文件处于 shrink-only 复杂度天花板，等 file-budget-headroom（task_f511d63b）落地；keyed-batch `readTaskDispatches` / 逐 binding lease 批读——没有 projection 批读 API，加第二条读路径不在本批。流 I/O 所有权挪到新同族模块，因为 `dispatch-stream.ts` 已顶格。

## 架构辩护

读者持有自己的游标、写者持有自己的描述符；点查只读它需要的流头，不物化它所属的列表。

## 改动内容

- `packages/daemon/src/dispatch-stream-io.ts`（新，85 行）：`readDispatchStreamIncrement`、`openDispatchStreamAppender`（持有描述符、大小上限检查、错误路径关闭且不吞 close 失败——CEO 删掉了 worker 的嵌套 catch，因此不需要新增 fallback-boundary 条目）。
- `packages/daemon/src/dispatch-stream.ts`：I/O 委托给同族模块；导出 `parseRecord`、`dispatchStreamPath` 供增量读取器使用。
- `packages/daemon/src/runtime-spawn-provider-stream.ts`：基于游标的 durable 等待（offset、`StringDecoder`、pending 行）。
- `packages/daemon/src/runtime-worker-host.ts`：每个 host 生命周期一个 appender。
- `packages/daemon/src/dispatch-read.ts`：`readTaskDispatchSession` 流头点读；`repo-cell.ts` / `repo-cell-proxy.ts` 消费它。
- `packages/daemon/src/agent-runtime-read.ts`：overview / session-groups 的 dispatch 收集按 session 与 snapshot 建索引；installation 索引。
- 测试：新 `dispatch-stream-io.test.ts`（持有描述符、重开）、`agent-runtime-overview-batching.test.ts`（一次批读、零点读）、`runtime-spawn-provider-stream.test.ts`（+durable 等待、不重复消费）、`dispatch-read.test.ts`（+有归属/无归属点读）；overview 用例从顶格的 `agent-runtime-slice-b.test.ts` 挪到新文件。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+206/-70 production (net positive: the new `dispatch-stream-io.ts` (85 lines) takes stream I/O ownership out of `dispatch-stream.ts`, which sits at its shrink-only ceiling; the cursor reader and the batched overview index replace re-reads with bookkeeping); tests +295/-47。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_55dc4cefae9472c35ff43550e8（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/fixplan-f-dispatch-tails`
- 公开范围：daemon dispatch 流 I/O、provider durable-output 等待、单 dispatch 的 session 查找、runtime overview/session-group 读面（fix-plan R2-02-F6/F8/F3/F10、R2-09t-F1、R2-09a-F2、R4-retry-F3）。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：R4-retry-F1（attemptChain 显式请求，CLI+协议）等协议/客户端文件恢复余量后再做；keyed-batch 派工/租约批读 deferred（无批读 API）；tmux/TerminalHost 异步另立任务；不改 wire 形状；不改 CI/gate/allowlist。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰 protected surface：是——`tools/write-road-registry.json`（`physicalWriteFiles` 加一条：`packages/daemon/src/dispatch-stream-io.ts`；manifest 派生的 `check-pr-governance` 规则未列此文件，本声明为主动声明）
- 范围：只是清单登记。`check-write-road-registry` 要求登记的物理写入文件集合与扫描结果精确相等；新文件 `dispatch-stream-io.ts` 引入了 `openSync`/`writeFileSync`（原本在已登记的 `dispatch-stream.ts` 里的持描述符读者与追加器；该文件 808 行、处于只减不增的天花板下，不能折回去）。不改门逻辑、预算与必需行；门自身测试仍 7/7。
- 依据：本 PR 首轮 CI 的 `boundaries` 以 `packages/daemon/src/dispatch-stream-io.ts: physical write sink is not declared` 失败；加条目后本地 `node tools/check-write-road-registry.mjs` 通过，`node --test tools/check-write-road-registry.test.mjs` 7/7。
- 依据：任务 task_55dc4cefae9472c35ff43550e8（fix-plan F 续跑，CEO 备注 2——在 `dispatch-stream.ts` 只减不增天花板下另立 I/O 模块）；登记表自身「`physicalWriteFiles` 必须与扫描到的写入集合精确相等」的规则；CI/gate 标准 `harness/governance/standards/ci-cd-standard.md`。

## 验证

- 基线 `origin/main` SHA：`7777e0e20`
- 分支与 `origin/main` 的 merge-base：`7777e0e20`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/fixplan-f-dispatch-tails`
- 私有证据路径：task_55dc4cefae9472c35ff43550e8 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO 在 head 65e1d0aba（base 7777e0e20）核实：fast/contract `agent-runtime-overview-batching`、`dispatch-read`、`dispatch-stream-io`、`runtime-spawn-provider-stream`、`dispatch-stream` 38/38（关闭路径修复后 22/22 复跑）；Ubuntu 隔离 `provider-fallback.integration` 2/2（`agent-runtime-slice-b` 与 `runtime-spawn.integration` 的隔离运行在 PR 下方补跑；第一次尝试与并发派测撞车、未运行即 exit 1）；`tsc -b` 干净；gates `check-file-complexity`、`run-local-line-density` G36、`check-cli-structure`、`check-bypass-write-boundary`、`check-import-boundaries`、`canonical-event-compat`、`ontology-daemon-specialization-lines`（gui-actions −5）、`check-fallback-boundaries`（删掉被吞的 close 错误后：无 unlisted/stale 条目）通过，`check-pr-governance` 跳过；G1 base 与 head 全等。worker（Codex Terra，两轮，报告 `artifacts/report.md`）：定向 50/50，隔离 `provider-fallback` 2/2、`dispatch-stream` 15/15，全部 gate；durable 游标变异（`>` → `>=`）让不重复消费测试如预期变红。worker 未对其余 finding 逐条做变异。 登记修正（本次 push 后的 head）：`check-write-road-registry` 通过、其测试 7/7、`check-pr-governance --base/--head` 报无 manifest 保护面、G33 production-delta 通过（+206/-70 不变；登记表不算 production）。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；通读 provider-stream、worker-host、dispatch-read 与 overview 的 diff，核对存活旗标与旧 `process.exited` 条件等价，删掉 worker 被吞的 close 错误（否则 fallback-boundary 门要新条目），核实点读调用方只消费 session id，并在最终 head 上重跑 gates、定向与隔离套件及 G1。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- durable-output 等待现在由流记录判定 worker 存活而不是解析后的 `process` 摘要；两者同源于 `process_started`/`process_exit` 行，没有 start 记录的流像以前一样立即退出等待。持有的 append 描述符意味着流文件被轮转或删除后要到 host 重启才重新解析；host 按 dispatch 短命。`readTaskDispatchSession` 只返回 session id，旧路径返回整行 dispatch；两个消费方（repo cell 与 proxy）只用 session id（tsc 保证）。修复批净 +140 行：一个新模块与显式记账替代重复读——明说，不藏。

## 参考

- 任务：task_55dc4cefae9472c35ff43550e8

