### PR TITLE
fix(daemon): bound only the unterminated JSON line, not a chunk of complete frames

### DIFF
--- a/packages/daemon/src/transport/frame-codec.ts
+++ b/packages/daemon/src/transport/frame-codec.ts
@@ -20,15 +20,16 @@ export function createJsonLineFrameReader(): JsonLineFrameReader {
   return {
     push: (chunk) => {
       buffered += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      // Complete lines are frames regardless of how many arrived in one chunk; the cap bounds only the
+      // unterminated remainder, because buffering a newline-less writer forever would grow without bound.
+      const lines = buffered.split("\n");
+      buffered = lines.pop() ?? "";
       if (Buffer.byteLength(buffered) > JSON_LINE_FRAME_MAX_BYTES) {
-        // Drop the unterminated line and hand the caller an error it can fail the connection with;
-        // buffering a newline-less writer forever would grow without bound.
+        // Drop the unterminated line and hand the caller an error it can fail the connection with.
         const error = new Error(`JSON-RPC frame exceeds ${JSON_LINE_FRAME_MAX_BYTES} bytes`);
         buffered = "";
         return { frames: [], error };
       }
-      const lines = buffered.split("\n");
-      buffered = lines.pop() ?? "";
       return parseLines(lines);
     },
     flush: () => {

--- a/packages/daemon/test/frame-codec.contract.test.ts
+++ b/packages/daemon/test/frame-codec.contract.test.ts
@@ -23,6 +23,23 @@ test("an unterminated frame larger than the transport cap fails the read instead
   assert.deepEqual(next.frames, [request]);
 });
 
+test("one chunk carrying many complete frames whose total exceeds the cap parses every frame", () => {
+  const reader = createJsonLineFrameReader();
+  // The cap bounds an unterminated line, not a batch: a peer that coalesces many small frames into one
+  // write must not be disconnected for it.
+  const line = encodeJsonLineFrame({ ...request, params: { body: "z".repeat(256 * 1024) } }),
+    count = Math.ceil(JSON_LINE_FRAME_MAX_BYTES / Buffer.byteLength(line)) + 2,
+    chunk = line.repeat(count);
+  assert.ok(Buffer.byteLength(chunk) > JSON_LINE_FRAME_MAX_BYTES, "fixture must exceed the cap in aggregate");
+  const batch = reader.push(chunk);
+  assert.equal(batch.error, undefined);
+  assert.equal(batch.frames.length, count);
+  // Complete frames followed by an over-cap unterminated tail: the frames are lost only with the tail.
+  const tail = reader.push(`${line}${"x".repeat(JSON_LINE_FRAME_MAX_BYTES + 1)}`);
+  assert.ok(tail.error, "an over-cap unterminated remainder must still surface an error");
+  assert.deepEqual(reader.push(`${JSON.stringify(request)}\n`).frames, [request]);
+});
+
 test("a frame just under the cap still parses across many chunks", () => {
   const reader = createJsonLineFrameReader();
   // A cap that rejected legitimate frames would break the largest payload the surface accepts today:


### PR DESCRIPTION
# English

## Summary

Follow-up to PR #2595 (fix-plan batch 13 A1, finding R2-01-F10), raised by the independent closeout review of task_62c0ccaaf06a87f09006ccffd4. The 4 MiB inbound frame cap was compared against the whole accumulated buffer before the newline split, so one write that coalesced many complete, individually small JSON lines whose total exceeded 4 MiB returned the cap error, discarded every frame and failed the connection. The cap exists to bound an unterminated line from a newline-less writer, so the reader now splits first and applies the cap to the pending remainder only. Complete frames in a chunk are always parsed; an over-cap unterminated tail still surfaces the error and is discarded, and the reader still recovers on the next well-formed frame.

## Architectural Justification

A bound on buffering applies to what is buffered (the unterminated remainder), not to what has already been delimited into frames.

## What Changed

- `packages/daemon/src/transport/frame-codec.ts` (+5/-4): in `push`, split on newline, pop the remainder, then check `Buffer.byteLength(remainder) > JSON_LINE_FRAME_MAX_BYTES`; comment says what the cap bounds.
- `packages/daemon/test/frame-codec.contract.test.ts` (+18): one chunk of many complete frames whose aggregate exceeds the cap parses every frame with no error; complete frames followed by an over-cap unterminated tail still error; the reader parses the next frame afterwards. The two existing cap tests are unchanged and still pass.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +5/-4 production (the cap check moves below the newline split in `frame-codec.ts`; one comment rewritten).

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root and on the branch head: every operation and metric identical, G38 passes on both. The change is in the transport frame reader's error path ordering; no read or write path is touched.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_62c0ccaaf06a87f09006ccffd4 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/fixplan-a1-frame-cap`
- Public scope: Ordering of the cap check inside the JSON-line frame reader. No protocol, cap value, error text or connection-failure behaviour change.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: A per-line cap for terminated lines (a single complete frame above 4 MiB is still parsed, as before this PR); nothing else from the A1 batch is reopened.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `27345bf54`
- Branch merge-base with `origin/main`: `27345bf54`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/fixplan-a1-frame-cap`
- Private evidence commit/path: task_62c0ccaaf06a87f09006ccffd4 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- CEO ground-truth on head 58fc4f63c (base 27345bf54): `node tools/run-node-tests.mjs --file packages/daemon/test/frame-codec.contract.test.ts` 4/4 (new test included); `npx eslint` on both files clean; Prettier clean; G33 production-delta pass (+5/-4, unclassified 0); G1 identical to base.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; read the reviewer's finding against the delivered code, confirmed the ordering defect by reading `push`, wrote the fix and the regression test, and ran the contract test and gates listed above..
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- None beyond the fix: the remainder check is the same comparison against the same constant, applied to a subset of the bytes it was applied to before; the only behaviour that changes is that complete frames in an oversized chunk are delivered instead of dropped.

## References

- Task: task_62c0ccaaf06a87f09006ccffd4

---

# 中文

## 概要

PR #2595（fix-plan 批 13 A1，finding R2-01-F10）的补刀，由 task_62c0ccaaf06a87f09006ccffd4 的独立 closeout 评审提出。4 MiB 入站帧上限原本在按换行拆分之前对整个累计缓冲比较，于是一次写入里合并了多条各自很小、总量却超过 4 MiB 的完整 JSON 行时，会返回超限错误、丢掉全部帧并断开连接。这个上限是为了约束没有换行的写者造成的无界缓冲，所以读者现在先拆分，只对未终止的剩余部分应用上限。块内完整帧总会被解析；超限的未终止尾巴仍报错并丢弃，读者仍在下一条合法帧上恢复。

## 架构辩护

缓冲上限作用于正在缓冲的东西（未终止的剩余部分），而不是已经切成帧的东西。

## 改动内容

- `packages/daemon/src/transport/frame-codec.ts`（+5/-4）：`push` 里先按换行拆分、弹出剩余部分，再检查 `Buffer.byteLength(remainder) > JSON_LINE_FRAME_MAX_BYTES`；注释写明上限约束的是什么。
- `packages/daemon/test/frame-codec.contract.test.ts`（+18）：一块里多条完整帧、总量超限时全部解析且无错误；完整帧后跟超限未终止尾巴时仍报错；之后读者能解析下一帧。原有两个上限测试不变、仍通过。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+5/-4 production (the cap check moves below the newline split in `frame-codec.ts`; one comment rewritten)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_62c0ccaaf06a87f09006ccffd4（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/fixplan-a1-frame-cap`
- 公开范围：JSON 行帧读者内部上限检查的顺序。不改协议、上限值、错误文案与断连行为。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：对已终止行的逐行上限（单条超过 4 MiB 的完整帧与本 PR 之前一样仍会被解析）；A1 批其他项不重开。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`27345bf54`
- 分支与 `origin/main` 的 merge-base：`27345bf54`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/fixplan-a1-frame-cap`
- 私有证据路径：task_62c0ccaaf06a87f09006ccffd4 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- CEO 在 head 58fc4f63c（base 27345bf54）核实：`node tools/run-node-tests.mjs --file packages/daemon/test/frame-codec.contract.test.ts` 4/4（含新测试）；两个文件 `npx eslint` 干净；Prettier 干净；G33 production-delta 通过（+5/-4，unclassified 0）；G1 与 base 一致。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；对照交付代码读评审 finding，读 `push` 确认顺序缺陷，亲自写修复与回归测试，跑上面列出的契约测试与门。。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 除修复本身外没有：剩余部分的检查是同一常量、同一比较，只是作用在比之前更小的字节子集上；唯一变化是超大块里的完整帧会被送达而不是丢弃。

## 参考

- 任务：task_62c0ccaaf06a87f09006ccffd4

