### PR TITLE
refactor: file-budget headroom — split read payload admission, catalog decoding and settings YAML helpers by responsibility

### DIFF
--- a/packages/daemon/src/repo-cell-api.ts
+++ b/packages/daemon/src/repo-cell-api.ts
@@ -65,7 +65,6 @@ import {
   type DaemonDecisionListResult,
   type DaemonGuiReadResultMap,
   type DaemonRelationGraphFacetPayload,
-  type DaemonTaskDispatchesPayload,
   type CanonicalRoot,
 } from "./protocol/daemon-protocol.contract.ts";
 import type { JsonObject } from "./protocol/json-rpc-types.ts";
@@ -101,6 +100,7 @@ import type { RepoBootstrapReceipt } from "./repo-bootstrap.ts";
 import { explainAuthenticationRequired, readTaskActionExplanation } from "./task-action-explanation-read.ts";
 import { commitRuntimeSessionAction } from "./runtime-session-action-runtime.ts";
 import { readTaskWipSnapshot, type TaskQueryCell } from "./repo-cell-task-query.ts";
+import { agendaQueryFromPayload, taskDispatchesPayloadFromCell } from "./repo-cell-read-payloads.ts";
 
 export interface RepoCellApiContext {
   readonly extracted: RepoCellOperationalContext;
@@ -575,7 +575,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
       });
     },
     "repo.agenda.read": (payload: Readonly<Record<string, unknown>>) =>
-      queryRead().agenda(agendaQueryFromPayload(payload)),
+      queryRead().agenda(agendaQueryFromPayload(context, payload)),
     "repo.triadic.relationGraph": (payload: Readonly<Record<string, unknown>>) => relationGraphFromPayload(payload),
     "repo.agent.entities.list": () =>
       readAgentEntityGuiProjection({
@@ -624,7 +624,7 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
       readTaskDispatches({
         rootDir: context.rootDir,
         projection: context.projection,
-        ...taskDispatchesPayloadFromCell(payload),
+        ...taskDispatchesPayloadFromCell(context, payload),
       }),
   } satisfies DaemonGuiReadHandlers;
   function decisionListFromPayload(payload: Readonly<Record<string, unknown>>): DaemonDecisionListResult {
@@ -700,22 +700,6 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
       ...(common.cursor ? { cursor: common.cursor } : {}),
     };
   }
-  function agendaQueryFromPayload(payload: Readonly<Record<string, unknown>>): {
-    readonly limit?: number;
-    readonly cursor?: string;
-  } {
-    if (
-      Object.keys(payload).some((field) => field !== "limit" && field !== "cursor") ||
-      (payload.limit !== undefined &&
-        (!Number.isSafeInteger(payload.limit) || Number(payload.limit) < 1 || Number(payload.limit) > 500)) ||
-      (payload.cursor !== undefined && (typeof payload.cursor !== "string" || !payload.cursor))
-    )
-      throw context.cellCodedError("invalid_command", "Agenda accepts --limit 1..500 and a non-empty cursor only.");
-    return {
-      ...(payload.limit === undefined ? {} : { limit: Number(payload.limit) }),
-      ...(typeof payload.cursor === "string" ? { cursor: payload.cursor } : {}),
-    };
-  }
   /**
    * The single serving point for every named use-case projection. Selector admission happens once,
    * in `admitUseCaseProjectionSelector`, so an unknown name, an inadmissible facet and a smuggled
@@ -750,27 +734,6 @@ export function createRepoCellApi(context: RepoCellApiContext): RepoCell & RepoC
         ),
       };
     return { ...envelope, projection: context.runtimeReads.sessionGroups(selector) };
-  }
-  function taskDispatchesPayloadFromCell(payload: Readonly<Record<string, unknown>>): DaemonTaskDispatchesPayload {
-    if (!Array.isArray(payload.taskIds)) return { taskId: context.requiredCellText(payload.taskId, "taskId") };
-    const taskIds = payload.taskIds.map((taskId) => context.requiredCellText(taskId, "taskIds[]")),
-      limit = payload.limit === undefined ? undefined : Number(payload.limit),
-      cursor = payload.cursor === undefined ? undefined : context.requiredCellText(payload.cursor, "cursor");
-    if (
-      taskIds.length === 0 ||
-      taskIds.length > 500 ||
-      new Set(taskIds).size !== taskIds.length ||
-      (limit !== undefined && (!Number.isSafeInteger(limit) || limit < 1 || limit > 500))
-    )
-      throw context.cellCodedError(
-        "invalid_command",
-        "Task dispatch batch requires 1..500 unique task ids and an optional limit of 1..500.",
-      );
-    return {
-      taskIds,
-      ...(limit === undefined ? {} : { limit }),
-      ...(cursor === undefined ? {} : { cursor }),
-    };
   }
   function taskListQueryFromAction(action: RepoTaskAction): TaskProjectionListQuery {
     return taskListQueryFromPayload(action);

--- a/packages/daemon/src/repo-cell-read-payloads.ts
+++ b/packages/daemon/src/repo-cell-read-payloads.ts
@@ -1,0 +1,44 @@
+import type { DaemonTaskDispatchesPayload } from "./protocol/daemon-protocol-gui-types.ts";
+import type { RepoCellApiContext } from "./repo-cell-api.ts";
+
+export function agendaQueryFromPayload(
+  context: RepoCellApiContext,
+  payload: Readonly<Record<string, unknown>>,
+): { readonly limit?: number; readonly cursor?: string } {
+  if (
+    Object.keys(payload).some((field) => field !== "limit" && field !== "cursor") ||
+    (payload.limit !== undefined &&
+      (!Number.isSafeInteger(payload.limit) || Number(payload.limit) < 1 || Number(payload.limit) > 500)) ||
+    (payload.cursor !== undefined && (typeof payload.cursor !== "string" || !payload.cursor))
+  )
+    throw context.cellCodedError("invalid_command", "Agenda accepts --limit 1..500 and a non-empty cursor only.");
+  return {
+    ...(payload.limit === undefined ? {} : { limit: Number(payload.limit) }),
+    ...(typeof payload.cursor === "string" ? { cursor: payload.cursor } : {}),
+  };
+}
+
+export function taskDispatchesPayloadFromCell(
+  context: RepoCellApiContext,
+  payload: Readonly<Record<string, unknown>>,
+): DaemonTaskDispatchesPayload {
+  if (!Array.isArray(payload.taskIds)) return { taskId: context.requiredCellText(payload.taskId, "taskId") };
+  const taskIds = payload.taskIds.map((taskId) => context.requiredCellText(taskId, "taskIds[]")),
+    limit = payload.limit === undefined ? undefined : Number(payload.limit),
+    cursor = payload.cursor === undefined ? undefined : context.requiredCellText(payload.cursor, "cursor");
+  if (
+    taskIds.length === 0 ||
+    taskIds.length > 500 ||
+    new Set(taskIds).size !== taskIds.length ||
+    (limit !== undefined && (!Number.isSafeInteger(limit) || limit < 1 || limit > 500))
+  )
+    throw context.cellCodedError(
+      "invalid_command",
+      "Task dispatch batch requires 1..500 unique task ids and an optional limit of 1..500.",
+    );
+  return {
+    taskIds,
+    ...(limit === undefined ? {} : { limit }),
+    ...(cursor === undefined ? {} : { cursor }),
+  };
+}

--- a/packages/gui/src/renderer/api-client-catalog.ts
+++ b/packages/gui/src/renderer/api-client-catalog.ts
@@ -1,0 +1,78 @@
+import { localErrorHint, isRendererRecord } from "./result-validation.ts";
+import type { CatalogPresetSuccess, CatalogRereadReceipt, CatalogSnapshotSuccess } from "./api-client.ts";
+
+export function readCatalogSnapshot(value: unknown): CatalogSnapshotSuccess {
+  if (!isCatalogSnapshotSuccess(value))
+    throw new Error(localErrorHint(value, "Catalog snapshot bridge returned an invalid result."));
+  return value;
+}
+
+export function readCatalogPreset(value: unknown): CatalogPresetSuccess {
+  if (!isCatalogPresetSuccess(value))
+    throw new Error(localErrorHint(value, "Catalog preset bridge returned an invalid result."));
+  return value;
+}
+
+export function readCatalogRereadReceipt(value: unknown): CatalogRereadReceipt {
+  if (!isCatalogRereadReceipt(value))
+    throw new Error(localErrorHint(value, "Catalog reread bridge returned an invalid receipt."));
+  return value;
+}
+
+function isCatalogSnapshotSuccess(value: unknown): value is CatalogSnapshotSuccess {
+  return (
+    isRendererRecord(value) &&
+    value.schema === "gui-catalog-snapshot/v1" &&
+    value.ok === true &&
+    ["ready", "pending"].includes(String(value.status)) &&
+    typeof value.repoId === "string" &&
+    isRendererRecord(value.defaults) &&
+    Array.isArray(value.presets) &&
+    Array.isArray(value.verticals) &&
+    Array.isArray(value.templates) &&
+    Array.isArray(value.adapters) &&
+    isRendererRecord(value.scaffolds) &&
+    Array.isArray(value.scaffolds.task) &&
+    Array.isArray(value.scaffolds.repository) &&
+    Array.isArray(value.settingsFields) &&
+    value.presets.every(
+      (row) =>
+        isRendererRecord(row) &&
+        Array.isArray(row.profiles) &&
+        row.profiles.every(
+          (profile) => isRendererRecord(profile) && typeof profile.id === "string" && typeof profile.title === "string",
+        ),
+    )
+  );
+}
+
+function isCatalogPresetSuccess(value: unknown): value is CatalogPresetSuccess {
+  return (
+    isRendererRecord(value) &&
+    value.schema === "gui-catalog-preset/v1" &&
+    value.ok === true &&
+    typeof value.repoId === "string" &&
+    isRendererRecord(value.preset) &&
+    isRendererRecord(value.resolved) &&
+    Array.isArray(value.resolved.documents) &&
+    value.resolved.documents.every(
+      (row) =>
+        isRendererRecord(row) &&
+        typeof row.slot === "string" &&
+        typeof row.path === "string" &&
+        typeof row.body === "string" &&
+        typeof row.mediaType === "string",
+    )
+  );
+}
+
+function isCatalogRereadReceipt(value: unknown): value is CatalogRereadReceipt {
+  return (
+    isRendererRecord(value) &&
+    value.schema === "catalog-reread-receipt/v1" &&
+    typeof value.ok === "boolean" &&
+    ["applied", "op_rejected"].includes(String(value.outcome)) &&
+    typeof value.operationId === "string" &&
+    typeof value.repoId === "string"
+  );
+}

--- a/packages/gui/src/renderer/api-client.ts
+++ b/packages/gui/src/renderer/api-client.ts
@@ -36,6 +36,7 @@ import type { SettingsFieldValue } from "./settings-form.ts";
 import { invoke } from "./api-client-invoke.ts";
 import { readGuiActionResult } from "./command-receipt.ts";
 import { daemonBridgeError } from "./daemon-startup.ts";
+import { readCatalogPreset, readCatalogRereadReceipt, readCatalogSnapshot } from "./api-client-catalog.ts";
 import {
   readDecisionControlList,
   readDecisionListResult,
@@ -784,21 +785,6 @@ function readDaemonControlReceipt(value: unknown): DaemonControlReceipt {
     throw new Error(localErrorHint(value, "Daemon control bridge returned an invalid receipt."));
   return value;
 }
-function readCatalogSnapshot(value: unknown): CatalogSnapshotSuccess {
-  if (!isCatalogSnapshotSuccess(value))
-    throw new Error(localErrorHint(value, "Catalog snapshot bridge returned an invalid result."));
-  return value;
-}
-function readCatalogPreset(value: unknown): CatalogPresetSuccess {
-  if (!isCatalogPresetSuccess(value))
-    throw new Error(localErrorHint(value, "Catalog preset bridge returned an invalid result."));
-  return value;
-}
-function readCatalogRereadReceipt(value: unknown): CatalogRereadReceipt {
-  if (!isCatalogRereadReceipt(value))
-    throw new Error(localErrorHint(value, "Catalog reread bridge returned an invalid receipt."));
-  return value;
-}
 
 function isSystemStatusSuccess(value: unknown): value is SystemStatusSuccess {
   return (
@@ -827,61 +813,6 @@ function isDaemonControlReceipt(value: unknown): value is DaemonControlReceipt {
     ["refresh", "restart"].includes(String(value.kind)) &&
     typeof value.operationId === "string" &&
     ["queued", "draining", "starting", "settled", "failed"].includes(String(value.phase))
-  );
-}
-function isCatalogSnapshotSuccess(value: unknown): value is CatalogSnapshotSuccess {
-  return (
-    isRendererRecord(value) &&
-    value.schema === "gui-catalog-snapshot/v1" &&
-    value.ok === true &&
-    ["ready", "pending"].includes(String(value.status)) &&
-    typeof value.repoId === "string" &&
-    isRendererRecord(value.defaults) &&
-    Array.isArray(value.presets) &&
-    Array.isArray(value.verticals) &&
-    Array.isArray(value.templates) &&
-    Array.isArray(value.adapters) &&
-    isRendererRecord(value.scaffolds) &&
-    Array.isArray(value.scaffolds.task) &&
-    Array.isArray(value.scaffolds.repository) &&
-    Array.isArray(value.settingsFields) &&
-    value.presets.every(
-      (row) =>
-        isRendererRecord(row) &&
-        Array.isArray(row.profiles) &&
-        row.profiles.every(
-          (profile) => isRendererRecord(profile) && typeof profile.id === "string" && typeof profile.title === "string",
-        ),
-    )
-  );
-}
-function isCatalogPresetSuccess(value: unknown): value is CatalogPresetSuccess {
-  return (
-    isRendererRecord(value) &&
-    value.schema === "gui-catalog-preset/v1" &&
-    value.ok === true &&
-    typeof value.repoId === "string" &&
-    isRendererRecord(value.preset) &&
-    isRendererRecord(value.resolved) &&
-    Array.isArray(value.resolved.documents) &&
-    value.resolved.documents.every(
-      (row) =>
-        isRendererRecord(row) &&
-        typeof row.slot === "string" &&
-        typeof row.path === "string" &&
-        typeof row.body === "string" &&
-        typeof row.mediaType === "string",
-    )
-  );
-}
-function isCatalogRereadReceipt(value: unknown): value is CatalogRereadReceipt {
-  return (
-    isRendererRecord(value) &&
-    value.schema === "catalog-reread-receipt/v1" &&
-    typeof value.ok === "boolean" &&
-    ["applied", "op_rejected"].includes(String(value.outcome)) &&
-    typeof value.operationId === "string" &&
-    typeof value.repoId === "string"
   );
 }
 

--- a/packages/kernel/src/domain/settings-closeout.ts
+++ b/packages/kernel/src/domain/settings-closeout.ts
@@ -1,4 +1,51 @@
 import { settingBlockValue } from "../layout/harness-settings.ts";
+import { setting } from "../layout/harness-settings.ts";
+
+function replaceScalar(body: string, indent: string, key: string, value: string): string {
+  const line = new RegExp(`^(${indent}${key}:[^\\S\\r\\n]*)[^#\\r\\n]*?([^\\S\\r\\n]*(?:#[^\\r\\n]*)?)$`, "mu");
+  if (!line.test(body)) throw new Error(`Missing ${key} in harness.yaml settings facet.`);
+  return body.replace(line, `$1${value}$2`);
+}
+
+export function replaceDefaultedScalar(
+  body: string,
+  indent: string,
+  key: string,
+  value: string,
+  fallback: string,
+): string {
+  if (setting(body, key) === undefined && value === fallback) return body;
+  return replaceScalar(body, indent, key, value);
+}
+
+export function replaceOptionalDefaultedScalar(
+  body: string,
+  indent: string,
+  key: string,
+  value: string,
+  fallback: string,
+): string {
+  if (setting(body, key) !== undefined) return replaceScalar(body, indent, key, value);
+  if (value === fallback) return body;
+  const header = /^settings:[^\r\n]*(?:\r?\n|$)/mu;
+  if (!header.test(body)) throw new Error("Missing settings block in harness.yaml.");
+  return body.replace(header, (match) => `${match}${indent}${key}: ${value}\n`);
+}
+
+export function replaceDefaultedBlockScalar(
+  body: string,
+  block: string,
+  key: string,
+  value: string,
+  fallback: string,
+): string {
+  if (settingBlockValue(body, block, key) === undefined && value === fallback) return body;
+  const section = new RegExp(`(^  ${block}:[^\\S\\r\\n]*(?:\\r?\\n))((?:    [^\\r\\n]*(?:\\r?\\n|$))*)`, "mu");
+  const match = section.exec(body);
+  if (!match) throw new Error(`Missing ${block} block in harness.yaml settings facet.`);
+  const replaced = replaceScalar(match[2]!, "    ", key, value);
+  return `${body.slice(0, match.index)}${match[1]}${replaced}${body.slice(match.index + match[0].length)}`;
+}
 
 export const closeoutProfiles = ["standard", "strict"] as const;
 export type CloseoutProfile = (typeof closeoutProfiles)[number];

--- a/packages/kernel/src/domain/settings.ts
+++ b/packages/kernel/src/domain/settings.ts
@@ -1,4 +1,9 @@
 import { setting, settingBlockValue } from "../layout/harness-settings.ts";
+import {
+  replaceDefaultedBlockScalar,
+  replaceDefaultedScalar,
+  replaceOptionalDefaultedScalar,
+} from "./settings-closeout.ts";
 import type { EntityDocumentJsonSchema } from "./entity-json-schema.ts";
 import { validateEntityJsonSchema } from "./entity-json-schema.ts";
 import {
@@ -538,48 +543,4 @@ function removeLegacyLocale(body: string): string {
 
 export function validateRepositorySettings(value: unknown): readonly string[] {
   return validateEntityJsonSchema(SETTINGS_REPOSITORY_V1_SCHEMA, value, "repository settings");
-}
-
-function replaceScalar(body: string, indent: string, key: string, value: string): string {
-  const line = new RegExp(`^(${indent}${key}:[^\\S\\r\\n]*)[^#\\r\\n]*?([^\\S\\r\\n]*(?:#[^\\r\\n]*)?)$`, "mu");
-  if (!line.test(body)) throw new Error(`Missing ${key} in harness.yaml settings facet.`);
-  return body.replace(line, `$1${value}$2`);
-}
-
-function replaceDefaultedScalar(body: string, indent: string, key: string, value: string, fallback: string): string {
-  if (setting(body, key) === undefined && value === fallback) return body;
-  return replaceScalar(body, indent, key, value);
-}
-
-function replaceOptionalDefaultedScalar(
-  body: string,
-  indent: string,
-  key: string,
-  value: string,
-  fallback: string,
-): string {
-  if (setting(body, key) !== undefined) return replaceScalar(body, indent, key, value);
-  if (value === fallback) return body;
-  const header = /^settings:[^\r\n]*(?:\r?\n|$)/mu;
-  if (!header.test(body)) throw new Error("Missing settings block in harness.yaml.");
-  return body.replace(header, (match) => `${match}${indent}${key}: ${value}\n`);
-}
-
-function replaceBlockScalar(body: string, block: string, key: string, value: string): string {
-  const section = new RegExp(`(^  ${block}:[^\\S\\r\\n]*(?:\\r?\\n))((?:    [^\\r\\n]*(?:\\r?\\n|$))*)`, "mu");
-  const match = section.exec(body);
-  if (!match) throw new Error(`Missing ${block} block in harness.yaml settings facet.`);
-  const replaced = replaceScalar(match[2]!, "    ", key, value);
-  return `${body.slice(0, match.index)}${match[1]}${replaced}${body.slice(match.index + match[0].length)}`;
-}
-
-function replaceDefaultedBlockScalar(
-  body: string,
-  block: string,
-  key: string,
-  value: string,
-  fallback: string,
-): string {
-  if (settingBlockValue(body, block, key) === undefined && value === fallback) return body;
-  return replaceBlockScalar(body, block, key, value);
 }


### PR DESCRIPTION
# English

## Summary

File-budget headroom, three of four planned splits. `repo-cell-api.ts` (1075 → 1035 lines) hands its agenda and task-dispatch payload admission to the new `repo-cell-read-payloads.ts`; `api-client.ts` (950 → 881) hands catalog response decoding to the new `api-client-catalog.ts`; `settings.ts` (590 → 546) moves its YAML scalar replacement helpers into the existing YAML facet module `settings-closeout.ts`. Each split is one commit and moves one responsibility, so the three oversized files regain headroom under their shrink-only ceilings without a behaviour change. The fourth split (the task-completion result validator) is not in this PR: every approved destination inside the daemon protocol modules forms an ESM initialisation cycle through `daemon-protocol-gui-types.ts` (a direct test hit `ReferenceError: Cannot access 'shape' before initialization`), and a separate module is rejected by the thin-CLI, daemon-transport and offline-maintenance import closures. CEO ruling: leave that validator where it is; moving lines is not a complexity reduction, and the closures are not changed for it.

## Architectural Justification

A file is split along an existing responsibility seam into a module that already has, or now gets, a single reason to change; helpers that belong to an existing facet join that facet instead of founding a new module.

## What Changed

- `packages/daemon/src/repo-cell-api.ts` (+3/-40) → `packages/daemon/src/repo-cell-read-payloads.ts` (new, +44): agenda and task-dispatch read payload admission.
- `packages/gui/src/renderer/api-client.ts` (+1/-70) → `packages/gui/src/renderer/api-client-catalog.ts` (new, +78): catalog response decoding.
- `packages/kernel/src/domain/settings.ts` (+5/-44) → `packages/kernel/src/domain/settings-closeout.ts` (+47): YAML scalar replacement helpers join the existing YAML facet module.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +178/-154 production (net +24: three responsibility splits move 154 lines out of `repo-cell-api.ts`, `api-client.ts` and `settings.ts` into one new daemon module, one new GUI module and the existing kernel YAML facet module; the extra lines are the module headers, imports and exports of the new homes).

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root and on the branch head: every operation and metric identical, G38 passes on both. Pure code motion; no read or write path changes.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_f511d63b2bfc2636b23151ccb2 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/file-budget-headroom`
- Public scope: Three file splits by responsibility (daemon read payload admission, GUI catalog decoding, kernel settings YAML helpers). No public API, protocol, persistence or projection change.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: The task-completion result validator split (fourth group): blocked by ESM initialisation cycles in all three approved destinations and by the import closures for a separate module; left in place by CEO ruling, no follow-up task (the file passes `check-file-complexity` as is). No allowlist or closure changes.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `7777e0e20`
- Branch merge-base with `origin/main`: `7777e0e20`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/file-budget-headroom`
- Private evidence commit/path: task_f511d63b2bfc2636b23151ccb2 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker (Codex Terra, report `artifacts/report.md`): `node tools/run-node-tests.mjs --file packages/daemon/test/task-query-read.test.ts --file packages/kernel/test/contracts/settings-action.test.ts` 28/28; isolated Ubuntu `gui-catalog.integration` 5/5 and `repo-cell-settings.integration` 1/1; `npm run test:gui` 89 files / 1002 tests; `node tools/run-manifest-gates.mjs --changed origin/main` pass (lint, CLI structure, import boundaries, kernel dead exports, duplicate definitions, implementation contracts); `node tools/check-file-complexity.mjs` pass. CEO ground-truth on head 73374f32a (base 7777e0e20): `git diff --numstat origin/main..HEAD` matches the table above (+178/-154); all three commits authored and committed by ZeyuLi; G1 probe identical to base (see below); G33 production-delta pass with the declared delta.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; read the three diffs, confirmed each commit moves one responsibility with no logic edits, ruled the fourth split out rather than widening the import closures, and ran the numstat, authorship and G1 checks listed under verification..
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Pure code motion; the only risk is an import that changed module (all covered by typecheck and the manifest import-boundary gate). Residual: `repo-cell-api.ts` (1035) and `api-client.ts` (881) are still above 600 and stay under shrink-only ceilings; the next split in each is a separate task.

## References

- Task: task_f511d63b2bfc2636b23151ccb2

---

# 中文

## 概要

文件预算余量，四组拆分做了三组。`repo-cell-api.ts`（1075 → 1035 行）把 agenda 与 task-dispatch 读载荷准入交给新建的 `repo-cell-read-payloads.ts`；`api-client.ts`（950 → 881）把 catalog 响应解码交给新建的 `api-client-catalog.ts`；`settings.ts`（590 → 546）把 YAML 标量替换辅助函数并入已有的 YAML facet 模块 `settings-closeout.ts`。每组一个 commit、只搬一个职责，三个超限文件在各自只减不增的天花板下重新有了余量，行为不变。第四组（task-completion 结果校验器）不在本 PR：daemon 协议模块里三个获准落点都会经 `daemon-protocol-gui-types.ts` 形成 ESM 初始化循环（实测 `ReferenceError: Cannot access 'shape' before initialization`），独立模块又被 thin-CLI、daemon-transport、offline-maintenance 三条 import 闭包拒绝。CEO 裁决：该校验器原地不动；搬行数不算降复杂度，不为它改闭包。

## 架构辩护

沿既有职责缝拆文件，落点是已有（或从此只有）单一变更理由的模块；属于既有 facet 的辅助函数并入该 facet，而不是另立新模块。

## 改动内容

- `packages/daemon/src/repo-cell-api.ts`（+3/-40）→ `packages/daemon/src/repo-cell-read-payloads.ts`（新，+44）：agenda 与 task-dispatch 读载荷准入。
- `packages/gui/src/renderer/api-client.ts`（+1/-70）→ `packages/gui/src/renderer/api-client-catalog.ts`（新，+78）：catalog 响应解码。
- `packages/kernel/src/domain/settings.ts`（+5/-44）→ `packages/kernel/src/domain/settings-closeout.ts`（+47）：YAML 标量替换辅助函数并入已有 YAML facet 模块。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+178/-154 production (net +24: three responsibility splits move 154 lines out of `repo-cell-api.ts`, `api-client.ts` and `settings.ts` into one new daemon module, one new GUI module and the existing kernel YAML facet module; the extra lines are the module headers, imports and exports of the new homes)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_f511d63b2bfc2636b23151ccb2（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/file-budget-headroom`
- 公开范围：按职责做三处文件拆分（daemon 读载荷准入、GUI catalog 解码、kernel settings YAML 辅助）。不改公开 API、协议、持久化与投影。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：task-completion 结果校验器拆分（第四组）：三个获准落点均有 ESM 初始化循环、独立模块被 import 闭包拒绝；CEO 裁决原地保留，不立后续任务（该文件现状通过 `check-file-complexity`）。不改 allowlist 与闭包。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`7777e0e20`
- 分支与 `origin/main` 的 merge-base：`7777e0e20`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/file-budget-headroom`
- 私有证据路径：task_f511d63b2bfc2636b23151ccb2 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Worker（Codex Terra，报告 `artifacts/report.md`）：`node tools/run-node-tests.mjs --file packages/daemon/test/task-query-read.test.ts --file packages/kernel/test/contracts/settings-action.test.ts` 28/28；Ubuntu 隔离 `gui-catalog.integration` 5/5、`repo-cell-settings.integration` 1/1；`npm run test:gui` 89 文件 / 1002 测试；`node tools/run-manifest-gates.mjs --changed origin/main` 通过（lint、CLI structure、import boundaries、kernel dead exports、duplicate definitions、implementation contracts）；`node tools/check-file-complexity.mjs` 通过。CEO 在 head 73374f32a（base 7777e0e20）核实：`git diff --numstat origin/main..HEAD` 与上表一致（+178/-154）；三个 commit 的作者与提交人均为 ZeyuLi；G1 探针与 base 完全一致（见下）；G33 production-delta 按声明值通过。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；通读三份 diff，确认每个 commit 只搬一个职责、无逻辑改动；裁决第四组不做而不是放宽 import 闭包；跑了 verification 里列的 numstat、作者与 G1 核对。。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 纯代码搬移；唯一风险是换了模块的 import（typecheck 与 manifest import-boundary 门覆盖）。残留：`repo-cell-api.ts`（1035）与 `api-client.ts`（881）仍在 600 以上、处于只减不增天花板下，各自的下一刀是单独任务。

## 参考

- 任务：task_f511d63b2bfc2636b23151ccb2

