### PR TITLE
docs(preset): point the repository agent overlay dispatch prose at ha agent run

### DIFF
--- a/packages/preset/assets/software-coding/templates/repository.agent.overlay/en-US.md
+++ b/packages/preset/assets/software-coding/templates/repository.agent.overlay/en-US.md
@@ -1,11 +1,11 @@
 ## Harness CLI (software/coding)
 
 - Use `ha <command>` or `npx harness-anything <command>` and inspect command help before composing writes.
-- Create task packages with `ha task create --title "<title>"`; do not hand-scaffold task directories, and replace every required `task_plan.md` placeholder before dispatch or `runtime run` rejects it with `plan_placeholder`.
+- Create task packages with `ha task create --title "<title>"`; do not hand-scaffold task directories, and replace every required `task_plan.md` placeholder before dispatch or `agent run` rejects it with `plan_placeholder`.
 - Select from the effective catalog with `ha preset list`. Packages reported unavailable must not be used to publish guidance or create a task.
 - Milestone creation requires an explicit `--task-class milestone`; the preset ID does not infer task class.
 - Both `--opt value` and `--opt=value` are accepted for value options; an unsupported option is rejected with `unknown_field`.
-- `runtime run --mission` takes a synced mission name, not a file path; submit the mission with `ha doc sync --submit` first or dispatch rejects it with `mission_not_found`.
+- `ha agent run <agent-id> --task <task-id> --mission <name>` takes a synced bare mission name, not a file path; submit the mission with `ha doc sync --submit` first or dispatch rejects it with `runtime_mission_unavailable`.
 - Closeout order is start → submit → independent `review-execution` → `review-consent` → complete; an out-of-order lifecycle action is `invalid_transition`, and self-review is `actor_unauthorized`.
 - `ha task complete` derives code/doc evidence from the submitted delivery; `--execution-id` is only for repairing an ambiguous current execution selection.
 - Before completion, replace `closeout.md` with the exact sections `## Summary`, `## Verification`, `## Residual Risk`, and `## Same Mechanism Elsewhere`, or completion rejects it with `closeout_placeholder`.

--- a/packages/preset/assets/software-coding/templates/repository.agent.overlay/zh-CN.md
+++ b/packages/preset/assets/software-coding/templates/repository.agent.overlay/zh-CN.md
@@ -1,11 +1,11 @@
 ## Harness CLI (software/coding)
 
 - 使用 `ha <command>` 或 `npx harness-anything <command>`，组装写入前先查看命令帮助。
-- 用 `ha task create --title "<title>"` 创建 task package；不要手工搭建 task 目录，并在派工前写实 `task_plan.md` 的每个必填占位，否则 `runtime run` 会以 `plan_placeholder` 拒绝。
+- 用 `ha task create --title "<title>"` 创建 task package；不要手工搭建 task 目录，并在派工前写实 `task_plan.md` 的每个必填占位，否则 `agent run` 会以 `plan_placeholder` 拒绝。
 - 通过 `ha preset list` 从 effective catalog 选择 preset。标为 unavailable 的 package 不得用于发布 guidance 或创建 task。
 - milestone 创建必须显式传入 `--task-class milestone`；preset ID 不推断 task class。
 - 带值选项同时接受 `--opt value` 与 `--opt=value`；不支持的选项会以 `unknown_field` 拒绝。
-- `runtime run --mission` 接受已同步的 mission 名称而非文件路径；必须先用 `ha doc sync --submit` 提交，否则派工会以 `mission_not_found` 拒绝。
+- `ha agent run <agent-id> --task <task-id> --mission <name>` 接受已同步的小写裸 mission 名称而非文件路径；必须先用 `ha doc sync --submit` 提交，否则派工会以 `runtime_mission_unavailable` 拒绝。
 - 收口链序为 start → submit → 独立 `review-execution` → `review-consent` → complete；乱序生命周期操作会是 `invalid_transition`，自己复核会是 `actor_unauthorized`。
 - `ha task complete` 从已提交交付推导 code/doc 证据；`--execution-id` 只用于修复当前 execution 选择歧义。
 - complete 前须把 `closeout.md` 写实为固定四节：`## Summary`、`## Verification`、`## Residual Risk`、`## Same Mechanism Elsewhere`，否则以 `closeout_placeholder` 拒绝。


### PR DESCRIPTION
# English

## Summary

Tail of task_067f53c8 (dispatch command surface simplified to `ha agent run <agent-id> --task <task-id>`, delivered by PR #2528). The repository agent overlay templates that `ha init` renders into a repository's agent guidance still described the retired `runtime run --mission` form in four lines (en-US and zh-CN, lines 4 and 8). They now describe the `ha agent run` form; the line that taught a usage unreachable in the new form is rewritten rather than kept with a compatibility note. Found by the closeout-prep worker's PARTIAL verdict on the task; this is the last open item of Goal 3 (preset/skill prose in sync with the command).

## Architectural Justification

Guidance that a preset renders into a repository states the one dispatch entry the product has; a retired spelling is removed, not annotated.

## What Changed

- `packages/preset/assets/software-coding/templates/repository.agent.overlay/en-US.md` and `zh-CN.md`: lines 4 and 8 rewritten to the `ha agent run <agent-id> --task <task-id>` dispatch form; no other lines touched.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-0 production (the two repository agent overlay templates are preset assets; four prose lines about dispatch commands change, no code).

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root and on the branch head: G38 passes on both; the only metric that moves is `task-create.fileReadBytes` 77381 → 77483 (+102 bytes at 200 and at 2000), because task creation reads the rendered overlay text and the rewritten lines are 102 bytes longer. Every other operation and metric is identical.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77483 | 77487 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_067f53c8e55721542492408817 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/agent-run-overlay-prose`
- Public scope: Preset overlay prose only. No command, protocol or gate change.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Nothing else from task_067f53c8; the command surface itself landed in #2528.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9e01830ba`
- Branch merge-base with `origin/main`: `9e01830ba`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/agent-run-overlay-prose`
- Private evidence commit/path: task_067f53c8e55721542492408817 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker (GLM `glm-worker`, report in the task package `artifacts/report.md` Round 6): `rg -n "runtime run" packages/preset/assets/software-coding/templates/` empty after the change; the preset tests that assert overlay text run green (named in the report). CEO ground-truth on head (base 9e01830ba): `git diff --stat` shows only the two template files; `rg` for the retired spelling under the templates directory returns 0 lines; G33 production-delta pass; G1: only `task-create.fileReadBytes` +102 bytes (longer overlay prose), everything else identical.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; read the two-file diff, confirmed both lines now match the shipped `ha agent run` form and that no compatibility wording remains, and ran the checks listed under verification..
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- None: rendered guidance text for new repositories changes; existing repositories keep the overlay they already rendered until they re-run `ha init`.

## References

- Task: task_067f53c8e55721542492408817

---

# 中文

## 概要

task_067f53c8（派工命令面收成 `ha agent run <agent-id> --task <task-id>`，PR #2528 已合）的尾巴。`ha init` 渲染进仓库的 repository agent overlay 模板里还有四行（en-US 与 zh-CN 的第 4、8 行）在讲已退役的 `runtime run --mission` 形态。现在改成 `ha agent run` 形态；教的是新形态下不可达用法的那行直接重写，不留兼容说明。由 closeout-prep worker 的 PARTIAL 判定发现，是 Goal 3（preset/skill 文案与命令同步）最后一项。

## 架构辩护

preset 渲染进仓库的指引只陈述产品现有的唯一派工入口；退役写法删除而不是加注。

## 改动内容

- `packages/preset/assets/software-coding/templates/repository.agent.overlay/en-US.md` 与 `zh-CN.md`：第 4、8 行改写为 `ha agent run <agent-id> --task <task-id>` 派工形态；不动其他行。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+0/-0 production (the two repository agent overlay templates are preset assets; four prose lines about dispatch commands change, no code)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_067f53c8e55721542492408817（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/agent-run-overlay-prose`
- 公开范围：只改 preset overlay 文案。不改命令、协议与门。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：task_067f53c8 其余已在 #2528 落地。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9e01830ba`
- 分支与 `origin/main` 的 merge-base：`9e01830ba`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/agent-run-overlay-prose`
- 私有证据路径：task_067f53c8e55721542492408817 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Worker（GLM `glm-worker`，报告见任务包 `artifacts/report.md` Round 6）：改后 `rg -n "runtime run" packages/preset/assets/software-coding/templates/` 为空；断言 overlay 文本的 preset 测试绿（报告点名）。CEO 在 head（base 9e01830ba）核实：`git diff --stat` 只有两份模板；模板目录下退役写法 `rg` 为 0 行；G33 production-delta 通过；G1：只有 `task-create.fileReadBytes` +102 字节（overlay 文案变长），其余与 base 一致。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；读了两文件 diff，确认两行都对齐已发布的 `ha agent run` 形态、没有残留兼容措辞，并跑了 verification 列出的检查。。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 无：只影响新仓库渲染出的指引文本；已有仓库保留已渲染的 overlay，直到重新 `ha init`。

## 参考

- 任务：task_067f53c8e55721542492408817

