### PR TITLE
fix: keep the reviewer-authored dispatch report at runtime archive instead of colliding with it

### DIFF
--- a/packages/daemon/src/doc-sync-publication.ts
+++ b/packages/daemon/src/doc-sync-publication.ts
@@ -106,6 +106,14 @@ export function archiveRuntimeDispatch(
     );
   const existingMissionRef = runtimeArchiveMissionRef(input, task.packagePath, value),
     missionRef = existingMissionRef ?? `${task.packagePath}/artifacts/missions/${value.dispatchId}.md`,
+    reportRef = documentPath(`${task.packagePath}/artifacts/reports/${value.dispatchId}.md`),
+    layout = resolveHarnessLayout(input.rootDir),
+    // A reviewer the completion facade dispatches authors its own report at the dispatch report path
+    // before the runtime settles. That authored report is the dispatch report; the final message is
+    // still reachable through resultRef, so it is not archived over the report and cannot collide.
+    reportAuthored =
+      input.projection.readDocument(reportRef).document !== null ||
+      existsSync(path.join(layout.authoredRoot, ...reportRef.split("/"))),
     dispatch = {
       schema: "runtime-dispatch/v1",
       dispatchId: value.dispatchId,
@@ -156,17 +164,20 @@ export function archiveRuntimeDispatch(
         body: `${JSON.stringify(dispatch, null, 2)}\n`,
         mediaType: "text/plain" as const,
       },
-      {
-        path: `${task.packagePath}/artifacts/reports/${value.dispatchId}.md`,
-        body: runtimeArchiveText(value.resultText),
-        mediaType: "text/markdown" as const,
-      },
+      ...(reportAuthored
+        ? []
+        : [
+            {
+              path: reportRef,
+              body: runtimeArchiveText(value.resultText),
+              mediaType: "text/markdown" as const,
+            },
+          ]),
     ].map((document) => ({
       ...document,
       path: documentPath(document.path),
       bytes: Buffer.from(document.body),
     })),
-    layout = resolveHarnessLayout(input.rootDir),
     reads = documents.map((document) => input.projection.readDocument(document.path)),
     opId = `runtime-archive-${createHash("sha256")
       .update(`${input.workspaceId}\0${value.dispatchId}\0${value.runtimeSessionId}`)

--- a/packages/daemon/src/runtime-spawn-settlement.ts
+++ b/packages/daemon/src/runtime-spawn-settlement.ts
@@ -141,7 +141,9 @@ export async function publishExit(
         if (archived.outcome !== "applied")
           throw context.runtimeSpawnError(
             "runtime_archive_failed",
-            `Runtime archive ${active.dispatchId} was not applied.`,
+            `Runtime archive ${active.dispatchId} was not applied: ${archived.outcome}${
+              "code" in archived && typeof archived.code === "string" ? ` ${archived.code}` : ""
+            }${"detail" in archived && archived.detail ? ` ${JSON.stringify(archived.detail)}` : ""}`,
           );
       } catch (error) {
         consumeKnownError(error);

--- a/packages/daemon/test/task-completion-review.integration.test.ts
+++ b/packages/daemon/test/task-completion-review.integration.test.ts
@@ -77,6 +77,10 @@ async function fixture(failProvider = false, available = true, artifactDelivery 
   git(root, "add", "README.md");
   git(root, "commit", "-qm", "docs: fixture delivery");
   const launches: { prompt: string; instanceId: string; model: string }[] = [];
+  const pendingProviders: {
+    output?: (chunk: string) => void;
+    exit?: (code: number | null) => void;
+  }[] = [];
   let instancesAvailable = available;
   const open = () =>
     openRepoCell({
@@ -122,24 +126,26 @@ async function fixture(failProvider = false, available = true, artifactDelivery 
           instanceId: prepared.definition.instanceId,
           model: prepared.definition.model,
         });
-        let output: ((chunk: string) => void) | undefined;
+        const pending: (typeof pendingProviders)[number] = {};
+        pendingProviders.push(pending);
         return {
           pid: 987650 + launches.length,
           onOutput: (listener) => {
-            output = listener;
+            pending.output = listener;
           },
           onErrorOutput: () => undefined,
           terminate: () => undefined,
           onExit: (listener) => {
+            pending.exit = listener;
             if (failProvider)
               setImmediate(() => {
-                output?.(
+                pending.output?.(
                   JSON.stringify({
                     type: "turn.failed",
                     error: { http_status: 429, code: "rate_limit", message: "HTTP 429 fixture capacity exhausted" },
                   }) + "\n",
                 );
-                listener(1);
+                pending.exit?.(1);
               });
           },
         };
@@ -262,6 +268,36 @@ async function fixture(failProvider = false, available = true, artifactDelivery 
         },
       );
     },
+    reportPath: (dispatchId: string) =>
+      path.join(root, "harness", packagePath, "artifacts", "reports", `${dispatchId}.md`),
+    settleReview: async (
+      dispatchId: string,
+      runtimeSessionId: string,
+      resultText: string,
+      reportText: string | null = null,
+    ) => {
+      if (reportText !== null) {
+        const report = path.join(root, "harness", packagePath, "artifacts", "reports", `${dispatchId}.md`);
+        mkdirSync(path.dirname(report), { recursive: true });
+        writeFileSync(report, reportText);
+      }
+      const pending = pendingProviders.at(-1)!;
+      pending.output?.(`${JSON.stringify({ type: "thread.started", thread_id: "review-provider-session" })}\n`);
+      pending.output?.(
+        `${JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: resultText } })}\n`,
+      );
+      pending.output?.(`${JSON.stringify({ type: "turn.completed", usage: {} })}\n`);
+      pending.exit?.(0);
+      for (let attempt = 0; attempt < 500; attempt += 1) {
+        const outcome = events().find(
+          (event) =>
+            event.type === "runtime_session_outcome_observed" && event.payload.runtimeSessionId === runtimeSessionId,
+        );
+        if (outcome?.type === "runtime_session_outcome_observed") return outcome.payload.outcome;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      throw new Error("reviewer runtime did not settle");
+    },
     close: async () => {
       await cell.close();
       rmSync(root, { recursive: true, force: true });
@@ -345,6 +381,46 @@ test("completion dispatches the bundled reviewer with no installed declaration a
     assert.equal(reviewed.outcome, "applied", JSON.stringify(reviewed));
     const completed = await f.complete(true);
     assert.equal(completed.outcome, "applied", JSON.stringify(completed));
+  } finally {
+    await f.close();
+  }
+});
+
+test("completion reviewer settlement keeps the report the reviewer authored at the dispatch report path", async () => {
+  const f = await fixture();
+  try {
+    const result = (await f.complete()) as Record<string, unknown>;
+    assert.equal(result.code, "review_missing", JSON.stringify(result));
+    const dispatchId = String(result.dispatchId),
+      authored = "# Closeout review\n\n- verdict: `approved`\n\nThe authored report, not the final message.\n";
+    assert.equal(
+      await f.settleReview(
+        dispatchId,
+        String(result.runtimeSessionId),
+        "Independent review registered; report written to the dispatch report path.",
+        authored,
+      ),
+      "succeeded",
+    );
+    assert.equal(readFileSync(f.reportPath(dispatchId), "utf8"), authored);
+  } finally {
+    await f.close();
+  }
+});
+
+test("completion reviewer settlement archives the final message when no report was authored", async () => {
+  const f = await fixture();
+  try {
+    const result = (await f.complete()) as Record<string, unknown>;
+    assert.equal(result.code, "review_missing", JSON.stringify(result));
+    assert.equal(
+      await f.settleReview(
+        String(result.dispatchId),
+        String(result.runtimeSessionId),
+        "# Independent review\n\nApproved.\n",
+      ),
+      "succeeded",
+    );
   } finally {
     await f.close();
   }

--- a/packages/kernel/src/domain/doc-sync-writer.ts
+++ b/packages/kernel/src/domain/doc-sync-writer.ts
@@ -306,18 +306,21 @@ function decideDocWriteInternal(input: DocWriteDecisionInput, requireAuthorizati
 
 function validRuntimeArchiveChanges(input: DocWriteDecisionInput, scope: RuntimeArchiveWriteScope): boolean {
   const artifactRoot = `${scope.packagePath}/artifacts`,
-    requiredPaths = new Set([
-      `${artifactRoot}/dispatches/${scope.dispatchId}.json`,
+    requiredPath = `${artifactRoot}/dispatches/${scope.dispatchId}.json`,
+    // The report is optional: a reviewer that authored its own report at the dispatch report path
+    // before settlement already owns it, and the mission is only written on the first archive.
+    allowedPaths = new Set([
+      requiredPath,
       `${artifactRoot}/reports/${scope.dispatchId}.md`,
+      `${artifactRoot}/missions/${scope.dispatchId}.md`,
     ]),
-    allowedMission = `${artifactRoot}/missions/${scope.dispatchId}.md`,
     paths = input.intent.changes.map(({ path }) => String(path));
   return (
     input.intent.executionId === null &&
     input.lease === null &&
     paths.length === new Set(paths).size &&
-    [...requiredPaths].every((path) => paths.includes(path)) &&
-    paths.every((path) => requiredPaths.has(path) || path === allowedMission) &&
+    paths.includes(requiredPath) &&
+    paths.every((path) => allowedPaths.has(path)) &&
     input.intent.changes.every((change) => change.baseBlobSha256 === null && change.candidate !== null) &&
     input.resolvedTaskIds?.every((taskId) => taskId === scope.taskId) === true
   );


### PR DESCRIPTION
# English

## Summary

Every reviewer dispatched by the completion facade (`ha task complete`) ended as `failed` in the GUI even though it exited 0 and its review was durably registered. Root cause: `task-completion-review.ts` tells the reviewer to write its report to `artifacts/reports/<dispatchId>.md`, and `archiveRuntimeDispatch` (`doc-sync-publication.ts`) later writes the runtime's final message to the same path; the archive's freshness check saw the authored file and threw `runtime_archive_collision`, so settlement marked the dispatch failed. Ground truth on dispatch_2ff1d037: the authored report is 2,907 bytes, the final message 768 bytes, so a byte-identical idempotency rule would not have covered it. The archive now keeps a report already authored at the dispatch report path (projected or on disk) and archives only the dispatch record (plus the mission on the first archive); the kernel runtime-archive rule `validRuntimeArchiveChanges` makes the report optional instead of required, since the reviewer already owns it. The settlement error now carries the receipt outcome and code (`op_rejected lease_conflict …`) instead of the opaque `was not applied`.

## Architectural Justification

Ownership of `artifacts/reports/<dispatchId>.md` is single: whoever writes it first under the dispatch's own namespace owns it; the archive is a fallback writer, not a competing one. Mission handling already followed this shape (`existingMissionRef`), so the report now matches it.

## What Changed

`packages/daemon/src/doc-sync-publication.ts` (+17/-6): compute `reportRef`, detect an authored report via projection or authored root, and omit the report document from the archive intent when present. `packages/kernel/src/domain/doc-sync-writer.ts` (+8/-5): `validRuntimeArchiveChanges` requires only `dispatches/<id>.json`; report and mission are allowed, not required. `packages/daemon/src/runtime-spawn-settlement.ts` (+3/-1): include receipt outcome/code/detail in `runtime_archive_failed`. `packages/daemon/test/task-completion-review.integration.test.ts` (+80/-4): fixture can settle the facade reviewer with an authored report; two new cases.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +28/-12 production; tests +80/-4.

## Per-Write Cost

`node tools/gates/cost-budget.mjs` at the canonical root (3279a5de6, base) and in the branch worktree (16a1b6fd4, head), same machine and environment: all 14 probed operations × 5 metrics identical (13 listed below; the probe's `agenda` operation is also identical — 93/93 sqlRowsRead, 0 elsewhere — but the body gate's operation pattern requires a hyphenated name, so it cannot appear in this table) at 200 and 2000; G38 passes on both. The archive change runs once per runtime settlement and is not one of the probed operations; it removes one document from the archive intent when the report is already authored and adds one projection read plus one `existsSync`.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| decision-reckon | sqlRowsRead | 75 | 75 | 75 | 75 |
| decision-reckon | sha256Calls | 28 | 28 | 28 | 28 |
| decision-reckon | sha256Bytes | 8494 | 8535 | 8494 | 8535 |
| decision-reckon | gitProcesses | 6 | 6 | 6 | 6 |
| decision-reckon | fileReadBytes | 1237 | 1245 | 1237 | 1245 |
| decision-reject | sqlRowsRead | 101 | 101 | 101 | 101 |
| decision-reject | sha256Calls | 40 | 40 | 40 | 40 |
| decision-reject | sha256Bytes | 29259 | 29290 | 29259 | 29290 |
| decision-reject | gitProcesses | 6 | 6 | 6 | 6 |
| decision-reject | fileReadBytes | 7219 | 7227 | 7219 | 7227 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| runtime-overview | sqlRowsRead | 150 | 1446 | 150 | 1446 |
| runtime-overview | sha256Calls | 0 | 0 | 0 | 0 |
| runtime-overview | sha256Bytes | 0 | 0 | 0 | 0 |
| runtime-overview | gitProcesses | 0 | 0 | 0 | 0 |
| runtime-overview | fileReadBytes | 0 | 0 | 0 | 0 |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77483 | 77487 | 77483 | 77487 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_7b68cefb782ca4cee90033173c (parent task_f7a3f1a44630ce11e4ff12afdd)
- Branch: `codex/runtime-archive-idempotent`
- Public scope: Task-package runtime archive at settlement (`archiveRuntimeDispatch`), the kernel runtime-archive write rule, and the settlement failure message. No change to what the reviewer is asked to do, to `RecordReview`, or to `ha agent run` dispatches (their reviewers write to the declaration's shared report path and never collided).
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Not changed: the reviewer prompt path convention, `dispatch-read.ts` report path, `ha agent run` archive behavior, GUI rendering of dispatch outcomes. Historical dispatches already marked failed are not rewritten.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `3279a5de6`
- Branch merge-base with `origin/main`: `3279a5de6`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/runtime-archive-idempotent`
- Private evidence commit/path: task_7b68cefb782ca4cee90033173c `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- `node tools/dispatch-isolated-test.mjs --file packages/daemon/test/task-completion-review.integration.test.ts` on the Ubuntu isolation target: tests 11 / pass 11 / fail 0 (exit 0, 30,195 ms). Red before the fix for the authored-report case: with the original collision check the same case settles `failed` (`Runtime archive … is not a fresh task artifact set`, worker's red run); with the daemon change alone but the kernel rule unchanged it settles `failed` with `op_rejected lease_conflict`, which is what the improved settlement message exposed. `--file packages/kernel/test/contracts/doc-sync-runtime-artifacts.test.ts --file packages/daemon/test/runtime-spawn-settlement.test.ts --file packages/daemon/test/fleet-transport.integration.test.ts`: tests 13 / pass 13 / fail 0 (exit 0). `node tools/run-manifest-gates.mjs --changed origin/main`: all 6 gates passed. Negative control retained: with no authored report the archive still writes the final message to the report path (second new case).

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; CEO ground-truthed the worker's first cut (sha256-identical idempotency) against a real failed dispatch and found it would not cover production (authored report ≠ final message); the worker's fixture and red run were kept, the mechanism was replaced by the CEO in the same worktree..
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A dispatch whose worker authored `reports/<id>.md` no longer gets the final message archived there; the final message stays reachable through `resultRef` in `dispatches/<id>.json`. The kernel rule no longer insists the report accompany the dispatch record, so an archive with only the dispatch record is now legal by construction (it was already legal in effect for `ha agent run` dispatches).

## References

- Task: task_7b68cefb782ca4cee90033173c

---

# 中文

## 概要

由完成门面（`ha task complete`）派出的评审员在 GUI 里全部显示「已失败」，尽管进程 exit 0 且评审已 durable 登记。根因：`task-completion-review.ts` 让评审员把报告写到 `artifacts/reports/<dispatchId>.md`，而 `archiveRuntimeDispatch`（`doc-sync-publication.ts`）随后把 runtime 最终消息写到同一路径；归档的「全新 artifact 集」检查看到已存在的文件就抛 `runtime_archive_collision`，结算于是把派工标成 failed。在 dispatch_2ff1d037 上实测：评审员报告 2,907 字节、最终消息 768 字节，按字节一致放行的幂等规则覆盖不到这个案例。现在归档保留已在派工报告路径写好的报告（已投影或仅落盘），只归档 dispatch 记录（首次归档再加 mission）；内核 `validRuntimeArchiveChanges` 把报告从必需改为可选，因为评审员已经拥有它。结算错误改为带回执 outcome 与 code（`op_rejected lease_conflict …`），不再是不透明的 `was not applied`。

## 架构辩护

`artifacts/reports/<dispatchId>.md` 单一归属：在派工自己的命名空间下先写者拥有；归档是兜底写者而非竞争写者。mission 早已如此（`existingMissionRef`），报告与之对齐。

## 改动内容

`packages/daemon/src/doc-sync-publication.ts`（+17/-6）：计算 `reportRef`，经投影或 authored root 判定报告是否已存在，存在则不把报告文档放进归档 intent。`packages/kernel/src/domain/doc-sync-writer.ts`（+8/-5）：`validRuntimeArchiveChanges` 只要求 `dispatches/<id>.json`，报告与 mission 允许但不必需。`packages/daemon/src/runtime-spawn-settlement.ts`（+3/-1）：`runtime_archive_failed` 带回执 outcome/code/detail。`packages/daemon/test/task-completion-review.integration.test.ts`（+80/-4）：fixture 可让门面评审员带已写报告结算；新增两例。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+28/-12 production; tests +80/-4。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_7b68cefb782ca4cee90033173c（父 task_f7a3f1a44630ce11e4ff12afdd）
- 分支：`codex/runtime-archive-idempotent`
- 公开范围：结算时的任务包 runtime 归档（`archiveRuntimeDispatch`）、内核 runtime-archive 写规则、结算失败消息。不改评审员被要求做的事、不改 `RecordReview`、不改 `ha agent run` 派工（其评审员写声明里的共享报告路径，从未碰撞）。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：未改：评审员 prompt 的路径约定、`dispatch-read.ts` 的报告路径、`ha agent run` 归档行为、GUI 对派工结果的呈现。历史上已标 failed 的派工不回写。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`3279a5de6`
- 分支与 `origin/main` 的 merge-base：`3279a5de6`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/runtime-archive-idempotent`
- 私有证据路径：task_7b68cefb782ca4cee90033173c 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- Ubuntu 隔离目标 `node tools/dispatch-isolated-test.mjs --file packages/daemon/test/task-completion-review.integration.test.ts`：tests 11 / pass 11 / fail 0（exit 0，30,195 ms）。修前红：同一「已写报告」用例在原碰撞检查下结算 `failed`（`Runtime archive … is not a fresh task artifact set`，worker 红跑）；只改 daemon 不改内核规则时结算 `failed` 且为 `op_rejected lease_conflict`——正是改进后的结算消息暴露出来的。`--file packages/kernel/test/contracts/doc-sync-runtime-artifacts.test.ts --file packages/daemon/test/runtime-spawn-settlement.test.ts --file packages/daemon/test/fleet-transport.integration.test.ts`：tests 13 / pass 13 / fail 0（exit 0）。`node tools/run-manifest-gates.mjs --changed origin/main`：6 项 gate 全过。阴性对照保留：无已写报告时归档仍把最终消息写到报告路径（第二个新用例）。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；CEO 用一个真实失败派工对 worker 第一刀（sha256 一致即放行）做 ground-truth，发现覆盖不到生产（已写报告 ≠ 最终消息）；保留 worker 的 fixture 与红跑，机制由 CEO 在同一 worktree 内替换。。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- worker 自己写了 `reports/<id>.md` 的派工，最终消息不再归档到该路径；最终消息仍可经 `dispatches/<id>.json` 的 `resultRef` 取到。内核规则不再坚持报告必须与 dispatch 记录同批，只带 dispatch 记录的归档从构造上合法（对 `ha agent run` 派工实际早已如此）。

## 参考

- 任务：task_7b68cefb782ca4cee90033173c

