### PR TITLE
feat: bundle the default closeout reviewer so a fresh repository can complete a task without installing an Agent

### DIFF
--- a/docs-release/start/en/01-install.md
+++ b/docs-release/start/en/01-install.md
@@ -69,8 +69,9 @@ The first-run wizard uses three steps:
    acquired before Electron started.
 2. In **Provider**, add a detected Claude, Codex, or AGY installation and choose its model. You may continue and
    configure it later.
-3. In **Agent · Squad**, create an Agent declaration and set its runtime preferences. Choose **Finish setup** when the
-   GUI is ready for normal use.
+3. In **Agent · Squad**, optionally create repository-specific Agents and Squads. The closeout reviewer is bundled and
+   uses a compatible configured runtime instance and that instance's default model. Installing an Agent with the same
+   id pins a repository-local override. Choose **Finish setup** when the GUI is ready for normal use.
 
 Harness Anything writes daemon state under `~/.harness` by default. Repository ledger files stay in the selected
 repository. No application server is used.

--- a/docs-release/start/zh/01-install.md
+++ b/docs-release/start/zh/01-install.md
@@ -66,7 +66,9 @@ canonical-only CLI autostart 路径取得 default daemon，再 detached 启动 E
 1. 选择 git 仓库，设置仓库 ID，并填写写入本地账本的 owner 身份。点击**初始化仓库**；应用会创建
    `harness/`，并把仓库注册到 CLI 在 Electron 启动前取得的 daemon。
 2. 在 **Provider** 工作区添加检测到的 Claude、Codex 或 AGY 安装并选择模型；也可以先继续，以后再设置。
-3. 在 **Agent · 含 Squad** 工作区创建 Agent 声明并设置 runtime 偏好。GUI 可正常使用后点击**完成设置**。
+3. 在 **Agent · 含 Squad** 工作区可选创建仓库专用的 Agent 与 Squad。收口评审 Agent 已随产品内置，会匹配
+   已配置的兼容运行时实例并使用该实例的默认模型；安装同 id Agent 可钉住仓库本地覆写。GUI 可正常使用后
+   点击**完成设置**。
 
 Harness Anything 默认把 daemon 状态写到 `~/.harness`。仓库账本留在所选仓库内；整个流程不使用应用服务器。
 

--- a/packages/cli/test/daemon-multi-repo-lifecycle-cli-init-bootstrap.test.ts
+++ b/packages/cli/test/daemon-multi-repo-lifecycle-cli-init-bootstrap.test.ts
@@ -70,8 +70,10 @@ test("REQ-CTX-01..10 empty init publishes the canonical scaffold, authority pari
     for (const kind of ["agent", "squad"]) {
       const catalog = JSON.parse(String(run(fixture.repo, fixture.userRoot, [kind, "list"]).evidence));
       assert.deepEqual(catalog[`${kind}s`], []);
-      assert.match(String(initialized.next), new RegExp(`${kind} install --source`));
     }
+    assert.match(String(initialized.next), /closeout-reviewer Agent is bundled/u);
+    assert.match(String(initialized.next), /agent install --source.*optional override/u);
+    assert.match(String(initialized.next), /squad install --source/u);
     const plan = initialized.plan as {
       digest: string;
       baseScaffoldDigest: string;

--- a/packages/daemon/src/agent-declaration-resolution.ts
+++ b/packages/daemon/src/agent-declaration-resolution.ts
@@ -1,0 +1,38 @@
+import { readBundledAgentDeclaration } from "../../preset/src/index.ts";
+import {
+  entitySlug,
+  openEntityStore,
+  parseAgentDeclarationV1,
+  type AgentDeclarationV1,
+  type EntityStore,
+} from "../../kernel/src/index.ts";
+
+export interface AgentDeclarationResolution {
+  readonly declaration: AgentDeclarationV1;
+  readonly layer: "installed" | "bundled";
+}
+
+export function readAgentDeclarationResolution(input: {
+  readonly rootDir: string;
+  readonly agentId: string;
+  readonly entityStore?: EntityStore;
+}): AgentDeclarationResolution | null {
+  if (!entitySlug(input.agentId)) return null;
+  const stored = (input.entityStore ?? openEntityStore(input.rootDir)).get("agent", input.agentId);
+  if (stored) return { declaration: parseAgentDeclarationV1(stored.value), layer: "installed" };
+  const bundled = readBundledAgentDeclaration(input.agentId);
+  return bundled ? { declaration: bundled, layer: "bundled" } : null;
+}
+
+export function readAgentDeclaration(input: {
+  readonly rootDir: string;
+  readonly agentId: string;
+  readonly entityStore?: EntityStore;
+}): AgentDeclarationV1 {
+  const resolved = readAgentDeclarationResolution(input);
+  if (!resolved)
+    throw Object.assign(new Error(`${input.agentId} is not an installed or bundled agent.`), {
+      code: "agent_not_found",
+    });
+  return resolved.declaration;
+}

--- a/packages/daemon/src/agent-entities.ts
+++ b/packages/daemon/src/agent-entities.ts
@@ -8,6 +8,9 @@ import {
   type EntityStore,
   type TaskProjection,
 } from "../../kernel/src/index.ts";
+import { readAgentDeclaration } from "./agent-declaration-resolution.ts";
+
+export { readAgentDeclaration, readAgentDeclarationResolution } from "./agent-declaration-resolution.ts";
 import {
   entitySlug,
   parseAgentDeclarationV1,
@@ -328,13 +331,6 @@ function readyEntityValue(
   const entity = projection.getEntity(kind, id);
   if (entity === null) throw entityError(`${kind}_not_found`, `${id} is not an installed ${kind}.`);
   return entity.value;
-}
-export function readAgentDeclaration(input: {
-  readonly rootDir: string;
-  readonly agentId: string;
-  readonly entityStore?: EntityStore;
-}): AgentDeclarationV1 {
-  return parseAgentDeclarationV1(readStoredDeclaration(input.rootDir, "agent", input.agentId, input.entityStore));
 }
 export function readSquadDeclaration(input: {
   readonly rootDir: string;

--- a/packages/daemon/src/repo-bootstrap.ts
+++ b/packages/daemon/src/repo-bootstrap.ts
@@ -501,9 +501,9 @@ function jsonStringEnd(body: string, start: number): number {
 function initNext(rootDir: string, repoId: string, orphaned: boolean, maintenanceDegraded: string | null): string {
   return [
     `ha daemon repo register --repo-id ${repoId} --root ${JSON.stringify(rootDir)}; ha --root ${JSON.stringify(rootDir)} daemon status${orphaned ? " # Resolve orphaned scaffold documents through an explicit governance task; init will not delete or migrate them." : ""}${maintenanceDegraded ? ` # ${maintenanceDegraded}` : ""}`,
-    "Init does not install agents or squads. To populate an empty catalog:",
-    "Install Agent packages first, then a Squad package referencing those agents.",
-    `ha --root ${JSON.stringify(rootDir)} agent install --source <directory-containing-agent.json>`,
+    "The closeout-reviewer Agent is bundled. Configure a runtime instance to use automatic task completion review.",
+    "Agent install pins a repository-local override; install custom Agents before Squads that reference them.",
+    `ha --root ${JSON.stringify(rootDir)} agent install --source <directory-containing-agent.json> # optional override`,
     `ha --root ${JSON.stringify(rootDir)} squad install --source <directory-containing-squad.json>`,
   ].join("\n");
 }

--- a/packages/daemon/src/task-completion-review.ts
+++ b/packages/daemon/src/task-completion-review.ts
@@ -114,16 +114,21 @@ export async function dispatchCompletionReview(
       });
     if (authorizationDecision.outcome !== "allowed")
       throw cell.cellCodedError("authorization_denied", authorizationDecision.nextActions.join(" "));
-    // Already inside the center queue. Only launch admission is awaited; provider completion is not.
+    // Already inside the center queue. Only launch admission is awaited; provider completion is not. A cell
+    // without a runtime route (no ready instance, no sealed daemon route) stops at the review gate like a
+    // missing reviewer would; it must not surface as an indeterminate publication.
     try {
       await cell.runtimeSpawner.spawn(payload, { ...binding, authorizationDecision });
     } catch (error) {
       if (
         !(error instanceof Error) ||
         !("code" in error) ||
-        !["agent_runtime_unavailable", "agent_model_unavailable", "runtime_model_not_ready"].includes(
-          String(error.code),
-        )
+        ![
+          "agent_runtime_unavailable",
+          "agent_model_unavailable",
+          "runtime_model_not_ready",
+          "runtime_preconditions_unavailable",
+        ].includes(String(error.code))
       )
         throw error;
       return {

--- a/packages/daemon/src/task-completion-review.ts
+++ b/packages/daemon/src/task-completion-review.ts
@@ -8,7 +8,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { readSubmissionArtifact } from "./submission-artifacts.ts";
 import { isRuntimeEvent } from "./runtime-spawn-errors.ts";
-import { readAgentDeclaration } from "./agent-entities.ts";
+import { readAgentDeclarationResolution } from "./agent-entities.ts";
 import { authorizeRepoCellAction } from "./repo-cell-authorization.ts";
 import type { RepoCellOperationalContext } from "./repo-cell-action-context.ts";
 import type { RepoCellBinding, Snapshot } from "./repo-cell-types.ts";
@@ -53,24 +53,25 @@ export async function dispatchCompletionReview(
       `Review dispatch ${dispatchOpId} conflicts with another event.`,
     );
   if (!existing) {
-    // Installed declarations are canonical; a missing default never turns the executor into a reviewer.
+    // Repository-installed declarations shadow bundled product defaults; the executor never becomes the reviewer.
     const reviewerId = cell.settings.readRepository().defaultReviewer ?? "closeout-reviewer";
-    if (cell.projection.getEntity("agent", reviewerId) === null)
-      return stopped(
-        "ha agent install --source <closeout-reviewer-declaration-directory>",
-        `Install an independent Agent declaration with id ${reviewerId}, or select an installed reviewer with ` +
-          "ha settings update --default-reviewer <agent-id>, then retry completion.",
-      );
-    const agent = readAgentDeclaration({
+    const resolved = readAgentDeclarationResolution({
       rootDir: cell.rootDir,
       agentId: reviewerId,
       entityStore: createEntityStore(cell.store),
     });
-    if (!agent.model)
+    if (!resolved)
+      return stopped(
+        "ha agent install --source <closeout-reviewer-declaration-directory>",
+        `Reviewer ${reviewerId} is not bundled or installed. Install a repository override, or select an available ` +
+          "reviewer with ha settings update --default-reviewer <agent-id>, then retry completion.",
+      );
+    const { declaration: agent, layer } = resolved;
+    if (layer === "installed" && !agent.model)
       return stopped(
         "ha agent install --source <closeout-reviewer-declaration-directory>",
         `Declare an explicit model for reviewer ${reviewerId}, then retry completion. ` +
-          "Automatic review must not select an ambient instance's default model.",
+          "Installed reviewer overrides must not select an instance default model.",
       );
     const report = `${packagePath}/artifacts/reports/${dispatchId}.md`,
       packet = `${packagePath}/artifacts/reports/${dispatchId}.json`,
@@ -128,8 +129,11 @@ export async function dispatchCompletionReview(
       return {
         ...stopped(
           "ha runtime instance list",
-          `Reviewer ${reviewerId} requires model ${agent.model}; configure a ready compatible instance, ` +
-            "then retry completion. The declared model is not replaced by an ambient default.",
+          layer === "bundled"
+            ? `Bundled reviewer ${reviewerId} needs a ready ${agent.runtime_type} runtime instance; configure one, ` +
+                "then retry completion. Its configured default model will be used."
+            : `Reviewer ${reviewerId} requires model ${agent.model}; configure a ready compatible instance, ` +
+                "then retry completion. The declared model is not replaced by an instance default.",
         ),
         diagnostic: { kind: "failure", code: String(error.code) },
         rejectionExplanation: error.message,

--- a/packages/daemon/test/agent-declaration-resolution.test.ts
+++ b/packages/daemon/test/agent-declaration-resolution.test.ts
@@ -1,0 +1,71 @@
+// harness-test-tier: integration
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentDeclarationV1, EntityStore } from "../../kernel/src/index.ts";
+import { readAgentDeclaration, readAgentDeclarationResolution } from "../src/agent-declaration-resolution.ts";
+
+const installed: AgentDeclarationV1 = {
+  schema: "agent-declaration/v1",
+  id: "closeout-reviewer",
+  name: "Repository reviewer",
+  instructions: "Review precisely.",
+  runtime_type: "codex",
+  model: "review-model",
+  role: "worker",
+};
+
+function entityStore(declaration: AgentDeclarationV1 | null): EntityStore {
+  return {
+    upsert: () => {
+      throw new Error("unused");
+    },
+    get: <T>() =>
+      declaration
+        ? ({
+            kind: "agent",
+            id: declaration.id,
+            value: declaration as T,
+            documentPath: "harness/agents/closeout-reviewer.json",
+            documentSha256: "fixture",
+            workspaceRevision: 1,
+          } as const)
+        : null,
+    list: () => [],
+  };
+}
+
+test("installed Agent declarations shadow the bundled product declaration", () => {
+  const bundled = readAgentDeclarationResolution({
+    rootDir: "/unused",
+    agentId: "closeout-reviewer",
+    entityStore: entityStore(null),
+  });
+  assert.ok(bundled);
+  assert.equal(bundled.layer, "bundled");
+  assert.equal(bundled.declaration.model, undefined);
+
+  const resolved = readAgentDeclarationResolution({
+    rootDir: "/unused",
+    agentId: "closeout-reviewer",
+    entityStore: entityStore(installed),
+  });
+  assert.ok(resolved);
+  assert.equal(resolved.layer, "installed");
+  assert.equal(resolved.declaration.name, "Repository reviewer");
+  assert.equal(
+    readAgentDeclaration({ rootDir: "/unused", agentId: "closeout-reviewer", entityStore: entityStore(installed) })
+      .model,
+    "review-model",
+  );
+});
+
+test("unknown and invalid Agent ids resolve as absent", () => {
+  assert.equal(
+    readAgentDeclarationResolution({ rootDir: "/unused", agentId: "not-bundled", entityStore: entityStore(null) }),
+    null,
+  );
+  assert.equal(
+    readAgentDeclarationResolution({ rootDir: "/unused", agentId: "../invalid", entityStore: entityStore(null) }),
+    null,
+  );
+});

--- a/packages/daemon/test/task-completion-review.integration.test.ts
+++ b/packages/daemon/test/task-completion-review.integration.test.ts
@@ -65,7 +65,7 @@ function instance(instanceId: string): RuntimeInstanceSummary {
 function git(root: string, ...args: string[]): string {
   return execFileSync("git", ["-C", root, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
 }
-async function fixture(failProvider = false, available = true, artifactDelivery = false) {
+async function fixture(failProvider = false, available = true, artifactDelivery = false, noInstances = false) {
   const root = mkdtempSync(path.join(tmpdir(), "ha-completion-review-")),
     repoId = workspaceId("completion-review");
   git(root, "init", "-q");
@@ -76,7 +76,7 @@ async function fixture(failProvider = false, available = true, artifactDelivery 
   writeFileSync(path.join(root, "README.md"), "# Reviewed delivery\n");
   git(root, "add", "README.md");
   git(root, "commit", "-qm", "docs: fixture delivery");
-  const launches: { prompt: string; instanceId: string }[] = [];
+  const launches: { prompt: string; instanceId: string; model: string }[] = [];
   let instancesAvailable = available;
   const open = () =>
     openRepoCell({
@@ -88,10 +88,13 @@ async function fixture(failProvider = false, available = true, artifactDelivery 
         daemonId: "fixture",
         endpoint: path.join(root, "user.sock"),
       },
-      runtimeInstances: () => [
-        { ...instance("ambient-first"), models: ["flash-model"], defaultModel: "flash-model" },
-        ...(instancesAvailable ? [instance("review-first"), instance("review-second")] : []),
-      ],
+      runtimeInstances: () =>
+        noInstances
+          ? []
+          : [
+              { ...instance("ambient-first"), models: ["flash-model"], defaultModel: "flash-model" },
+              ...(instancesAvailable ? [instance("review-first"), instance("review-second")] : []),
+            ],
       prepareRuntimeLaunch: (instanceId, request) => ({
         definition: {
           schema: "agent-definition-snapshot/v1",
@@ -100,7 +103,7 @@ async function fixture(failProvider = false, available = true, artifactDelivery 
           installationId: installation.installationId,
           kindId: "codex",
           providerId: "openai",
-          model: "review-model",
+          model: request.model ?? (instanceId === "ambient-first" ? "flash-model" : "review-model"),
           reasoningEffort: null,
           fast: false,
           baseUrl: null,
@@ -114,7 +117,11 @@ async function fixture(failProvider = false, available = true, artifactDelivery 
         prompt: request.prompt,
       }),
       runtimeLaunch: (prepared): RuntimeProcess => {
-        launches.push({ prompt: prepared.prompt, instanceId: prepared.definition.instanceId });
+        launches.push({
+          prompt: prepared.prompt,
+          instanceId: prepared.definition.instanceId,
+          model: prepared.definition.model,
+        });
         let output: ((chunk: string) => void) | undefined;
         return {
           pid: 987650 + launches.length,
@@ -263,15 +270,11 @@ async function fixture(failProvider = false, available = true, artifactDelivery 
 }
 
 test(
-  "completion selects install guidance, reuses the cut dispatch after a lost response/reopen, and requires later owner consent",
+  "completion uses an installed override, reuses the cut dispatch after a lost response/reopen, and requires later owner consent",
   { timeout: 20_000 },
   async () => {
     const f = await fixture();
     try {
-      const missing = await f.complete(true);
-      assert.equal(missing.code, "review_missing", JSON.stringify(missing));
-      assert.match(JSON.stringify((missing as Record<string, unknown>).next), /ha agent install --source/u);
-      assert.equal(f.launches.length, 0);
       await f.install();
       const configured = await f.run({ kind: "settings-update", defaultReviewer: "selected-reviewer" });
       assert.equal(configured.outcome, "applied", JSON.stringify(configured));
@@ -328,6 +331,38 @@ test(
     }
   },
 );
+
+test("completion dispatches the bundled reviewer with no installed declaration and accepts its review", async () => {
+  const f = await fixture();
+  try {
+    const result = (await f.complete()) as Record<string, unknown>;
+    assert.equal(result.code, "review_missing", JSON.stringify(result));
+    assert.equal(f.launches.length, 1);
+    assert.equal(f.launches[0]!.instanceId, "ambient-first");
+    assert.equal(f.launches[0]!.model, "flash-model");
+    assert.match(f.launches[0]!.prompt, /Independently review the submitted execution/u);
+    const reviewed = await f.review(String(result.runtimeSessionId), "review-bundled");
+    assert.equal(reviewed.outcome, "applied", JSON.stringify(reviewed));
+    const completed = await f.complete(true);
+    assert.equal(completed.outcome, "applied", JSON.stringify(completed));
+  } finally {
+    await f.close();
+  }
+});
+
+test("bundled reviewer without a ready instance returns configuration guidance", async () => {
+  const f = await fixture(false, false, false, true);
+  try {
+    f.disableInstances();
+    const result = await f.complete();
+    assert.equal(result.code, "review_missing", JSON.stringify(result));
+    assert.match(JSON.stringify((result as Record<string, unknown>).next), /configured default model/u);
+    assert.deepEqual(result.diagnostic, { kind: "failure", code: "agent_runtime_unavailable" });
+    assert.equal(f.launches.length, 0);
+  } finally {
+    await f.close();
+  }
+});
 
 test("completion requires a declared reviewer model instead of selecting the ambient default", async () => {
   const f = await fixture();

--- a/packages/preset/assets/software-coding/agents/closeout-reviewer.json
+++ b/packages/preset/assets/software-coding/agents/closeout-reviewer.json
@@ -1,0 +1,8 @@
+{
+  "schema": "agent-declaration/v1",
+  "id": "closeout-reviewer",
+  "name": "Closeout Reviewer",
+  "instructions": "Independently review the submitted execution against its task contract and pinned delivery evidence. Verify claims directly, record approved or changes_requested through the provided review command, and never submit, consent to, or complete the task.",
+  "runtime_type": "any",
+  "role": "worker"
+}

--- a/packages/preset/src/bundled-agent-declarations.ts
+++ b/packages/preset/src/bundled-agent-declarations.ts
@@ -1,0 +1,15 @@
+import { existsSync, lstatSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { entitySlug, parseAgentDeclarationV1, type AgentDeclarationV1 } from "../../kernel/src/index.ts";
+
+const bundledAgentRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../assets/software-coding/agents");
+
+export function readBundledAgentDeclaration(agentId: string): AgentDeclarationV1 | null {
+  if (!entitySlug(agentId)) return null;
+  const source = path.join(bundledAgentRoot, `${agentId}.json`);
+  if (!existsSync(source) || !lstatSync(source).isFile() || lstatSync(source).isSymbolicLink()) return null;
+  const declaration = parseAgentDeclarationV1(JSON.parse(readFileSync(source, "utf8")));
+  if (declaration.id !== agentId) throw new Error(`Bundled Agent file ${agentId}.json declares id ${declaration.id}.`);
+  return declaration;
+}

--- a/packages/preset/src/index.ts
+++ b/packages/preset/src/index.ts
@@ -36,3 +36,4 @@ export { acceptBuiltinVerticalScriptPlan, prepareBuiltinVerticalScriptExecution 
 export type { PreparedBuiltinVerticalScript } from "./vertical-script.ts";
 export { listGovernanceScaffoldOverlays } from "./scaffold-overlay.ts";
 export type { GovernanceScaffoldOverlays } from "./scaffold-overlay.ts";
+export { readBundledAgentDeclaration } from "./bundled-agent-declarations.ts";

--- a/packages/preset/test/preset-resolver-bundled-catalog.test.ts
+++ b/packages/preset/test/preset-resolver-bundled-catalog.test.ts
@@ -5,12 +5,21 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { makeTaskEventStore, sha256Text } from "../../kernel/src/index.ts";
-import { compileTaskBootstrap } from "../src/index.ts";
+import { compileTaskBootstrap, readBundledAgentDeclaration } from "../src/index.ts";
 import { createRuntime, presetDocumentBody } from "../src/preset-resolver.ts";
 import { effectiveCatalog } from "../src/preset-catalog.ts";
 import { defaultBundled, key } from "../src/preset-resolver-common.ts";
 
 import { git } from "./preset-resolver.fixtures.ts";
+test("bundled closeout reviewer is machine-independent and leaves instance model selection open", () => {
+  const reviewer = readBundledAgentDeclaration("closeout-reviewer");
+  assert.ok(reviewer);
+  assert.equal(reviewer.runtime_type, "any");
+  assert.equal(reviewer.instance, undefined);
+  assert.equal(reviewer.model, undefined);
+  assert.doesNotMatch(reviewer.instructions, /(?:\/Users\/|harness\/tasks\/|\\Users\\)/u);
+  assert.equal(readBundledAgentDeclaration("not-bundled"), null);
+});
 test("bundled candidates are decoded once per process while user packages stay live", () => {
   const root = mkdtempSync(path.join(tmpdir(), "ha-preset-catalog-cache-")),
     userRoot = path.join(root, "user");


### PR DESCRIPTION
# English

## Summary

A fresh repository can complete a task without first installing an Agent. `task complete` defaults its reviewer to `closeout-reviewer`; until now that id had to be installed by hand, so `ha init` on a new machine ended in `ha agent install …` before the first closeout. The `closeout-reviewer` declaration now ships inside the `preset` package (`packages/preset/assets/software-coding/agents/closeout-reviewer.json`, machine-independent: no instance, no model). Resolution is installed-first, bundled-second, through a nullable lookup (`readAgentDeclarationResolution` returns `{declaration, layer} | null`); a repository-installed declaration with the same id shadows the bundled one. Model rule: an installed override must still declare an explicit model (unchanged); the bundled reviewer runs on the configured instance's default model, since the product ships no model binding. Only `closeout-reviewer` is bundled: it is the one Agent id a product state machine selects implicitly. The default worker, implementer/scanner/commander families and squad recipes stay installable packs. Init guidance and the bilingual install docs say the reviewer is bundled and that `agent install` pins an optional override. CEO ruling applied: the installed→bundled step is a nullable read, not a caught `agent_not_found`, so no fallback-boundary allowlist entry was needed.

## Architectural Justification

Product defaults ship as data inside the package that owns presets, and the daemon resolves an Agent id through one nullable lookup whose layers are ordered installed → bundled; absence is a value, not an exception to catch.

## What Changed

- `packages/preset/assets/software-coding/agents/closeout-reviewer.json` (new, 8): bundled declaration (`runtime_type: any`, `role: worker`, no instance/model).
- `packages/preset/src/bundled-agent-declarations.ts` (new, +15) + `index.ts` (+1): `readBundledAgentDeclaration(agentId)` reads `<preset>/assets/software-coding/agents/<id>.json` (slug-checked, regular file only, id must match) and parses it with the kernel's declaration parser.
- `packages/daemon/src/agent-declaration-resolution.ts` (new, +38): `readAgentDeclarationResolution` (installed store first, bundled second, `null` for ordinary absence) and the throwing `readAgentDeclaration` on top of it; `agent-entities.ts` (+3/-7) re-exports both and drops its old installed-only body.
- `packages/daemon/src/task-completion-review.ts` (+17/-13): completion review resolves the reviewer through the nullable lookup; `stopped` messages distinguish "not bundled or installed" from "installed override without a model" and from "no ready instance" (bundled: uses the instance default model; installed: declared model is required).
- `packages/daemon/src/repo-bootstrap.ts` (+3/-3): init next-steps text.
- `docs-release/start/{en,zh}/01-install.md`: first-run guidance.
- Tests: new `agent-declaration-resolution.test.ts` (installed shadows bundled, unknown id → null), `task-completion-review.integration.test.ts` (+48/-13: zero-installed bundled path through dispatch/review/consent/complete, installed override rule, no-instance guidance), `preset-resolver-bundled-catalog.test.ts` (bundled file publication, machine-independence), CLI init bootstrap receipt assertions.
- `packages/daemon/src/task-completion-review.ts` (second commit f2c80c3e5, +5/-1): `runtime_preconditions_unavailable` joins the no-runtime codes that stop at the review gate. Found by CI: with the reviewer bundled, `json-rpc-protocol.test.ts` (an in-process cell with no sealed daemon route) reached the spawn step and the thrown code escaped the facade as an `applied / publication_indeterminate` receipt instead of `review_missing`.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +86/-27 production (net +59: one bundled declaration file, a 15-line package-relative reader in `preset`, a 38-line nullable resolution module in `daemon`, one more no-runtime code in the completion-review stop list; the installed-only guard, its stop message and the old `readAgentDeclaration` body are deleted).

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root and on the branch head: every operation and metric identical, G38 passes on both. The probes never reach completion review; the evidence for this change is the completion integration test (zero installed agents → bundled reviewer dispatched, reviewed, consented, completed).

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_7d7cc7576fbcd6e5297bdfbd94 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/bundled-default-agents`
- Public scope: Bundled default `closeout-reviewer` declaration and installed-first/bundled-second Agent resolution in completion review; init and install-doc wording. No protocol, persistence, projection or gate change.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Bundling any other Agent or Squad (default worker, implementer/scanner/commander, squad recipes): not selected implicitly by a product state machine, stays in installable packs. A `ha agent inspect` view of the bundled layer, and an interactive end-to-end CLI walkthrough beyond the hermetic integration test, are not in this PR.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `97965fc9c`
- Branch merge-base with `origin/main`: `97965fc9c`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/bundled-default-agents`
- Private evidence commit/path: task_7d7cc7576fbcd6e5297bdfbd94 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker (Codex Sol, report `artifacts/report.md`, at the pre-rebase head ca36f8989 on 7777e0e20): `run-manifest-gates --changed origin/main` 9/9; isolated Ubuntu `agent-declaration-resolution` 2/2, `agent-entities` 21/21, `task-completion-review.integration` 9/9, `preset-resolver-bundled-catalog` 13/13, CLI `daemon-multi-repo-lifecycle-cli-init-bootstrap` 5/5; `check-fallback-boundaries` pass with no allowlist change; `check-file-complexity`, `line-density`, G33 pass. CEO ground-truth after rebasing onto 27345bf54 (head 49916ff53): fast `preset-resolver-bundled-catalog` + `agent-entities` + `agent-declaration-resolution` 36/36; isolated Ubuntu `task-completion-review.integration` pass (dispatcher exit 0, 30.6 s), CLI init bootstrap pass (dispatcher exit 0, 31.1 s); `git diff --numstat` +223/-41 total, production +77/-23 (G33 pass, unclassified 0); `check-pr-governance --base/--head` reports no protected surface; G1 identical to base; commit authored and committed by ZeyuLi. After the second commit: `json-rpc-protocol.test.ts` `milestone-closeout uses the normal completion facade…` passes locally (was the CI failure; whole file 48/48 before the fix except that one); isolated Ubuntu `task-completion-review.integration` re-run pass (dispatcher exit 0, 30.4 s); `check-fallback-boundaries` pass with no allowlist change; G33 pass (+86/-27). Branch rebased onto 97965fc9c before this push.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; read the resolution, completion-review and preset diffs; confirmed the installed→bundled step is a nullable read (no caught error, no allowlist), that installed declarations shadow the bundled one, that the explicit-model rule is kept for installed overrides and relaxed only for the bundled declaration; reviewed and approved the bundled instructions text; re-ran the fast and isolated tests after the rebase..
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- The bundled reviewer runs on the instance's default model, which the old code refused for any reviewer; the refusal is kept for installed overrides. A repository that already installed `closeout-reviewer` sees no change (installed shadows bundled). The bundled file is read from the preset package's own asset directory at runtime, so a packaging that drops `assets/software-coding/agents/` would surface as `Reviewer closeout-reviewer is not bundled or installed` rather than a crash.

## References

- Task: task_7d7cc7576fbcd6e5297bdfbd94

---

# 中文

## 概要

新仓库不用先装 Agent 就能完成任务。`task complete` 默认评审员是 `closeout-reviewer`，此前这个 id 必须手工安装，新机器 `ha init` 后第一次收口前都得先 `ha agent install …`。现在 `closeout-reviewer` 声明随 `preset` 包出厂（`packages/preset/assets/software-coding/agents/closeout-reviewer.json`，机器无关：不绑 instance、不绑 model）。解析顺序是已安装优先、出厂其次，走可空查询（`readAgentDeclarationResolution` 返回 `{declaration, layer} | null`）；仓库里安装了同 id 的声明就遮蔽出厂版。模型规则：安装的覆盖版仍必须显式声明 model（不变）；出厂评审员用所配 instance 的默认模型，因为产品不出厂任何模型绑定。只出厂 `closeout-reviewer`：它是唯一被产品状态机隐式选中的 Agent id；默认 worker、implementer/scanner/commander 家族与 squad 配方仍是可安装包。init 提示与中英安装文档改为「评审员已出厂，`agent install` 只是可选覆盖」。已按 CEO 裁决：已安装→出厂这一步是可空读取，不是捕获 `agent_not_found`，因此不需要 fallback-boundary allowlist 条目。

## 架构辩护

产品默认值作为数据随拥有 preset 的包出厂；daemon 通过一次可空查询解析 Agent id，层级顺序是已安装 → 出厂；缺席是一个值，不是要捕获的异常。

## 改动内容

- `packages/preset/assets/software-coding/agents/closeout-reviewer.json`（新，8 行）：出厂声明（`runtime_type: any`、`role: worker`，无 instance/model）。
- `packages/preset/src/bundled-agent-declarations.ts`（新，+15）+ `index.ts`（+1）：`readBundledAgentDeclaration(agentId)` 读 `<preset>/assets/software-coding/agents/<id>.json`（slug 校验、只认普通文件、id 必须一致），用 kernel 的声明解析器解析。
- `packages/daemon/src/agent-declaration-resolution.ts`（新，+38）：`readAgentDeclarationResolution`（先已安装 store、后出厂、普通缺席返回 `null`）及其上的抛错版 `readAgentDeclaration`；`agent-entities.ts`（+3/-7）转出口两者、删掉旧的只看已安装的实现。
- `packages/daemon/src/task-completion-review.ts`（+17/-13）：收口评审经可空查询解析评审员；`stopped` 提示区分「既未出厂也未安装」「安装覆盖版没声明 model」「没有就绪 instance」（出厂版：用 instance 默认模型；安装版：必须用声明的模型）。
- `packages/daemon/src/repo-bootstrap.ts`（+3/-3）：init 下一步文案。
- `docs-release/start/{en,zh}/01-install.md`：首次运行指引。
- 测试：新 `agent-declaration-resolution.test.ts`（已安装遮蔽出厂、未知 id → null）、`task-completion-review.integration.test.ts`（+48/-13：零安装走出厂评审员完成 dispatch/review/consent/complete、安装覆盖规则、无 instance 提示）、`preset-resolver-bundled-catalog.test.ts`（出厂文件发布、机器无关）、CLI init bootstrap 回执断言。
- `packages/daemon/src/task-completion-review.ts`（第二个 commit f2c80c3e5，+5/-1）：`runtime_preconditions_unavailable` 加入「没有可用 runtime」的停在评审门代码清单。CI 发现：评审员出厂后，`json-rpc-protocol.test.ts`（进程内 cell、没有 sealed daemon route）走到了 spawn 一步，抛出的错误码逃出门面变成 `applied / publication_indeterminate` 回执而不是 `review_missing`。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+86/-27 production (net +59: one bundled declaration file, a 15-line package-relative reader in `preset`, a 38-line nullable resolution module in `daemon`, one more no-runtime code in the completion-review stop list; the installed-only guard, its stop message and the old `readAgentDeclaration` body are deleted)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_7d7cc7576fbcd6e5297bdfbd94（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/bundled-default-agents`
- 公开范围：出厂默认 `closeout-reviewer` 声明与收口评审里「已安装优先、出厂其次」的 Agent 解析；init 与安装文档措辞。不改协议、持久化、投影与门。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：出厂其他 Agent/Squad（默认 worker、implementer/scanner/commander、squad 配方）：不被产品状态机隐式选中，仍留在可安装包。`ha agent inspect` 显示出厂层、以及 hermetic 集成测试之外的交互式 CLI 全程走查，不在本 PR。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`97965fc9c`
- 分支与 `origin/main` 的 merge-base：`97965fc9c`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/bundled-default-agents`
- 私有证据路径：task_7d7cc7576fbcd6e5297bdfbd94 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Worker（Codex Sol，报告 `artifacts/report.md`，rebase 前 head ca36f8989 基于 7777e0e20）：`run-manifest-gates --changed origin/main` 9/9；Ubuntu 隔离 `agent-declaration-resolution` 2/2、`agent-entities` 21/21、`task-completion-review.integration` 9/9、`preset-resolver-bundled-catalog` 13/13、CLI `daemon-multi-repo-lifecycle-cli-init-bootstrap` 5/5；`check-fallback-boundaries` 通过且无 allowlist 改动；`check-file-complexity`、`line-density`、G33 通过。CEO 在 rebase 到 27345bf54 后（head 49916ff53）核实：fast `preset-resolver-bundled-catalog` + `agent-entities` + `agent-declaration-resolution` 36/36；Ubuntu 隔离 `task-completion-review.integration` pass (dispatcher exit 0, 30.6 s)、CLI init bootstrap pass (dispatcher exit 0, 31.1 s)；`git diff --numstat` 合计 +223/-41、production +77/-23（G33 通过，unclassified 0）；`check-pr-governance --base/--head` 报无保护面；G1 与 base 一致；commit 作者与提交人为 ZeyuLi。 第二个 commit 后：`json-rpc-protocol.test.ts` 的 `milestone-closeout uses the normal completion facade…` 本地通过（即 CI 的那条红；修前整文件 48 条只红这一条）；Ubuntu 隔离 `task-completion-review.integration` 重跑 pass (dispatcher exit 0, 30.4 s)；`check-fallback-boundaries` 通过且无 allowlist 改动；G33 通过（+86/-27）。 本次 push 前分支已 rebase 到 97965fc9c。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；通读 resolution、completion-review 与 preset 三处 diff；确认已安装→出厂是可空读取（无捕获错误、无 allowlist）、已安装声明遮蔽出厂版、显式模型规则对安装覆盖版保留、只对出厂声明放宽；审阅并批准出厂 instructions 文本；rebase 后重跑 fast 与隔离测试。。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 出厂评审员使用 instance 默认模型，旧代码对任何评审员都拒绝这样做；对安装的覆盖版仍保留拒绝。已经安装了 `closeout-reviewer` 的仓库行为不变（已安装遮蔽出厂）。出厂文件在运行时从 preset 包自己的 assets 目录读取，打包时若丢了 `assets/software-coding/agents/`，表现为 `Reviewer closeout-reviewer is not bundled or installed` 提示而不是崩溃。

## 参考

- 任务：task_7d7cc7576fbcd6e5297bdfbd94

