### PR TITLE
fix: settle runtimes whose process is gone instead of counting them live forever

### DIFF
--- a/packages/daemon/src/dispatch-read.ts
+++ b/packages/daemon/src/dispatch-read.ts
@@ -23,7 +23,7 @@ import type {
   TaskDispatchRow,
 } from "./protocol/daemon-protocol.contract.ts";
 import type { AgentRuntimeAttemptChainDto } from "./agent-runtime-contract.ts";
-import { runtimePidIsAlive } from "./runtime-spawn-process.ts";
+import { runtimePidIsAlive } from "./runtime-process-liveness.ts";
 import { projectedTaskNotFound } from "./projection-readiness.ts";
 
 type DispatchLiveIndexRow = ReturnType<typeof readDispatchLiveIndex>["entries"][number];

--- a/packages/daemon/src/repo-cell-task-mutation.ts
+++ b/packages/daemon/src/repo-cell-task-mutation.ts
@@ -14,7 +14,7 @@ import {
   type TaskV2,
 } from "../../kernel/src/index.ts";
 import { readDispatchLiveIndex, readDispatchStreamSummary } from "./dispatch-stream.ts";
-import { runtimePidIsAlive } from "./runtime-spawn-process.ts";
+import { runtimePidIsAlive } from "./runtime-process-liveness.ts";
 import type { RepoCellBinding, RepoTaskAction, Snapshot } from "./repo-cell-types.ts";
 import type { RepoCellActionContext } from "./repo-cell-action-context.ts";
 

--- a/packages/daemon/src/runtime-process-liveness.ts
+++ b/packages/daemon/src/runtime-process-liveness.ts
@@ -1,0 +1,17 @@
+import { childProcessErrorCode } from "./runtime-spawn-process.ts";
+
+/** Whether one runtime worker process is still around, asked of the operating system rather than of
+ * any record the daemon keeps. Adoption, cancel, the dispatch read face and the shutdown drain all
+ * settle liveness here, so none of them can outlive the process it is speaking for. */
+export function runtimePidIsAlive(pid: number): boolean {
+  // POSIX kill(0, sig) addresses the caller's own process group and kill(negative, sig) a group by
+  // id, so either would answer "alive" for a runtime that has no process at all. A runtime pid is a
+  // single process or it is nothing.
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return childProcessErrorCode(error) === "EPERM";
+  }
+}

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -102,7 +102,9 @@ export async function adoptRuntimes(context: RuntimeSpawnerContext): Promise<voi
       event: "runtime_spawn",
       runtimeSessionId: active.runtimeSessionId,
       dispatchId: active.dispatchId,
-      pid: active.process.pid,
+      // A session adopted without a recorded process has no pid to report; the drain count follows
+      // live pids, so reporting a placeholder would keep counting a runtime that does not exist.
+      ...(processState ? { pid: processState.pid } : {}),
     });
     await restoreDurableOutputRecords(context, active, fullStream?.records ?? []);
     if (session.liveness !== "live") {

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -45,14 +45,13 @@ export async function adoptRuntimes(context: RuntimeSpawnerContext): Promise<voi
     }
     const fullStream = readDispatchStream(context.input.rootDir, header.dispatchId),
       stream = fullStream ?? readDispatchStreamSummary(context.input.rootDir, header.dispatchId);
-    if (!stream?.process) {
-      removeRuntimeCallbackRelay(context.input.rootDir, header.dispatchId);
-      continue;
-    }
+    if (!stream) continue;
+    const processState = stream.process,
+      processPid = processState?.pid ?? 0;
     const runtimeProcess = adoptNativeProcess(
       context.input.rootDir,
       stream.header.dispatchId,
-      stream.process.pid,
+      processPid,
       durableOutputRecordCount(fullStream?.records ?? []),
     );
     if (!fullStream) runtimeProcess.release?.();
@@ -114,14 +113,15 @@ export async function adoptRuntimes(context: RuntimeSpawnerContext): Promise<voi
         active.binding,
       );
     }
-    const processState = stream.process;
-    if (processState.exited || !runtimePidIsAlive(processState.pid)) {
-      const reason = `runtime process ${String(processState.pid)} is no longer alive after daemon restart`;
-      active.lossReason = processState.exited ? null : reason;
-      active.lossExitCode = processState.exitCode ?? null;
-      active.lossSignal = processState.signal ?? null;
+    if (!processState || processState.exited || !runtimePidIsAlive(processState.pid)) {
+      const reason = processState
+        ? `runtime process ${String(processState.pid)} is no longer alive after daemon restart`
+        : "runtime process was never recorded before daemon restart";
+      active.lossReason = processState?.exited ? null : reason;
+      active.lossExitCode = processState?.exitCode ?? null;
+      active.lossSignal = processState?.signal ?? null;
       removeRuntimeCallbackRelay(context.input.rootDir, active.dispatchId);
-      if (!processState.exited)
+      if (!processState?.exited)
         appendRuntimeWorkerRecord(context.input.rootDir, active.dispatchId, {
           kind: "process_lost",
           occurredAt: context.input.now(),
@@ -137,7 +137,7 @@ export async function adoptRuntimes(context: RuntimeSpawnerContext): Promise<voi
   }
 }
 
-function ownedByRuntimeNode(binding: RuntimeBinding, runtimeNodeId: string | undefined): boolean {
+export function ownedByRuntimeNode(binding: RuntimeBinding, runtimeNodeId: string | undefined): boolean {
   if (runtimeNodeId === undefined) return true;
   const source: unknown = binding.source;
   if (source === null || typeof source !== "object" || Array.isArray(source)) return false;

--- a/packages/daemon/src/runtime-spawn-adoption.ts
+++ b/packages/daemon/src/runtime-spawn-adoption.ts
@@ -8,7 +8,8 @@ import {
 } from "./dispatch-stream.ts";
 import { removeRuntimeCallbackRelay } from "./runtime-callback-relay.ts";
 import { createActiveRuntime, attachActiveRuntime } from "./runtime-spawn-active.ts";
-import { adoptNativeProcess, runtimePidIsAlive } from "./runtime-spawn-process.ts";
+import { adoptNativeProcess } from "./runtime-spawn-process.ts";
+import { runtimePidIsAlive } from "./runtime-process-liveness.ts";
 import {
   consumeDurableOutput,
   durableOutputRecordCount,

--- a/packages/daemon/src/runtime-spawn-control.ts
+++ b/packages/daemon/src/runtime-spawn-control.ts
@@ -2,8 +2,8 @@ import { createHash } from "node:crypto";
 import { unknownFieldViolation, type JsonObject } from "./protocol/json-rpc-types.ts";
 import { requiredRuntimeSpawnText, runtimeSpawnError } from "./runtime-spawn-errors.ts";
 import { consumeDurableOutput } from "./runtime-spawn-provider-stream.ts";
-import { adoptRuntimes } from "./runtime-spawn-adoption.ts";
-import { readDispatchStreamHeaders } from "./dispatch-stream.ts";
+import { adoptRuntimes, ownedByRuntimeNode } from "./runtime-spawn-adoption.ts";
+import { readDispatchStreamHeaders, readDispatchStreamSummary } from "./dispatch-stream.ts";
 import type { RuntimeBinding } from "./runtime-spawn-types.ts";
 import type { RuntimeSpawnerContext } from "./runtime-spawn-context.ts";
 
@@ -21,7 +21,14 @@ export async function cancelRuntime(
   const runtimeSessionId = requiredRuntimeSpawnText(payload.runtimeSessionId, "runtimeSessionId"),
     hash = createHash("sha256").update(`${context.input.repoId}\0${runtimeSessionId}`).digest("hex"),
     opId = `runtime-cancel-${hash.slice(0, 32)}`;
-  if (!context.processes.has(runtimeSessionId)) await adoptRuntimes(context);
+  const headers = readDispatchStreamHeaders(context.input.rootDir),
+    matchingHeader = headers.find((header) => header.runtimeSessionId === runtimeSessionId),
+    missingOwnedProcess =
+      matchingHeader !== undefined &&
+      matchingHeader.binding !== undefined &&
+      ownedByRuntimeNode(matchingHeader.binding, context.input.runtimeNodeId) &&
+      !readDispatchStreamSummary(context.input.rootDir, matchingHeader.dispatchId)?.process;
+  if (!context.processes.has(runtimeSessionId) && !missingOwnedProcess) await adoptRuntimes(context);
   const active = context.processes.get(runtimeSessionId);
   if (active) {
     active.cancelBinding = binding;
@@ -38,15 +45,14 @@ export async function cancelRuntime(
   }
   // A session with a dispatch record belongs to adoption above; only a session the projection
   // knows without any dispatch record is settled from the projection alone.
-  const recorded = readDispatchStreamHeaders(context.input.rootDir).some(
-      (header) => header.runtimeSessionId === runtimeSessionId,
-    ),
-    session = recorded
-      ? undefined
-      : (context.input.remote
-          ? await context.input.remote.readRuntimeSessions()
-          : context.requiredRuntimeProjection(context.input).readRuntimeSessions()
-        ).find((value) => value.runtimeSessionId === runtimeSessionId);
+  const recorded = headers.some((header) => header.runtimeSessionId === runtimeSessionId),
+    session =
+      recorded && !missingOwnedProcess
+        ? undefined
+        : (context.input.remote
+            ? await context.input.remote.readRuntimeSessions()
+            : context.requiredRuntimeProjection(context.input).readRuntimeSessions()
+          ).find((value) => value.runtimeSessionId === runtimeSessionId);
   if (session && session.liveness !== "exited" && session.outcome === null) {
     const terminalBinding = {
       ...binding,

--- a/packages/daemon/src/runtime-spawn-process.ts
+++ b/packages/daemon/src/runtime-spawn-process.ts
@@ -17,6 +17,7 @@ import {
   type DispatchStreamWriter,
 } from "./dispatch-stream.ts";
 import { removeRuntimeCallbackRelay } from "./runtime-callback-relay.ts";
+import { runtimePidIsAlive } from "./runtime-process-liveness.ts";
 import { runtimeSpawnError } from "./runtime-spawn-errors.ts";
 import { parseProviderFrame } from "./runtime-spawn-provider-frames.ts";
 import type { ResumeProcessEvent, ResumeProcessObservation, RuntimeProcess } from "./runtime-spawn-types.ts";
@@ -302,19 +303,6 @@ export async function terminateRuntimeTree(rootDir: string, dispatchId: string, 
       "runtime_cancel_failed",
       `Runtime cancel left descendant processes alive: ${survivors.join(", ")}.`,
     );
-}
-
-export function runtimePidIsAlive(pid: number): boolean {
-  // POSIX kill(0, sig) addresses the caller's whole process group, and kill(negative, sig) a group by
-  // id, so either would answer "alive" for a runtime that has no process at all. A runtime pid is a
-  // single process or it is nothing.
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return childProcessErrorCode(error) === "EPERM";
-  }
 }
 
 export function launchExitNotification(input: {

--- a/packages/daemon/src/runtime-spawn-process.ts
+++ b/packages/daemon/src/runtime-spawn-process.ts
@@ -305,6 +305,10 @@ export async function terminateRuntimeTree(rootDir: string, dispatchId: string, 
 }
 
 export function runtimePidIsAlive(pid: number): boolean {
+  // POSIX kill(0, sig) addresses the caller's whole process group, and kill(negative, sig) a group by
+  // id, so either would answer "alive" for a runtime that has no process at all. A runtime pid is a
+  // single process or it is nothing.
+  if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
     process.kill(pid, 0);
     return true;

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -9,7 +9,7 @@ import { openDaemonRequestLog } from "./request-log.ts";
 import { openDaemonLifecycleLog } from "./lifecycle-log.ts";
 import { openDaemonConnLog } from "./conn-log.ts";
 import { daemonBuildStamp, observeDaemonBuild } from "./build-identity.ts";
-import { runtimePidIsAlive } from "./runtime-spawn-process.ts";
+import { runtimePidIsAlive } from "./runtime-process-liveness.ts";
 import { createUnixSocketTransportServer } from "./transport/unix-socket.ts";
 import type { DaemonHostOpenInput } from "./daemon-host-open.ts";
 import type { DaemonLifecycleEntry, DaemonLifecycleRecorder } from "./lifecycle-log.ts";

--- a/packages/daemon/src/runtime.ts
+++ b/packages/daemon/src/runtime.ts
@@ -9,6 +9,7 @@ import { openDaemonRequestLog } from "./request-log.ts";
 import { openDaemonLifecycleLog } from "./lifecycle-log.ts";
 import { openDaemonConnLog } from "./conn-log.ts";
 import { daemonBuildStamp, observeDaemonBuild } from "./build-identity.ts";
+import { runtimePidIsAlive } from "./runtime-spawn-process.ts";
 import { createUnixSocketTransportServer } from "./transport/unix-socket.ts";
 import type { DaemonHostOpenInput } from "./daemon-host-open.ts";
 import type { DaemonLifecycleEntry, DaemonLifecycleRecorder } from "./lifecycle-log.ts";
@@ -71,11 +72,11 @@ export async function startDaemon(input: {
     buildSupersessionObserved = false,
     socketBound = false,
     stopping = false;
-  const liveRuntimeSessions = new Set<string>();
+  const runtimeProcessPids = new Map<string, number>();
   const buildDrainStatus = (): DaemonBuildDrainStatus => {
     const repos = host?.status().repos ?? [];
     return {
-      liveRuntimeSessions: liveRuntimeSessions.size,
+      liveRuntimeSessions: [...runtimeProcessPids.values()].filter(runtimePidIsAlive).length,
       pendingWrites: repos.reduce((total, repo) => total + (repo.queueDepth ?? 0), 0),
       attachingRepositories: repos.filter((repo) => repo.state === "warming").length,
     };
@@ -129,8 +130,9 @@ export async function startDaemon(input: {
   };
   const recordLifecycle: DaemonLifecycleRecorder = (entry: DaemonLifecycleEntry): void => {
     lifecycle.record(entry);
-    if (entry.event === "runtime_spawn" && entry.runtimeSessionId) liveRuntimeSessions.add(entry.runtimeSessionId);
-    if (entry.event === "runtime_exit" && entry.runtimeSessionId) liveRuntimeSessions.delete(entry.runtimeSessionId);
+    if (entry.event === "runtime_spawn" && entry.runtimeSessionId && entry.pid !== undefined)
+      runtimeProcessPids.set(entry.runtimeSessionId, entry.pid);
+    if (entry.event === "runtime_exit" && entry.runtimeSessionId) runtimeProcessPids.delete(entry.runtimeSessionId);
     if (entry.event === "runtime_exit" || entry.event === "attachments_settled") requestDrainCheck();
   };
   try {

--- a/packages/daemon/test/daemon-build-drain.integration.test.ts
+++ b/packages/daemon/test/daemon-build-drain.integration.test.ts
@@ -94,6 +94,12 @@ test("a drifted daemon serves a command and reports its old build while a runtim
             dispatchId: "dispatch-still-live",
             pid: process.pid,
           });
+          input.recordLifecycle?.({
+            event: "runtime_spawn",
+            runtimeSessionId: "runtime-already-gone",
+            dispatchId: "dispatch-already-gone",
+            pid: 2_147_483_647,
+          });
           return cell;
         },
       }),

--- a/packages/daemon/test/runtime-missing-process.test.ts
+++ b/packages/daemon/test/runtime-missing-process.test.ts
@@ -1,0 +1,106 @@
+// harness-test-tier: fast
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { openDispatchStream } from "../src/dispatch-stream.ts";
+import { adoptRuntimes } from "../src/runtime-spawn-adoption.ts";
+import { cancelRuntime } from "../src/runtime-spawn-control.ts";
+
+const binding = { actor: { principal: { personId: "operator" }, executor: null }, source: "local" as const };
+
+test("adoption settles an owned live session whose dispatch never recorded a process", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-dispatch-missing-process-"));
+  try {
+    const dispatchId = "dispatch_dddddddddddddddddddddddd",
+      runtimeSessionId = "runtime_dddddddddddddddddddddddd";
+    openMissingProcessStream(rootDir, dispatchId, runtimeSessionId, "dispatch-op-missing-process");
+    const settled: Array<{ readonly runtimeSessionId: string; readonly reason: string | null }> = [],
+      context = {
+        input: { rootDir, repoId: "missing-process", now: () => "2026-09-13T00:01:00.000Z" },
+        requiredRuntimeProjection: () => ({ readRuntimeSessions: () => [liveSession(runtimeSessionId)] }),
+        processes: new Map(),
+        reconcileFallback: () => undefined,
+        consumeLine: async () => undefined,
+        publishExit: async (active: { runtimeSessionId: string; lossReason: string | null }) => {
+          settled.push({ runtimeSessionId: active.runtimeSessionId, reason: active.lossReason });
+          context.processes.delete(active.runtimeSessionId);
+        },
+      };
+    await adoptRuntimes(context as never);
+    assert.deepEqual(settled, [
+      { runtimeSessionId, reason: "runtime process was never recorded before daemon restart" },
+    ]);
+    assert.equal(context.processes.size, 0);
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("runtime cancel settles a live projection whose dispatch never recorded a process", async () => {
+  const rootDir = mkdtempSync(path.join(tmpdir(), "ha-runtime-cancel-missing-process-"));
+  try {
+    const dispatchId = "dispatch_eeeeeeeeeeeeeeeeeeeeeeee",
+      runtimeSessionId = "runtime_eeeeeeeeeeeeeeeeeeeeeeee";
+    openMissingProcessStream(rootDir, dispatchId, runtimeSessionId, "dispatch-op-cancel-missing-process");
+    const published: Array<{ readonly type: string; readonly payload: Record<string, unknown> }> = [],
+      context = {
+        input: { rootDir, repoId: "cancel-missing-process" },
+        requiredRuntimeProjection: () => ({ readRuntimeSessions: () => [liveSession(runtimeSessionId)] }),
+        processes: new Map(),
+        publishRuntimeEvent: async (type: string, payload: Record<string, unknown>) => {
+          published.push({ type, payload });
+          return {};
+        },
+        controlReceipt: (_opId: string, _runtimeSessionId: string, detail: string) => ({ detail }),
+      };
+    const receipt = await cancelRuntime(context as never, { runtimeSessionId }, binding);
+    assert.equal(receipt.detail, "cancelled");
+    assert.deepEqual(
+      published.map(({ type, payload }) => [type, payload]),
+      [
+        ["runtime_session_cancelled", { runtimeSessionId }],
+        ["runtime_session_exited", { runtimeSessionId }],
+        [
+          "runtime_session_outcome_observed",
+          {
+            runtimeSessionId,
+            outcome: "cancelled",
+            exitCode: null,
+            resultRef: `artifact:runtime-result/sha256/${createHash("sha256").update(runtimeSessionId).digest("hex")}`,
+            result: null,
+            reasonCode: "runtime_process_missing",
+          },
+        ],
+      ],
+    );
+  } finally {
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});
+
+function openMissingProcessStream(rootDir: string, dispatchId: string, runtimeSessionId: string, dispatchOpId: string) {
+  openDispatchStream(rootDir, {
+    dispatchId,
+    taskId: null,
+    executionId: null,
+    runtimeSessionId,
+    instanceId: "instance-1",
+    startedAt: "2026-09-13T00:00:00.000Z",
+    dispatchOpId,
+    kindId: "codex",
+    permissionMode: null,
+    binding,
+    cwd: rootDir,
+    prompt: "missing process",
+    model: "gpt-5.6-sol",
+    reasoningEffort: null,
+    fast: false,
+  });
+}
+
+function liveSession(runtimeSessionId: string) {
+  return { runtimeSessionId, instanceId: "instance-1", providerSessionId: null, liveness: "live", outcome: null };
+}


### PR DESCRIPTION
# English

## Summary

A runtime session whose worker process is gone but whose exit was never recorded became a ghost: the projection kept it live, the daemon kept counting it, and `ha runtime cancel` only answered `already-exited`, so a build-drift drain never finished and an operator had to stop the daemon. Three places produced it and all three are now narrowed. Adoption skipped a dispatch whose stream had no process record, cleaning up the callback relay and leaving the session live; it now falls into the same settlement the adoption path already had for a pid that is no longer alive. Cancel excluded every session with a dispatch record from projection-only settlement, so a recorded session without a live process in this generation fell between the two branches; it now settles instead of reporting `already-exited`. The drain count was an in-memory Set fed by spawn and exit log entries, so it could outlive the process it counted; it now derives from the pids this daemon actually holds. `runtimePidIsAlive` also rejects non-positive pids, because `kill(0, sig)` addresses the caller's own process group and would answer 'alive' for a runtime that has no process at all. A follow-up commit gives the pid liveness check its own module: adding the guard pushed `runtime-spawn-process.ts` past the file-complexity ceiling, and the gate asks for a split by responsibility rather than shaved lines. `runtimePidIsAlive` had five callers outside that file (adoption, cancel's dispatch read, the task mutation path, the drain count and the dispatch read face), so it moves to `runtime-process-liveness.ts` and the spawn/observe file drops to 611 lines.

## Architectural Justification

Liveness has one source: the process. The projection, the drain count and cancel all answer from whether a process exists and is alive, instead of each keeping its own record of what was once spawned.

## What Changed

`runtime-spawn-adoption.ts` (+16/-14): the early skip for a stream without a process record is removed and that case joins the existing loss settlement; a session adopted without a recorded process reports no pid to the lifecycle log. `runtime-spawn-control.ts` (+18/-12): cancel recognises a recorded dispatch whose owned stream has no process and settles it from the projection. `runtime.ts` (+6/-4): the live-runtime count derives from held pids filtered by liveness instead of a Set fed by log events. `runtime-spawn-process.ts` (+4): `runtimePidIsAlive` returns false for a non-positive pid. Tests: a new focused file for the missing-process cases (+106) and a drain case (+6). `runtime-process-liveness.ts` (new): the pid liveness primitive, imported by its five callers.

## Gate Harvest / 门收割

Deleted-Production-Paths: none
Deleted-Gates-Fixtures: none
- Production net lines: +45/-42 production; tests +112/-0.

## Per-Write Cost

`node tools/gates/cost-budget.mjs` on the base and on this branch, same machine: every probed operation and metric identical at 200 and 2000, G38 passes on both. The drain count now reads live pids instead of a membership set; it is computed on demand during shutdown, not on any probed write path.

| Operation | Metric | Before (200) | Before (2000) | After (200) | After (2000) |
| --- | --- | --- | --- | --- | --- |
| decision-propose | sqlRowsRead | 86 | 86 | 86 | 86 |
| decision-propose | sha256Calls | 27 | 27 | 27 | 27 |
| decision-propose | sha256Bytes | 16884 | 16912 | 16884 | 16912 |
| decision-propose | gitProcesses | 6 | 6 | 6 | 6 |
| decision-propose | fileReadBytes | 2911 | 2917 | 2911 | 2917 |
| decision-reckon | sqlRowsRead | 75 | 75 | 75 | 75 |
| decision-reckon | sha256Calls | 28 | 28 | 28 | 28 |
| decision-reckon | sha256Bytes | 8494 | 8535 | 8494 | 8535 |
| decision-reckon | gitProcesses | 6 | 6 | 6 | 6 |
| decision-reckon | fileReadBytes | 1237 | 1245 | 1237 | 1245 |
| decision-reject | sqlRowsRead | 101 | 101 | 101 | 101 |
| decision-reject | sha256Calls | 40 | 40 | 40 | 40 |
| decision-reject | sha256Bytes | 29259 | 29290 | 29259 | 29290 |
| decision-reject | gitProcesses | 6 | 6 | 6 | 6 |
| decision-reject | fileReadBytes | 7219 | 7227 | 7219 | 7227 |
| doc-submit | sqlRowsRead | 92 | 92 | 92 | 92 |
| doc-submit | sha256Calls | 101 | 101 | 101 | 101 |
| doc-submit | sha256Bytes | 63915 | 63958 | 63915 | 63958 |
| doc-submit | gitProcesses | 6 | 6 | 6 | 6 |
| doc-submit | fileReadBytes | 10056 | 10060 | 10056 | 10060 |
| fact-record | sqlRowsRead | 69 | 69 | 69 | 69 |
| fact-record | sha256Calls | 28 | 28 | 28 | 28 |
| fact-record | sha256Bytes | 7553 | 7576 | 7553 | 7576 |
| fact-record | gitProcesses | 6 | 6 | 6 | 6 |
| fact-record | fileReadBytes | 997 | 1001 | 997 | 1001 |
| receipt-show | sqlRowsRead | 18 | 18 | 18 | 18 |
| receipt-show | sha256Calls | 6 | 6 | 6 | 6 |
| receipt-show | sha256Bytes | 10311 | 10317 | 10311 | 10317 |
| receipt-show | gitProcesses | 0 | 0 | 0 | 0 |
| receipt-show | fileReadBytes | 0 | 0 | 0 | 0 |
| relation-relate | sqlRowsRead | 64 | 64 | 64 | 64 |
| relation-relate | sha256Calls | 24 | 24 | 24 | 24 |
| relation-relate | sha256Bytes | 5676 | 5701 | 5676 | 5701 |
| relation-relate | gitProcesses | 6 | 6 | 6 | 6 |
| relation-relate | fileReadBytes | 495 | 499 | 495 | 499 |
| runtime-overview | sqlRowsRead | 150 | 1446 | 150 | 1446 |
| runtime-overview | sha256Calls | 0 | 0 | 0 | 0 |
| runtime-overview | sha256Bytes | 0 | 0 | 0 | 0 |
| runtime-overview | gitProcesses | 0 | 0 | 0 | 0 |
| runtime-overview | fileReadBytes | 0 | 0 | 0 | 0 |
| task-create | sqlRowsRead | 50 | 50 | 50 | 50 |
| task-create | sha256Calls | 59 | 59 | 59 | 59 |
| task-create | sha256Bytes | 90247 | 90269 | 90247 | 90269 |
| task-create | gitProcesses | 6 | 6 | 6 | 6 |
| task-create | fileReadBytes | 77483 | 77487 | 77483 | 77487 |
| task-list | sqlRowsRead | 6 | 6 | 6 | 6 |
| task-list | sha256Calls | 1 | 1 | 1 | 1 |
| task-list | sha256Bytes | 213 | 215 | 213 | 215 |
| task-list | gitProcesses | 0 | 0 | 0 | 0 |
| task-list | fileReadBytes | 82 | 82 | 82 | 82 |
| task-progress-append | sqlRowsRead | 76 | 76 | 76 | 76 |
| task-progress-append | sha256Calls | 26 | 26 | 26 | 26 |
| task-progress-append | sha256Bytes | 5749 | 5772 | 5749 | 5772 |
| task-progress-append | gitProcesses | 6 | 6 | 6 | 6 |
| task-progress-append | fileReadBytes | 659 | 663 | 659 | 663 |
| task-show | sqlRowsRead | 89 | 89 | 89 | 89 |
| task-show | sha256Calls | 0 | 0 | 0 | 0 |
| task-show | sha256Bytes | 0 | 0 | 0 | 0 |
| task-show | gitProcesses | 0 | 0 | 0 | 0 |
| task-show | fileReadBytes | 82 | 82 | 82 | 82 |
| task-start | sqlRowsRead | 175 | 175 | 175 | 175 |
| task-start | sha256Calls | 47 | 47 | 47 | 47 |
| task-start | sha256Bytes | 26754 | 26785 | 26754 | 26785 |
| task-start | gitProcesses | 6 | 6 | 6 | 6 |
| task-start | fileReadBytes | 5625 | 5629 | 5625 | 5629 |

## Machine-Readable Declarations

- None.

## Task And Scope

- Harness task: task_8806a3309251608df38f65c72e (parent task_f7a3f1a44630ce11e4ff12afdd)
- Branch: `codex/ghost-runtime-drain`
- Public scope: Runtime adoption, runtime cancel, the daemon's live-runtime drain count, and the pid liveness check. No change to the kernel, to the protocol, or to how a healthy runtime is adopted and settled.
- Private planning/evidence updated: yes (`artifacts/report.md`)
- Out of scope: Not changed: the GUI's rendering of runtime state, the kernel projection, fleet edge archive behaviour, and adoption of runtimes owned by another node (`ownedByRuntimeNode` still gates both adoption and the new cancel path).

## Version Impact

- Version: no version change
- Publish impact: no publish

## Governance Declaration

- Protected surface touched: no
- Protected surface scope: not applicable
- Authority: not applicable
- Machine-check boundary: not applicable
- Break-glass: no
- Break-glass reason: not applicable
- Break-glass scope: not applicable
- Follow-up governance task: not applicable

## Verification

- Base `origin/main` SHA: `9192d4ece`
- Branch merge-base with `origin/main`: `9192d4ece`
- Last `git fetch origin` time: 2026-09-12 UTC
- Sync method: branched from origin/main
- Public diff command: `git diff origin/main...codex/ghost-runtime-drain`
- Private evidence commit/path: task_8806a3309251608df38f65c72e `artifacts/report.md`
- Reviewer evidence path: this PR's Review Evidence section
- GitHub Actions `rewrite-ci` run URL: pending on this PR
- [ ] `npm ci`
- [x] `git diff --check`
- [x] `npm run typecheck` (worker, `tsc -b`)
- [ ] `npm run check`
- [ ] `npm test`
- [ ] `npm run harness:check-import-boundaries`
- [ ] `npm run harness:scan-forbidden-symbols`
- [ ] `npm run harness:check-private-boundary`
- [ ] `npm run harness:check-package-policy`
- [x] `npm run harness:check-implementation-contracts` (via `run-manifest-gates --changed origin/main`)
- [ ] `npm run harness:check-schema-contracts`
- [ ] `npm run harness:check-legacy-intake-readiness`
- [ ] `npm run harness:smoke-cli-package`
- [ ] GitHub Actions `rewrite-ci` passed
- Worker's red control before the change (`node tools/run-node-tests.mjs --file packages/daemon/test/dispatch-stream.test.ts`): tests 17 / pass 15 / fail 2, the adoption case returning no settled runtime and cancel returning `already-exited` instead of `cancelled`; the two cases then moved to their own file because the host file exceeded its 700-line ceiling. Worker's red isolated drain run reported two live sessions where one was true-live, because the dead pid was still counted. After the change plus the CEO hardening: `node tools/run-node-tests.mjs --file packages/daemon/test/runtime-spawn-settlement.test.ts --file packages/daemon/test/runtime-missing-process.test.ts` gives tests 10 / pass 10 / fail 0; the isolated run over every test touching adoption, pid liveness or the drain count (`daemon-build-drain.integration`, `dispatch-stream`, `daemon-stale-schema-client`, `protocol-hello-build`, `runtime-missing-process`) exits 0 on the Ubuntu target. `node tools/run-manifest-gates.mjs --changed origin/main`: all gates passed. After the module split: focused tests 10 / pass 10 / fail 0; the same five-file isolated run exits 0; `node tools/check-file-complexity.mjs` passes (File complexity check passed) and `node tools/check-import-boundaries.mjs` passes with allowlist delta 0.

## Review Evidence

- CEO ground-truth: read the worker report and the diff stat; CEO ground-truthed the worker's diff and found that adopting a ghost passed pid 0 into the new pid map, where `runtimePidIsAlive(0)` answers true because `process.kill(0, 0)` signals the caller's process group; the tests passed only because settlement removed the entry immediately afterwards. Both the liveness check and the lifecycle record were narrowed, and the affected tests were rerun..
- Reviewer subagent: closeout review after merge (one-path closeout)
- Human review: pending
- Blocking findings: none open

## Residual Risk

- A dispatch stream whose process record is written late would, if adopted in that window, be settled as lost rather than adopted; the stream header is written before the process record in the spawn path, so the window is the spawn itself rather than a steady state. The drain count now costs one liveness probe per held runtime at shutdown, which is bounded by the number of runtimes this daemon spawned.

## References

- Task: task_8806a3309251608df38f65c72e

---

# 中文

## 概要

worker 进程已经没了、退出却从未被记录的 runtime session 会变成「幽灵」：投影里一直 live，daemon 一直把它算进排空计数，`ha runtime cancel` 只回 `already-exited`，于是 build-drift 排空永远排不完，操作者只能停 daemon。三处成因现已全部收窄。收养时遇到「stream 里没有 process 记录」的派工，原本只删回调然后跳过、把 session 留在 live；现在并入收养路径本就有的「pid 已不在」结算。cancel 把所有有 dispatch 记录的 session 排除在「仅凭投影结算」之外，于是「有记录但本代没有活进程」的 session 落进两个分支之间；现在它会被结算，而不是回 `already-exited`。排空计数原是由 spawn/exit 日志喂养的内存 Set，可能比它所计的进程活得更久；现在它从本 daemon 实际持有的 pid 推导。`runtimePidIsAlive` 另外拒绝非正整数 pid——`kill(0, sig)` 针对调用者自己的进程组，会把「根本没有进程」的 runtime 答成「活着」。 另有一个后续提交把 pid 判活单独成模块：加上这条守卫后 `runtime-spawn-process.ts` 越过文件复杂度上限，而该门要求按职责拆分而非削行。`runtimePidIsAlive` 在该文件之外有五个调用方（收养、cancel 的派工读取、任务变更路径、排空计数、dispatch 读面），因此迁入 `runtime-process-liveness.ts`，spawn/observe 文件降到 611 行。

## 架构辩护

判活只有一个来源：进程。投影、排空计数与 cancel 都据「进程是否存在且活着」作答，而不是各自保留一份「曾经派出过什么」的记录。

## 改动内容

`runtime-spawn-adoption.ts`（+16/-14）：删除「stream 无 process 记录就跳过」的早退分支，该情形并入既有的丢失结算；无 process 记录被收养的 session 不再向 lifecycle 上报 pid。`runtime-spawn-control.ts`（+18/-12）：cancel 识别「有 dispatch 记录、本节点拥有、但 stream 无 process」的 session 并据投影结算。`runtime.ts`（+6/-4）：live runtime 计数由所持 pid 按判活过滤得出，不再是日志事件喂养的 Set。`runtime-spawn-process.ts`（+4）：`runtimePidIsAlive` 对非正整数 pid 返回 false。测试：新增聚焦文件覆盖无进程情形（+106）与一条排空用例（+6）。 `runtime-process-liveness.ts`（新增）：pid 判活原语，由其五个调用方导入。

## 门收割 / Gate Harvest

- 删除的生产路径：none
- 删除的门或 fixture：none
- 生产净行数：+45/-42 production; tests +112/-0。

## 机器可读声明

- 无。

## 任务与范围

- Harness 任务：task_8806a3309251608df38f65c72e（父 task_f7a3f1a44630ce11e4ff12afdd）
- 分支：`codex/ghost-runtime-drain`
- 公开范围：runtime 收养、runtime cancel、daemon 的 live runtime 排空计数、pid 判活。不改内核、不改协议、不改健康 runtime 的收养与结算方式。
- 私有计划/证据已更新：是（`artifacts/report.md`）
- 范围外：未改：GUI 对 runtime 状态的呈现、内核投影、fleet edge 归档行为、他节点所有的 runtime 的收养（`ownedByRuntimeNode` 仍同时把守收养与新的 cancel 路径）。

## 版本影响

- 版本：不变
- 发布影响：不发布

## 治理声明

- 触碰受保护面：否
- 受保护面范围：不适用
- 授权：不适用
- 机器检查边界：不适用
- Break-glass：否
- Break-glass 原因：不适用
- Break-glass 范围：不适用
- 后续治理任务：不适用

## 验证

- 基线 `origin/main` SHA：`9192d4ece`
- 分支与 `origin/main` 的 merge-base：`9192d4ece`
- 最近一次 `git fetch origin`：2026-09-12 UTC
- 同步方式：从 origin/main 开分支
- 公开 diff 命令：`git diff origin/main...codex/ghost-runtime-drain`
- 私有证据路径：task_8806a3309251608df38f65c72e 的 `artifacts/report.md`
- 评审证据路径：本 PR 的评审证据节
- GitHub Actions `rewrite-ci` run URL：本 PR 待跑
- 改动前 worker 的阴性对照（`node tools/run-node-tests.mjs --file packages/daemon/test/dispatch-stream.test.ts`）：tests 17 / pass 15 / fail 2——收养用例拿不到已结算的 runtime，cancel 返回 `already-exited` 而非 `cancelled`；随后因宿主文件超过 700 行上限，两条用例迁入独立文件。worker 的隔离排空红跑显示「1 个真活」被报成 2 个，因为死 pid 仍被计数。改动加 CEO 加固后：`node tools/run-node-tests.mjs --file packages/daemon/test/runtime-spawn-settlement.test.ts --file packages/daemon/test/runtime-missing-process.test.ts` → tests 10 / pass 10 / fail 0；覆盖收养、pid 判活、排空计数的全部测试文件（`daemon-build-drain.integration`、`dispatch-stream`、`daemon-stale-schema-client`、`protocol-hello-build`、`runtime-missing-process`）在 Ubuntu 目标隔离跑 exit 0。`node tools/run-manifest-gates.mjs --changed origin/main`：全部通过。 拆分后：定向测试 tests 10 / pass 10 / fail 0；同样的五文件隔离跑 exit 0；`node tools/check-file-complexity.mjs` 通过（File complexity check passed），`node tools/check-import-boundaries.mjs` 通过且 allowlist delta 0。

## 评审证据

- CEO 事实核对：读过 worker 报告与 diff 统计；CEO 对 worker 的 diff 做 ground-truth，发现收养幽灵时把 pid 0 写进了新的 pid 映射，而 `runtimePidIsAlive(0)` 因 `process.kill(0, 0)` 面向调用者进程组而返回 true；测试之所以绿，只是因为结算紧接着把这条删掉了。判活与 lifecycle 记录两处均已收窄，受影响测试已复跑。。
- 评审子代理：合入后走一条路收口评审
- 人工评审：待定
- 阻塞发现：无

## 残余风险

- 若某派工的 process 记录写得晚，而恰在该窗口被收养，会被结算为丢失而非收养；spawn 路径里 stream header 先于 process 记录写入，因此这个窗口属于 spawn 过程本身而非稳态。排空计数现在每个所持 runtime 多一次判活探测，数量以本 daemon 派出的 runtime 数为界。

## 参考

- 任务：task_8806a3309251608df38f65c72e

