### PR TITLE
fix: settle GUI task document reads through the shared projection judgment

### DIFF
--- a/packages/daemon/src/doc-sync-reads.ts
+++ b/packages/daemon/src/doc-sync-reads.ts
@@ -28,6 +28,7 @@ import {
   requiredDocSyncText,
 } from "./doc-sync-files.ts";
 import { scanReceipt, scopeTouches } from "./doc-sync-settlement.ts";
+import { requireCurrentTaskProjection } from "./projection-readiness.ts";
 
 export function readAction(input: Input): WriteReceipt {
   if (input.action.kind !== "doc-show") {
@@ -228,16 +229,18 @@ export function readProjectedDocument(
   const { rootDir, projection } = context,
     taskId = requiredDocSyncText(payload.taskId, "taskId"),
     requested = requiredDocSyncText(payload.path, "path"),
-    task = projection.read(taskId);
-  if (!task.packagePath) throw docSyncError("task_not_found", `Task ${taskId} has no projected package path.`);
-  const logical = documentPath(`${task.packagePath}/${requested}`),
+    // Absence settles through the same judgment as task show / dispatches / read-set: a lagging
+    // cut is not an answer about this task, and a current cut without it is a not-found naming it.
+    task = requireCurrentTaskProjection(projection, taskId, "task document read"),
+    packagePath = task.packagePath;
+  const logical = documentPath(`${packagePath}/${requested}`),
     read = projection.readDocument(logical),
     document = read.document,
     // What the accepted policy says this document is, and — before anything is accepted — what the
     // path itself claims. A reader must never have to infer "not text" from an empty body.
     binary =
       document === null ? classifyRawArtifactPath(logical) !== null : document.policyId === RAW_ARTIFACT_POLICY_ID,
-    packageRoot = taskPackageWorktreeRoot(rootDir, task.packagePath),
+    packageRoot = taskPackageWorktreeRoot(rootDir, packagePath),
     worktree = readWorktreeDocument(packageRoot, requested, binary),
     inline =
       binary && document !== null && Number(document.size) <= TASK_DOCUMENT_INLINE_BYTES_MAX
@@ -286,11 +289,13 @@ export function listProjectedTaskDocuments(
   payload: Readonly<Record<string, unknown>>,
 ): import("./protocol/daemon-protocol.contract.ts").DaemonTaskDocumentListResult {
   const taskId = requiredDocSyncText(payload.taskId, "taskId"),
-    task = projection.read(taskId);
-  if (!task.packagePath) throw docSyncError("task_not_found", `Task ${taskId} has no projected package path.`);
-  const prefix = `${task.packagePath}/`,
+    // Same shared judgment as the document read above: the list must not answer a lagging cut
+    // with stale rows, nor a current cut without the task with an empty success.
+    task = requireCurrentTaskProjection(projection, taskId, "task documents list"),
+    packagePath = task.packagePath;
+  const prefix = `${packagePath}/`,
     basis = projection.readReplicaBasis(null),
-    worktree = worktreeDocumentIndex(taskPackageWorktreeRoot(rootDir, task.packagePath), task.packagePath),
+    worktree = worktreeDocumentIndex(taskPackageWorktreeRoot(rootDir, packagePath), packagePath),
     worktreeByPath = new Map(worktree.map((row) => [row.path, row])),
     documents = [
       ...basis.documents

--- a/packages/daemon/src/projection-readiness.ts
+++ b/packages/daemon/src/projection-readiness.ts
@@ -7,7 +7,7 @@ export function requireCurrentTaskProjection(
   projection: Pick<TaskProjection, "read">,
   taskId: string,
   purpose: string,
-): ReturnType<TaskProjection["read"]> {
+): ReturnType<TaskProjection["read"]> & { readonly packagePath: string } {
   const read = projection.read(taskId);
   if (read.watermark < read.sourceRevision)
     throw projectionNotReady(
@@ -20,7 +20,7 @@ export function requireCurrentTaskProjection(
     });
   if (!read.packagePath)
     throw projectionNotReady(`Task ${taskId} has a canonical event but no projected package for ${purpose}`, read);
-  return read;
+  return read as ReturnType<TaskProjection["read"]> & { readonly packagePath: string };
 }
 
 // Serving read faces (task show, task dispatches) resolve one requested id against the applied

--- a/packages/daemon/test/projection-readiness.test.ts
+++ b/packages/daemon/test/projection-readiness.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { tmpdir } from "node:os";
 import test from "node:test";
 import type { TaskProjection } from "../../kernel/src/index.ts";
+import { listProjectedTaskDocuments, readProjectedDocument } from "../src/doc-sync-reads.ts";
 import { requireCurrentTaskProjection } from "../src/projection-readiness.ts";
 import type { RepoCellOperationalContext } from "../src/repo-cell-action-context.ts";
 import { runFactAction } from "../src/repo-cell-fact-action.ts";
@@ -138,6 +139,88 @@ test("a projected task without a package is not ready", () => {
     (error: unknown) =>
       (error as { readonly code?: unknown }).code === "content_not_ready" &&
       /has a canonical event but no projected package for unit test/u.test(String((error as Error).message)),
+  );
+});
+
+function missingTaskRead(): TaskRead {
+  return {
+    ...readyTaskRead(),
+    snapshot: { revision: 0, task: null, lease: null, executions: [] },
+    packagePath: null,
+  } as unknown as TaskRead;
+}
+
+function guiDocumentReadContext(projection: Pick<TaskProjection, "read">) {
+  return {
+    rootDir: tmpdir(),
+    projection: projection as unknown as TaskProjection,
+    store: { readContentBlob: () => null },
+  };
+}
+
+// The GUI document read faces must settle absence the same way task show and dispatches do:
+// a lagging cut is not an answer about the task, a current cut without the task is a not-found
+// naming the id, and a task without a package is a not-ready — never a not-found for a task
+// that does exist.
+test("task document read settles lagging, absent, and unpackaged tasks via the shared judgment", () => {
+  assert.throws(
+    () =>
+      readProjectedDocument(
+        guiDocumentReadContext(
+          projectionOf({ ...readyTaskRead(), status: "pending", watermark: 1, sourceRevision: 2 }),
+        ),
+        { taskId: "task_ready", path: "task_plan.md" },
+      ),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "content_not_ready",
+  );
+  assert.throws(
+    () =>
+      readProjectedDocument(guiDocumentReadContext(projectionOf(missingTaskRead())), {
+        taskId: "task_missing",
+        path: "task_plan.md",
+      }),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "task_not_found",
+  );
+  assert.throws(
+    () =>
+      readProjectedDocument(guiDocumentReadContext(projectionOf({ ...readyTaskRead(), packagePath: null })), {
+        taskId: "task_ready",
+        path: "task_plan.md",
+      }),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "content_not_ready",
+  );
+});
+
+test("task documents list settles lagging, absent, and unpackaged tasks via the shared judgment", () => {
+  assert.throws(
+    () =>
+      listProjectedTaskDocuments(
+        tmpdir(),
+        projectionOf({
+          ...readyTaskRead(),
+          status: "pending",
+          watermark: 1,
+          sourceRevision: 2,
+        }) as unknown as TaskProjection,
+        { taskId: "task_ready" },
+      ),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "content_not_ready",
+  );
+  assert.throws(
+    () =>
+      listProjectedTaskDocuments(tmpdir(), projectionOf(missingTaskRead()) as unknown as TaskProjection, {
+        taskId: "task_missing",
+      }),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "task_not_found",
+  );
+  assert.throws(
+    () =>
+      listProjectedTaskDocuments(
+        tmpdir(),
+        projectionOf({ ...readyTaskRead(), packagePath: null }) as unknown as TaskProjection,
+        { taskId: "task_ready" },
+      ),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "content_not_ready",
   );
 });
 

--- a/packages/daemon/test/task-documents-list.integration.test.ts
+++ b/packages/daemon/test/task-documents-list.integration.test.ts
@@ -79,6 +79,26 @@ test("repo.tasks.documents.list rejects an unknown task with task_not_found", as
   }
 });
 
+test("repo.tasks.document.read rejects an unknown task with task_not_found", async () => {
+  const repoId = "task-doc-read-missing";
+  const rootDir = mkdtempSync(path.join(tmpdir(), `ha-${repoId}-`));
+  initRepo(rootDir);
+  const cell = await openRepoCell({
+    repoId: workspaceId(repoId),
+    rootDir: canonicalRoot(rootDir),
+    ownerId: `daemon-${repoId}`,
+  });
+  try {
+    await assert.rejects(
+      () => cell.read("repo.tasks.document.read", { taskId: "task-missing", path: "task_plan.md" }),
+      (error: unknown) => (error as { code?: string }).code === "task_not_found",
+    );
+  } finally {
+    await cell.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
 function initRepo(rootDir: string): void {
   git(rootDir, "init", "--quiet");
   git(rootDir, "config", "user.name", "Task Doc List Test");


### PR DESCRIPTION
# English

## Summary

Third and final cut for this task. The closeout review of PR #2591 found that Goal 3 covers every task read face taking a taskId, and two GUI reads were still outside the shared judgment: `readProjectedDocument` (repo.tasks.document.read) and `listProjectedTaskDocuments` (repo.tasks.documents.list) each called `projection.read(taskId)` and threw their own `task_not_found` when the package path was missing, which reported a lagging projection cut as not-found. Both now call `requireCurrentTaskProjection`, the same judgment task show, task dispatches, task read-set and task review use: a lagging cut is `projection_not_ready` (the caller's pending case), and a current cut without the task is `task_not_found` naming the id. The shared helper's return type now narrows `packagePath` to a string, since it already throws when the package is missing, so no caller needs a non-null assertion.

## Architectural Justification

One judgment about whether a task exists at the current cut, in one place: `requireCurrentTaskProjection`. Every read face taking a taskId consults it rather than repeating the rule, which is what made the lagging-cut case answer differently in different faces.

## What Changed

`packages/daemon/src/doc-sync-reads.ts` (+13/-8): both faces resolve the task through `requireCurrentTaskProjection` and their own `task_not_found` branches are deleted. `packages/daemon/src/projection-readiness.ts` (+2/-2): the return type narrows `packagePath` to `string`. `packages/daemon/test/projection-readiness.test.ts` (+83): two cases pinning lagging, absent and unpackaged tasks for both faces. `packages/daemon/test/task-documents-list.integration.test.ts` (+20): the not-found case at the integration level.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +15/-10 production; tests +103/-0.

## Per-Write Cost

`node tools/gates/cost-budget.mjs` on the base and in the branch worktree, same machine: every probed operation and metric identical at 200 and 2000, G38 passes on both. The two read faces are GUI reads, not probed write operations; the change replaces one `projection.read` with the shared helper's single `projection.read`, so no read is added.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| decision-reckon | sqlRowsRead | 75 | 75 | 75 | 75 |
| decision-reckon | sha256Calls | 28 | 28 | 28 | 28 |
| decision-reckon | sha256Bytes | 8494 | 8535 | 8494 | 8535 |
| decision-reckon | gitProcesses | 6 | 6 | 6 | 6 |
| decision-reckon | fileReadBytes | 1237 | 1245 | 1237 | 1245 |
| decision-reject | sqlRowsRead | 101 | 101 | 101 | 101 |
| decision-reject | sha256Calls | 40 | 40 | 40 | 40 |
| decision-reject | sha256Bytes | 29259 | 29290 | 29259 | 29290 |
| decision-reject | gitProcesses | 6 | 6 | 6 | 6 |
| decision-reject | fileReadBytes | 7219 | 7227 | 7219 | 7227 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| runtime-overview | sqlRowsRead | 150 | 1446 | 150 | 1446 |
| runtime-overview | sha256Calls | 0 | 0 | 0 | 0 |
| runtime-overview | sha256Bytes | 0 | 0 | 0 | 0 |
| runtime-overview | gitProcesses | 0 | 0 | 0 | 0 |
| runtime-overview | fileReadBytes | 0 | 0 | 0 | 0 |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77483 | 77487 | 77483 | 77487 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_9bfc30291aa26570c662f67c47 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/read-face-gui-documents`
- Public scope: The two GUI task-document read faces in `doc-sync-reads.ts` and the return type of `requireCurrentTaskProjection`. No change to the GUI renderer, to the protocol contract, or to what the faces return on success.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Not changed: the GUI renderer's handling of either error, the daemon protocol contract, other read faces already on the shared judgment, and the kernel projection itself.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9165264d7`
- Branch merge-base with `origin/main`: `9165264d7`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/read-face-gui-documents`
- Private evidence commit/path: task_9bfc30291aa26570c662f67c47 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Red before the change: `node tools/run-node-tests.mjs --file packages/daemon/test/projection-readiness.test.ts` → tests 8 / pass 6 / fail 2, the two new cases failing because the old implementation never judged the cut. Green after: tests 8 / pass 8 / fail 0. Mutation control by the worker: commenting out the shared judgment's `task_not_found` branch turns three cases red, then restored. Isolation target (Ubuntu, exit 0): task-documents-list 4/4, artifacts-gui-read 1/1, dispatch-parent-session 2/2, migration-import-replay-records 8/8, remote-proxy 7/7, task-raw-artifact-consumer-read 2/2, dispatch-read 15/15, agenda 5/5, json-rpc-protocol 48/48, rejection-next-actions 12/12, task-read-set 1/1, task-surface-pages-facts 2/2. After the CEO's type narrowing, rerun: readiness 8/8 and the three GUI read integration files exit 0. `node tools/run-manifest-gates.mjs --changed origin/main`: all gates passed.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; CEO ground-truthed the reviewer's finding against the submitted commit before dispatching the third cut, and after the worker's report replaced its non-null assertions by narrowing the shared helper's return type, then reran the readiness and GUI read tests..
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A GUI client that previously saw `task_not_found` for a lagging cut now sees `projection_not_ready`. That is the intended distinction and matches the other read faces, but a client special-casing the old code for these two calls would need to follow.

## References

- Task: task_9bfc30291aa26570c662f67c47

---

# 中文

## 概要

本任务第三刀，收口。PR #2591 的收官评审指出 Goal 3 覆盖所有带 taskId 的 task 读面，而两个 GUI 读面仍在共享判定之外：`readProjectedDocument`（repo.tasks.document.read）与 `listProjectedTaskDocuments`（repo.tasks.documents.list）各自 `projection.read(taskId)`，在缺 package path 时自抛 `task_not_found`，把「投影落后的 cut」也报成 not-found。现两者改用 `requireCurrentTaskProjection`——与 task show、task dispatches、task read-set、task review 同一判定：落后 cut 给 `projection_not_ready`（调用方的 pending 情形），当前 cut 无此 task 才给点名 id 的 `task_not_found`。共享判定的返回类型把 `packagePath` 收窄为 string（它本就在缺 package 时抛错），调用方不再需要非空断言。

## 架构辩护

「当前 cut 下这个 task 是否存在」只有一个判定、只在一处：`requireCurrentTaskProjection`。所有带 taskId 的读面查它而不是各自重写规则——规则重复正是落后 cut 在不同读面上给出不同答案的原因。

## 改动内容

`packages/daemon/src/doc-sync-reads.ts`（+13/-8）：两个读面经 `requireCurrentTaskProjection` 解析任务，各自的 `task_not_found` 分支删除。`packages/daemon/src/projection-readiness.ts`（+2/-2）：返回类型把 `packagePath` 收窄为 `string`。`packages/daemon/test/projection-readiness.test.ts`（+83）：两例钉住两个读面的落后 cut、不存在、无 package 三种情形。`packages/daemon/test/task-documents-list.integration.test.ts`（+20）：integration 层的 not-found 用例。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+15/-10 production; tests +103/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_9bfc30291aa26570c662f67c47（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/read-face-gui-documents`
- 公开范围：`doc-sync-reads.ts` 里的两个 GUI 任务文档读面，以及 `requireCurrentTaskProjection` 的返回类型。不改 GUI 渲染层、不改协议契约、不改两个读面成功路径的返回内容。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：未改：GUI 渲染层对两种错误的处理、daemon 协议契约、已在共享判定上的其他读面、内核投影本身。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9165264d7`
- 分支与 `origin/main` 的 merge-base：`9165264d7`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/read-face-gui-documents`
- 私有证据路径：task_9bfc30291aa26570c662f67c47 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 修前红：`node tools/run-node-tests.mjs --file packages/daemon/test/projection-readiness.test.ts` → tests 8 / pass 6 / fail 2，两条新用例失败，因为旧实现从不判 cut。修后绿：tests 8 / pass 8 / fail 0。worker 做了变异对照：注释掉共享判定的 `task_not_found` 分支后三条转红，随后恢复。隔离目标（Ubuntu，exit 0）：task-documents-list 4/4、artifacts-gui-read 1/1、dispatch-parent-session 2/2、migration-import-replay-records 8/8、remote-proxy 7/7、task-raw-artifact-consumer-read 2/2、dispatch-read 15/15、agenda 5/5、json-rpc-protocol 48/48、rejection-next-actions 12/12、task-read-set 1/1、task-surface-pages-facts 2/2。CEO 收窄类型后复跑：readiness 8/8，三个 GUI 读面 integration 文件 exit 0。`node tools/run-manifest-gates.mjs --changed origin/main`：全部通过。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；CEO 先对提交 commit 复核评审员的发现再派第三刀；worker 交付后，把它的非空断言改为收窄共享判定的返回类型，并复跑 readiness 与 GUI 读面测试。。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 此前在落后 cut 上看到 `task_not_found` 的 GUI 客户端现在会看到 `projection_not_ready`。这正是本次要建立的区分，与其他读面一致；若有客户端对这两个调用特判旧码，需要跟随修改。

## 参考

- 任务：task_9bfc30291aa26570c662f67c47

