### PR TITLE
fix: settle the task completion read through the shared projection judgment

### DIFF
--- a/packages/daemon/src/task-completion-read.ts
+++ b/packages/daemon/src/task-completion-read.ts
@@ -10,6 +10,7 @@ import {
 } from "../../kernel/src/index.ts";
 import { readTaskTransitionDocument } from "./transition-document-access.ts";
 import { readEffectiveCloseoutGates } from "./repo-cell-settings-state.ts";
+import { requireCurrentTaskProjection } from "./projection-readiness.ts";
 
 /** Explicit --consent is recorded under every profile; the profile only decides whether absence blocks. */
 export function completionBlockersForAction(
@@ -69,7 +70,10 @@ export function readCompletionContext(
 }
 
 export function readTaskCompletion(projection: TaskProjectionQueries, taskId: string): DaemonTaskCompletionResult {
-  const read = projection.read(taskId);
+  // The same judgment task show, task dispatches, task read-set, task review and the task document
+  // reads consult: a lagging cut is not an answer about this task, and a current cut without it is a
+  // not-found naming the id — never an ok-shaped completion for a task that does not exist.
+  const read = requireCurrentTaskProjection(projection, taskId, "task completion read");
   return {
     ok: true,
     taskId,

--- a/packages/daemon/test/projection-readiness.test.ts
+++ b/packages/daemon/test/projection-readiness.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import type { TaskProjection } from "../../kernel/src/index.ts";
 import { listProjectedTaskDocuments, readProjectedDocument } from "../src/doc-sync-reads.ts";
 import { requireCurrentTaskProjection } from "../src/projection-readiness.ts";
+import { readTaskCompletion } from "../src/task-completion-read.ts";
 import type { RepoCellOperationalContext } from "../src/repo-cell-action-context.ts";
 import { runFactAction } from "../src/repo-cell-fact-action.ts";
 import type { RepoCellBinding } from "../src/repo-cell-types.ts";
@@ -235,3 +236,22 @@ function readyTaskRead(): TaskRead {
     catchUp: { maxItems: 1, reducedItems: 1, sqliteTransactions: 1 },
   } as unknown as TaskRead;
 }
+
+test("task completion read settles lagging, absent, and unpackaged tasks via the shared judgment", () => {
+  assert.throws(
+    () =>
+      readTaskCompletion(
+        projectionOf({ ...readyTaskRead(), status: "pending", watermark: 1, sourceRevision: 2 }),
+        "task_ready",
+      ),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "content_not_ready",
+  );
+  assert.throws(
+    () => readTaskCompletion(projectionOf(missingTaskRead()), "task_missing"),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "task_not_found",
+  );
+  assert.throws(
+    () => readTaskCompletion(projectionOf({ ...readyTaskRead(), packagePath: null }), "task_ready"),
+    (error: unknown) => (error as { readonly code?: unknown }).code === "content_not_ready",
+  );
+});


### PR DESCRIPTION
# English

## Summary

Fourth and last cut for this task, after PR #2588, #2591 and #2607. The review of the third cut found the remaining read face: `repo.tasks.completion.read` reached `readTaskCompletion`, which called `projection.read(taskId)` directly and returned an ok-shaped completion result for a task the current cut does not have, and answered from a lagging cut as though it were current. It now uses `requireCurrentTaskProjection`, the same judgment behind task show, task dispatches, task read-set, task review and the two task document reads. An exhaustive sweep of the remaining callers is recorded below: every other direct `projection.read(taskId)` in the daemon is a write path that already holds the task lease, so Goal 3's read-only scope is now closed.

## Architectural Justification

One judgment about whether a task exists at the current cut, consulted by every read-only face that takes a taskId. This cut closes the set rather than fixing one more face: the sweep below is what makes 'every such face' checkable instead of asserted.

## What Changed

`packages/daemon/src/task-completion-read.ts` (+5/-1): `readTaskCompletion` resolves the task through `requireCurrentTaskProjection` instead of a bare `projection.read`. `packages/daemon/test/projection-readiness.test.ts` (+20): a case pinning lagging, absent and unpackaged tasks for this face, alongside the existing cases for the other faces.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +5/-1 production; tests +20/-0.

## Per-Write Cost

`node tools/gates/cost-budget.mjs` on the base and on this branch, same machine: every probed operation and metric identical at 200 and 2000, G38 passes on both. The change replaces one `projection.read` with the shared helper's single `projection.read`, so no read is added.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| decision-reckon | sqlRowsRead | 75 | 75 | 75 | 75 |
| decision-reckon | sha256Calls | 28 | 28 | 28 | 28 |
| decision-reckon | sha256Bytes | 8494 | 8535 | 8494 | 8535 |
| decision-reckon | gitProcesses | 6 | 6 | 6 | 6 |
| decision-reckon | fileReadBytes | 1237 | 1245 | 1237 | 1245 |
| decision-reject | sqlRowsRead | 101 | 101 | 101 | 101 |
| decision-reject | sha256Calls | 40 | 40 | 40 | 40 |
| decision-reject | sha256Bytes | 29259 | 29290 | 29259 | 29290 |
| decision-reject | gitProcesses | 6 | 6 | 6 | 6 |
| decision-reject | fileReadBytes | 7219 | 7227 | 7219 | 7227 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| runtime-overview | sqlRowsRead | 150 | 1446 | 150 | 1446 |
| runtime-overview | sha256Calls | 0 | 0 | 0 | 0 |
| runtime-overview | sha256Bytes | 0 | 0 | 0 | 0 |
| runtime-overview | gitProcesses | 0 | 0 | 0 | 0 |
| runtime-overview | fileReadBytes | 0 | 0 | 0 | 0 |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77483 | 77487 | 77483 | 77487 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_9bfc30291aa26570c662f67c47 (parent task_2b8f79fa4412cb726a26f9bfc7)
- Branch: `codex/read-face-completion`
- Public scope: `readTaskCompletion` in `task-completion-read.ts` and one regression case. No change to `readCompletionContext`, to completion semantics for a task that does exist, or to the write paths that call `readTaskCompletion` while holding a lease.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Not changed: the GUI renderer, the protocol contract for this method, and the write paths' own lease-based resolution.

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9192d4ece`
- Branch merge-base with `origin/main`: `9192d4ece`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/read-face-completion`
- Private evidence commit/path: task_9bfc30291aa26570c662f67c47 `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Red control: with only the source change reverted and the test kept, `node tools/run-node-tests.mjs --file packages/daemon/test/projection-readiness.test.ts` gave tests 9 / pass 8 / fail 1, the new case failing. Green with the change: tests 9 / pass 9 / fail 0. Isolation target (Ubuntu, exit 0): `task-completion-review.integration.test.ts` and `task-documents-list.integration.test.ts` both pass, 4/4 on the last file reported. `node tools/run-manifest-gates.mjs --changed origin/main`: all gates passed.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; CEO ground-truthed the reviewer's finding, then swept the daemon rather than fixing only the named face: `grep -rn "projection.read(taskId)" packages/daemon/src` returns 22 call sites; excluding the shared helper itself, `repo.tasks.completion.read` was the only remaining read-only face, and the other 20 are in task-maintenance, task-create, task-command-docs, completion, task-progress, action-dispatch, repo-cell-open and doc-sync-command-actions, all write paths that resolve the task under a lease. The task read faces exposed by `repo-cell-api.ts` are `repo.task.dispatches`, `repo.tasks.completion.read`, `repo.tasks.document.read`, `repo.tasks.documents.list` (all now on the shared judgment) plus `repo.tasks.list` and `repo.tasks.wip`, which take no taskId..
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A GUI client that previously received an ok-shaped completion result for an unknown or lagging task now receives `task_not_found` or `content_not_ready`. That is the intended distinction and matches every other task read face.

## References

- Task: task_9bfc30291aa26570c662f67c47

---

# 中文

## 概要

本任务第四刀，也是最后一刀（前三刀为 PR #2588、#2591、#2607）。第三刀的评审找出剩下的那个读面：`repo.tasks.completion.read` 走到 `readTaskCompletion`，它直接 `projection.read(taskId)`，对当前 cut 里不存在的 task 仍返回 ok 形状的完成结果，对落后的 cut 也当作当前答复。现改用 `requireCurrentTaskProjection`——task show、task dispatches、task read-set、task review 与两个任务文档读面共用的那个判定。剩余调用方已穷举核对（见下）：daemon 里其他直接 `projection.read(taskId)` 全部是已持有任务租约的写路径，Goal 3 的只读范围至此收口。

## 架构辩护

「当前 cut 下这个 task 是否存在」只有一个判定，所有带 taskId 的只读面都查它。本刀的意义是把这个集合封口，而不是再修一个面：下面的穷举让「所有这类面」可核对而不只是断言。

## 改动内容

`packages/daemon/src/task-completion-read.ts`（+5/-1）：`readTaskCompletion` 经 `requireCurrentTaskProjection` 解析任务，不再裸调 `projection.read`。`packages/daemon/test/projection-readiness.test.ts`（+20）：为该读面补落后 cut、不存在、无 package 三种情形的用例，与其他读面的已有用例并列。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+5/-1 production; tests +20/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_9bfc30291aa26570c662f67c47（父 task_2b8f79fa4412cb726a26f9bfc7）
- 分支：`codex/read-face-completion`
- 公开范围：`task-completion-read.ts` 的 `readTaskCompletion` 与一条回归用例。不改 `readCompletionContext`、不改存在的 task 的完成语义、不改持有租约时调用 `readTaskCompletion` 的写路径。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：未改：GUI 渲染层、该方法的协议契约、写路径自身基于租约的解析。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9192d4ece`
- 分支与 `origin/main` 的 merge-base：`9192d4ece`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/read-face-completion`
- 私有证据路径：task_9bfc30291aa26570c662f67c47 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 阴性对照：只回退源码改动、保留测试，`node tools/run-node-tests.mjs --file packages/daemon/test/projection-readiness.test.ts` → tests 9 / pass 8 / fail 1，新用例失败。带改动为绿：tests 9 / pass 9 / fail 0。隔离目标（Ubuntu，exit 0）：`task-completion-review.integration.test.ts` 与 `task-documents-list.integration.test.ts` 均通过。`node tools/run-manifest-gates.mjs --changed origin/main`：全部通过。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；CEO 先复核评审员的发现，然后不是只修被点名的那个面，而是把 daemon 扫了一遍：`grep -rn "projection.read(taskId)" packages/daemon/src` 命中 22 处；除共享判定自身外，只读面只剩 `repo.tasks.completion.read` 一个，另外 20 处分布在 task-maintenance、task-create、task-command-docs、completion、task-progress、action-dispatch、repo-cell-open 与 doc-sync-command-actions，全部是在租约下解析任务的写路径。`repo-cell-api.ts` 暴露的 task 读面为 `repo.task.dispatches`、`repo.tasks.completion.read`、`repo.tasks.document.read`、`repo.tasks.documents.list`（现均在共享判定上），以及不带 taskId 的 `repo.tasks.list` 与 `repo.tasks.wip`。。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 此前对未知或落后 cut 的 task 收到 ok 形状完成结果的 GUI 客户端，现在会收到 `task_not_found` 或 `content_not_ready`。这正是要建立的区分，与其他所有 task 读面一致。

## 参考

- 任务：task_9bfc30291aa26570c662f67c47

