### PR TITLE
fix(preset): close documentation tasks on artifact evidence

### DIFF
--- a/packages/preset/assets/software-coding/agents/closeout-reviewer.json
+++ b/packages/preset/assets/software-coding/agents/closeout-reviewer.json
@@ -2,7 +2,7 @@
   "schema": "agent-declaration/v1",
   "id": "closeout-reviewer",
   "name": "Closeout Reviewer",
-  "instructions": "Independently review the submitted execution against its task contract and pinned delivery evidence. Verify claims directly, record approved or changes_requested through the provided review command, and never submit, consent to, or complete the task.",
+  "instructions": "Independently review the submitted execution against its task contract and pinned delivery evidence. When submission.commitSha is null, review each center-accepted frozen artifact in the dispatch prompt; artifact delivery does not require a Git commit or ancestry. Verify claims directly, honor only the completion gates declared by the task, record approved or changes_requested through the provided review command, and never submit, consent to, or complete the task.",
   "runtime_type": "any",
   "role": "worker"
 }

--- a/packages/preset/src/preset-bootstrap.ts
+++ b/packages/preset/src/preset-bootstrap.ts
@@ -22,8 +22,9 @@ import {
   type OpaqueTextualMediaType,
   type WriteSource,
 } from "../../kernel/src/index.ts";
-import { serializePresetSnapshotV1, type PresetSnapshotV1 } from "./preset.contract.ts";
+import { canonicalPresetBytes, serializePresetSnapshotV1, type PresetSnapshotV1 } from "./preset.contract.ts";
 import { createRuntime, type PresetResolverOptions } from "./preset-resolver.ts";
+import { resolverContentHash } from "./preset-resolver-common.ts";
 
 export interface TaskModuleRegistration {
   readonly key: string;
@@ -111,7 +112,8 @@ export function compileTaskPackage(input: CompileTaskPackageInput): CompiledTask
     );
   if (resolved.requiredTaskClass && input.taskClass !== resolved.requiredTaskClass)
     throw bootstrapFailure("task_class_mismatch", `Preset requires taskClass=${resolved.requiredTaskClass}.`);
-  const slug = input.slug ?? slugifyTaskTitle(input.title),
+  const snapshot = input.workKind === "docs" ? withoutCodeDeliveryGates(resolved.snapshot) : resolved.snapshot,
+    slug = input.slug ?? slugifyTaskTitle(input.title),
     packagePath = `tasks/${input.taskId}-${slug}`,
     metadata: TaskMetadataV1 = {
       idempotencyKey: input.idempotencyKey ?? null,
@@ -215,8 +217,8 @@ export function compileTaskPackage(input: CompileTaskPackageInput): CompiledTask
           locale: input.locale,
           metadata,
           registerModule: input.registerModule ?? null,
-          completionGates: resolved.snapshot.profile.completionGateIds,
-          presetSnapshotDigest: resolved.snapshot.digest,
+          completionGates: snapshot.profile.completionGateIds,
+          presetSnapshotDigest: snapshot.digest,
           scaffold: {
             baseVersion: resolved.snapshot.scaffold.baseVersion,
             overlayDigest: resolved.snapshot.scaffold.overlayDigest,
@@ -238,7 +240,7 @@ export function compileTaskPackage(input: CompileTaskPackageInput): CompiledTask
       ...additions,
       ...presetScripts,
     ];
-  return { snapshot: resolved.snapshot, packagePath, scaffoldDigest, documents, metadata };
+  return { snapshot, packagePath, scaffoldDigest, documents, metadata };
   function machine(slot: string, relativePath: string, body: string): CompiledTaskDocument {
     return {
       slot,
@@ -252,6 +254,19 @@ export function compileTaskPackage(input: CompileTaskPackageInput): CompiledTask
       templateRef: null,
     };
   }
+}
+
+function withoutCodeDeliveryGates(snapshot: PresetSnapshotV1): PresetSnapshotV1 {
+  const completionGateIds = snapshot.profile.completionGateIds.filter(
+    (gateId) => gateId !== "ci" && gateId !== "code-doc-reconciliation",
+  );
+  if (completionGateIds.length === snapshot.profile.completionGateIds.length) return snapshot;
+  const { digest: _digest, ...withoutDigest } = snapshot,
+    effective = { ...withoutDigest, profile: { ...snapshot.profile, completionGateIds } };
+  return {
+    ...effective,
+    digest: `sha256:${resolverContentHash(canonicalPresetBytes(effective))}`,
+  };
 }
 export function compileTaskBootstrap(input: CompileTaskBootstrapInput): CompiledTaskBootstrap {
   const compiled = compileTaskPackage(input),

--- a/packages/preset/test/preset-bootstrap.test.ts
+++ b/packages/preset/test/preset-bootstrap.test.ts
@@ -52,6 +52,25 @@ test("standard and milestone bootstrap compile one exact canonical birth and reb
       ["machine", "machine", "doc-sync", "doc-sync", "doc-sync"],
     );
     assert.equal(JSON.parse(standard.documents[1]!.body).documents[2].owner, "doc-sync");
+    const documentation = compileTaskBootstrap({
+      ...common,
+      taskId: "task-documentation",
+      title: "Documentation",
+      presetId: "standard-task",
+      workKind: "docs",
+      workspaceRevision: 2,
+      eventId: "event-documentation",
+      opId: "op-documentation",
+    });
+    const documentationContract = JSON.parse(documentation.documents[1]!.body) as {
+      completionGates: readonly string[];
+      presetSnapshotDigest: string;
+    };
+    assert.deepEqual(documentation.snapshot.profile.completionGateIds, []);
+    assert.deepEqual(documentation.event.payload.task.completionGateIds, []);
+    assert.deepEqual(documentationContract.completionGates, []);
+    assert.equal(documentationContract.presetSnapshotDigest, documentation.snapshot.digest);
+    assert.notEqual(documentation.snapshot.digest, standard.snapshot.digest);
     const packageOnly = compileTaskPackage({
       userRoot,
       taskId: "configure-verify-smoke",

--- a/packages/preset/test/preset-resolver-bundled-catalog.test.ts
+++ b/packages/preset/test/preset-resolver-bundled-catalog.test.ts
@@ -17,6 +17,8 @@ test("bundled closeout reviewer is machine-independent and leaves instance model
   assert.equal(reviewer.runtime_type, "any");
   assert.equal(reviewer.instance, undefined);
   assert.equal(reviewer.model, undefined);
+  assert.match(reviewer.instructions, /artifact delivery does not require a Git commit or ancestry/u);
+  assert.match(reviewer.instructions, /only the completion gates declared by the task/u);
   assert.doesNotMatch(reviewer.instructions, /(?:\/Users\/|harness\/tasks\/|\\Users\\)/u);
   assert.equal(readBundledAgentDeclaration("not-bundled"), null);
 });


### PR DESCRIPTION
# English

## Summary

Documentation and read-only analysis tasks could not be closed honestly (task_f9445954; three live rejections on task_997414da / task_222cf57f / task_7873609b). A task created with the `standard-task` preset and `workKind=docs` froze a contract carrying the `ci` and `code-doc-reconciliation` completion gates, which a task without a product commit can never satisfy: the daemon refuses a harness-ledger sha as the submission cut, and the bundled `closeout-reviewer` read a null `submission.commitSha` as a missing witness and requested changes. Two source fixes in the unique path, no bypass: (1) `compileTaskPackage` derives the effective preset snapshot for `workKind=docs` without those two gates and recomputes the snapshot digest, so the task event, the frozen contract and the snapshot agree from creation; (2) the bundled reviewer declaration states that an artifact delivery (null commitSha, artifact deliverables) is reviewed item by item from the center-frozen artifacts, without Git ancestry or a commit sha, and that a docs contract has no ci / code-doc gate to demand. Existing frozen tasks were corrected out of band with `ha task contract migrate --to-preset docs-task` (nine tasks); no old task event, contract or review was rewritten.

## Architectural Justification

A task's effective completion contract is derived once at bootstrap from its declared work kind, and reviewers evaluate artifact deliveries against the frozen artifacts the center accepted.

## What Changed

- `packages/preset/src/preset-bootstrap.ts` (+20/-5): `withoutCodeDeliveryGates` filters `ci` / `code-doc-reconciliation` out of the resolved profile for `workKind=docs` and re-hashes the snapshot with the resolver's own `canonicalPresetBytes` + `resolverContentHash`; `completionGates`, `presetSnapshotDigest` and the returned `snapshot` come from that effective snapshot (scaffold digests still come from the resolved one).
- `packages/preset/assets/software-coding/agents/closeout-reviewer.json`: one instructions sentence — artifact deliveries are reviewed from frozen artifacts; docs contracts carry no ci / code-doc gate.
- `packages/preset/test/preset-bootstrap.test.ts` (+19): `standard-task` + `workKind=docs` yields empty gates and one digest across snapshot, task event and contract.
- `packages/preset/test/preset-resolver-bundled-catalog.test.ts` (+2): the bundled reviewer keeps both the artifact rule and the declared-gate rule.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +20/-5 production in one file (net +15: a 13-line docs-snapshot derivation replaces the unqualified use of the resolved preset gates; the bundled reviewer declaration is a preset asset, not counted).

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root (the base file was taken at 2860a94cf) and on the branch head: every operation and metric identical and G38 passes on both, with one exception — `task-create.fileReadBytes` 77381 → 77483 (+102 bytes). Those 102 bytes are the task-plan overlay prose merged in #2603 (9b5b37465), which this branch inherits from its base 5f34896e0 and the older base file predates; this branch adds no file read. The docs-kind derivation is a pure in-memory calculation and is not visible to these probes.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77381 | 77385 | 77483 | 77487 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_f9445954f44f2e1aec8aa6ea16 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/docs-closeout-contract`
- Public scope: Task bootstrap contract derivation for `workKind=docs`; bundled closeout-reviewer instructions.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: No inference of docs status from titles (`workKind` is the classifier); no automatic migration of already-frozen contracts; no daemon, CLI, CI, gate or allowlist change; the dedicated `docs-task` / `code-impact-analysis` / `architecture-rot-audit` presets are untouched (they already declare empty gates).

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `5f34896e0`
- Branch merge-base with `origin/main`: `5f34896e0`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/docs-closeout-contract`
- Private evidence commit/path: task_f9445954f44f2e1aec8aa6ea16 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker (Codex Sol, report `artifacts/report.md`, head 26b83f71d on base 9e01830ba): isolated Ubuntu `preset-bootstrap.test.ts` PASS, `preset-resolver-bundled-catalog.test.ts` PASS, `task-completion-review.integration.test.ts` PASS; local fast `closeout-submission-cut.test.ts` 15/15; `npm run typecheck`, `npm run lint`, G36 line-density, file-complexity, G33 (+20/-5), `git diff --check` all pass. CEO on the rebased head 8f1a52e06 (base 5f34896e0): fast `preset-bootstrap.test.ts` 2/2 and `preset-resolver-bundled-catalog.test.ts` 13/13, G33 pass, G1 as noted above. Usage evidence on the live ledger: the same rule installed in the local `closeout-reviewer` declaration plus `contract migrate --to-preset docs-task` on task_7873609b produced the first `approved` verdict from artifacts (reviewer report `dispatch_bb2d13511d78b5409e16ac06`); its registration is still in flight on a reviewer-role dispatch, so completion of a migrated docs task is not yet witnessed.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; read the diff, confirmed the recomputed digest uses the resolver's own canonical bytes and hash, re-ran the fast tests and G33/G1 on the rebased head, and cross-checked against the live ledger where the migrated contract plus the same reviewer rule produced the first artifact-based approval.
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- Task bootstrap is a pure calculation and the center queue still accepts every artifact byte and revision, so multiple edge nodes gain no new writer. A docs task explicitly created with a code preset and `workKind=null` stays a malformed request rather than being guessed into another contract. Frozen contracts are not migrated automatically (done once by hand for the nine affected tasks). Alternative considered and not taken: defaulting `--kind docs` to the `docs-task` preset — callers choose the preset explicitly and that preset changes the whole package shape (artifact output), whereas the work kind must be honest under any preset.

## References

- Task: task_f9445954f44f2e1aec8aa6ea16

---

# 中文

## 概要

纯文档/只读分析任务无法诚实收口（task_f9445954；task_997414da / task_222cf57f / task_7873609b 三次实录打回）。用 `standard-task` preset 加 `workKind=docs` 创建的任务冻结了带 `ci` 与 `code-doc-reconciliation` completion gate 的合同，而没有产品 commit 的任务永远满足不了：daemon 拒绝把 harness 台账 sha 当 submission cut，bundled `closeout-reviewer` 把 `submission.commitSha` 为 null 读成缺 witness 而打回。两处唯一路径上的源头修复，不加旁路：(1) `compileTaskPackage` 为 `workKind=docs` 派生去掉这两个 gate 的有效 preset 快照并重算 digest，任务事件、冻结合同与快照从创建起一致；(2) bundled reviewer 声明写明 artifact 交付（commitSha 为 null、deliverables 是 artifact 锚）按中心冻结的 artifact 逐项对照合同评审，不要求 Git 祖先与 commit sha，docs 合同没有 ci / code-doc gate 可索要。既有冻结任务已在台账侧用 `ha task contract migrate --to-preset docs-task` 逐个纠正（九个任务）；未改写任何旧事件、合同或评审。

## 架构辩护

任务的有效完成合同在 bootstrap 时按声明的 work kind 一次派生；评审者按中心接受的冻结 artifact 评审 artifact 交付。

## 改动内容

- `packages/preset/src/preset-bootstrap.ts`（+20/-5）：`withoutCodeDeliveryGates` 在 `workKind=docs` 时从已解析 profile 里滤掉 `ci` / `code-doc-reconciliation`，并用 resolver 自己的 `canonicalPresetBytes` + `resolverContentHash` 重算快照 digest；`completionGates`、`presetSnapshotDigest` 与返回的 `snapshot` 都取自该有效快照（scaffold digest 仍取自解析结果）。
- `packages/preset/assets/software-coding/agents/closeout-reviewer.json`：instructions 加一句——artifact 交付按冻结 artifact 评审；docs 合同没有 ci / code-doc gate。
- `packages/preset/test/preset-bootstrap.test.ts`（+19）：`standard-task` + `workKind=docs` 得到空 gate，且快照、任务事件、合同三处 digest 同一。
- `packages/preset/test/preset-resolver-bundled-catalog.test.ts`（+2）：bundled reviewer 同时保留 artifact 规则与 declared-gate 规则。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+20/-5 production in one file (net +15: a 13-line docs-snapshot derivation replaces the unqualified use of the resolved preset gates; the bundled reviewer declaration is a preset asset, not counted)。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_f9445954f44f2e1aec8aa6ea16（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/docs-closeout-contract`
- 公开范围：`workKind=docs` 的任务 bootstrap 合同派生；bundled closeout-reviewer 指令。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：不从标题猜 docs（`workKind` 是分类器）；不自动迁移已冻结合同；不改 daemon、CLI、CI、gate、allowlist；专用 `docs-task` / `code-impact-analysis` / `architecture-rot-audit` preset 未动（本就声明空 gate）。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`5f34896e0`
- 分支与 `origin/main` 的 merge-base：`5f34896e0`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/docs-closeout-contract`
- 私有证据路径：task_f9445954f44f2e1aec8aa6ea16 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- worker（Codex Sol，报告 `artifacts/report.md`，head 26b83f71d，base 9e01830ba）：Ubuntu 隔离 `preset-bootstrap.test.ts` PASS、`preset-resolver-bundled-catalog.test.ts` PASS、`task-completion-review.integration.test.ts` PASS；本地 fast `closeout-submission-cut.test.ts` 15/15；`npm run typecheck`、`npm run lint`、G36 line-density、file-complexity、G33（+20/-5）、`git diff --check` 全部通过。CEO 在 rebase 后的 head 8f1a52e06（base 5f34896e0）：fast `preset-bootstrap.test.ts` 2/2、`preset-resolver-bundled-catalog.test.ts` 13/13，G33 通过，G1 见上注。台账侧使用证据：本地 `closeout-reviewer` 声明装入同一规则、task_7873609b 经 `contract migrate --to-preset docs-task` 后，首次拿到基于 artifact 的 `approved`（评审报告 `dispatch_bb2d13511d78b5409e16ac06`）；其登记仍在 reviewer-role 派发中飞行，迁移后 docs 任务的 complete 尚未见证。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；通读 diff，确认重算 digest 用的是 resolver 自己的 canonical bytes 与 hash，在 rebase 后的 head 上重跑 fast 测试与 G33/G1，并与台账实况交叉核对：迁移后的合同加同一 reviewer 规则产出了首个基于 artifact 的批准。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 任务 bootstrap 是纯计算，中心队列仍接受每一个 artifact 字节与修订，多边缘节点不新增写者。显式用代码 preset 且 `workKind=null` 创建的文档任务仍是畸形请求，不猜成别的合同。冻结合同不自动迁移（受影响九个任务已手工迁一次）。考虑过但未采用的替代方案：把 `--kind docs` 默认路由到 `docs-task` preset——调用方显式选 preset，且该 preset 改变整个包形态（artifact 输出），而 work kind 在任何 preset 下都必须诚实。

## 参考

- 任务：task_f9445954f44f2e1aec8aa6ea16

