### PR TITLE
test(kernel): make the daemon-registry v2-mode re-read miss the mtime cache deterministically

### DIFF
--- a/packages/kernel/test/store/daemon-registry.test.ts
+++ b/packages/kernel/test/store/daemon-registry.test.ts
@@ -92,6 +92,11 @@ test("daemon registry persists explicit workspace modes and rejects rows that om
       persisted = JSON.parse(readFileSync(registryPath, "utf8")) as { repos: Record<string, unknown>[] };
     delete persisted.repos[0]!.mode;
     writeFileSync(registryPath, `${JSON.stringify(persisted)}\n`, "utf8");
+    // Coarse-clock filesystems (Linux keeps mtimes at kernel-tick granularity) can leave this
+    // rewrite on the same mtimeMs the read above cached, so the mtime-keyed read cache would
+    // serve the pre-rewrite registry; move the timestamp past it instead of waiting out the tick.
+    const bumped = new Date(statSync(registryPath).mtimeMs + 1_000);
+    utimesSync(registryPath, bumped, bumped);
     assert.equal(readDaemonRegistry({ userRoot }).repos.length, 0);
     assert.match(readDaemonRegistry({ userRoot }).invalidRepos[0]?.error ?? "", /missing or invalid mode/u);
     assert.throws(


### PR DESCRIPTION
# English

## Summary

`daemon-registry.test.ts` was red on the Ubuntu isolated target and green on macOS and GitHub CI. Root cause is a platform assumption in the test, not a registry defect: the `v2 mode` case reads the registry (which fills the module-level mtime cache), rewrites the file externally, and re-reads at once, assuming the rewrite changes `mtimeMs`. On ext4 with a coarse kernel clock the two writes land on the same millisecond tick (probe: 48 of 50 write pairs collide on the VM, 0 of 50 on APFS), so the cache serves the pre-rewrite snapshot and `repos.length` is 1 instead of 0. GitHub's Linux runners are the same coarse clock; there the parse/decode work between the writes usually crosses a tick, which is why CI stays green while the VM fails almost every time. The fix moves the rewritten file's mtime explicitly past the cached value with `utimesSync` (the pattern this file already uses elsewhere), making the cache miss deterministic on every filesystem. Production code is untouched: the production write path (`writeDaemonRegistry`) invalidates the cache itself, and the repository has no other same-process read → external rewrite → immediate re-read site (the two other external-rewrite tests re-read from fresh child processes).

## Architectural Justification

A test that depends on an mtime-keyed cache missing must make the miss deterministic itself; it may not rely on the clock resolution of the filesystem it happens to run on.

## What Changed

- `packages/kernel/test/store/daemon-registry.test.ts` (+5/-0, lines 95-99): after the external rewrite, `utimesSync` sets the file mtime to the cached `mtimeMs + 1000` ms so the next read cannot hit the cache; three comment lines state the assumption being removed.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +0/-0 production (test-only: +5/-0 in `packages/kernel/test/store/daemon-registry.test.ts`).

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root and on the branch head: every operation and metric identical, G38 passes on both. Test-only change.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77381 | 77385 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_d324fb2fd1567dd4c4fe75fcb0 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/daemon-registry-ubuntu`
- Public scope: One test file. No production, protocol or gate change.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: No change to the registry cache policy (a content-hash freshness key was considered and rejected: the only consumer that rewrites externally is this test).

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9e01830ba`
- Branch merge-base with `origin/main`: `9e01830ba`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/daemon-registry-ubuntu`
- Private evidence commit/path: task_d324fb2fd1567dd4c4fe75fcb0 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker (GLM `glm-worker`, report `artifacts/reports/daemon-registry-isolation.md`): reproduction frame — Ubuntu isolated `node tools/dispatch-isolated-test.mjs --file packages/kernel/test/store/daemon-registry.test.ts` exit 1 (`AssertionError: 1 !== 0` at :95), macOS `run-node-tests --file` 15/15; negative control on macOS by pinning mtime to force a collision reproduces the same failure at :98; mtime-collision probe 48/50 on ext4 vs 0/50 on APFS. After the fix: Ubuntu isolated exit 0, 15/15 (duration 17.9 s); macOS 15/15. CEO ground-truth on head be6daac62 (base 9e01830ba): `git diff --stat` is the single test file +5; commit authored and committed by ZeyuLi; G33 pass; G1 identical to base.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; read the reproduction frame, the class search (only one same-process external-rewrite site) and the five-line diff; confirmed the fix follows the file's existing `utimesSync` pattern and does not touch the cache policy..
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- None for production. The test now states its freshness assumption instead of relying on filesystem timestamp resolution.

## References

- Task: task_d324fb2fd1567dd4c4fe75fcb0

---

# 中文

## 概要

`daemon-registry.test.ts` 在 Ubuntu 隔离目标上红、在 macOS 与 GitHub CI 上绿。根因是测试的平台假设，不是 registry 缺陷：`v2 mode` 用例先读 registry（填充模块级 mtime 缓存）、外部改写文件、随即重读，隐含「改写必然改变 `mtimeMs`」。ext4 加粗粒度内核时钟下两次写落在同一毫秒 tick（探针：VM 上 50 对写 48 对碰撞，APFS 上 0 对），缓存返回改写前快照，`repos.length` 为 1 而不是 0。GitHub 的 Linux runner 同样是粗时钟，只是两次写之间的解析工作通常跨过 tick，所以 CI 绿而 VM 几乎必红。修法是改写后用 `utimesSync` 把文件 mtime 显式顶过缓存值（本文件其他地方已在用的写法），让缓存 miss 在任何文件系统上都确定。生产代码不动：生产写路径 `writeDaemonRegistry` 自己失效缓存，全仓也没有第二处「同进程读 → 外部改写 → 立即重读」（另两个外部改写测试都是在新子进程里重读）。

## 架构辩护

依赖 mtime 键缓存 miss 的测试必须自己让 miss 确定发生，不能依赖它碰巧运行的文件系统的时钟分辨率。

## 改动内容

- `packages/kernel/test/store/daemon-registry.test.ts`（+5/-0，第 95-99 行）：外部改写后用 `utimesSync` 把 mtime 设为缓存值 +1000 ms，下一次读必然 miss；三行注释写明被移除的假设。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+0/-0 production (test-only: +5/-0 in `packages/kernel/test/store/daemon-registry.test.ts`)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_d324fb2fd1567dd4c4fe75fcb0（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/daemon-registry-ubuntu`
- 公开范围：一个测试文件。不改生产、协议与门。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：不改 registry 缓存策略（考虑过改内容 hash 作新鲜度键，否决：唯一外部改写的消费者就是这个测试）。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9e01830ba`
- 分支与 `origin/main` 的 merge-base：`9e01830ba`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/daemon-registry-ubuntu`
- 私有证据路径：task_d324fb2fd1567dd4c4fe75fcb0 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Worker（GLM `glm-worker`，报告 `artifacts/reports/daemon-registry-isolation.md`）：复现帧——Ubuntu 隔离 `node tools/dispatch-isolated-test.mjs --file packages/kernel/test/store/daemon-registry.test.ts` exit 1（`AssertionError: 1 !== 0` at :95），macOS `run-node-tests --file` 15/15；macOS 阴性对照钉住 mtime 强制碰撞后同一用例同样红（:98）；mtime 碰撞探针 ext4 48/50、APFS 0/50。修后：Ubuntu 隔离 exit 0、15/15（17.9 s）；macOS 15/15。CEO 在 head be6daac62（base 9e01830ba）核实：`git diff --stat` 只有这一个测试文件 +5；commit 作者与提交人为 ZeyuLi；G33 通过；G1 与 base 一致。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；读了复现帧、类排查（全仓只此一处同进程外部改写）与五行 diff；确认修法沿用本文件既有 `utimesSync` 写法且不碰缓存策略。。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 生产无风险。测试现在把新鲜度假设写明，不再依赖所在文件系统的时间戳分辨率。

## 参考

- 任务：task_d324fb2fd1567dd4c4fe75fcb0

